### PR TITLE
Add Workspace Management Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ SystemLink CLI (`slcli`) is a cross-platform Python CLI for SystemLink integrato
 - **Test Plan Templates**: Complete management (list, export, import, delete, init) with JSON and table output formats
 - **Jupyter Notebooks**: Full lifecycle management (list, download, create, update, delete) with workspace filtering
 - **Workflows**: Full workflow management (list, export, import, delete, init, update) with comprehensive state and action definitions
+- **Workspace Management**: Essential workspace administration (list, info, disable) with comprehensive resource details
 - **Cross-Platform**: Windows, macOS, and Linux support with standalone binaries
 - **Professional CLI**: Consistent error handling, colored output, and comprehensive help system
 - **Output Formats**: JSON and table output options for programmatic integration and human-readable display
@@ -319,6 +320,56 @@ slcli notebook update --id <notebook_id> --metadata metadata.json --content myno
 ```bash
 slcli notebook delete --id <notebook_id>
 ```
+
+## Workspace Management
+
+SystemLink CLI provides essential workspace management capabilities for viewing and administering workspaces in your SystemLink environment.
+
+### List workspaces
+
+```bash
+# List all enabled workspaces
+slcli workspace list
+
+# Include disabled workspaces
+slcli workspace list --include-disabled
+
+# Filter by workspace name
+slcli workspace list --name "Production"
+
+# JSON output for programmatic use
+slcli workspace list --format json
+```
+
+### Get detailed workspace information
+
+```bash
+# Get workspace details by ID
+slcli workspace info --id <workspace_id>
+
+# Get workspace details by name
+slcli workspace info --name "Production Workspace"
+
+# JSON output with full workspace contents
+slcli workspace info --name "Production Workspace" --format json
+```
+
+The info command provides comprehensive workspace details including:
+
+- Workspace properties (ID, name, enabled status, default status)
+- Test plan templates in the workspace
+- Workflows in the workspace
+- Notebooks in the workspace
+- Summary counts of all resources
+
+### Disable a workspace
+
+```bash
+# Disable a workspace (requires confirmation)
+slcli workspace disable --id <workspace_id>
+```
+
+**Note**: Workspace creation and duplication are managed through the SystemLink web interface. This CLI provides read-only access and workspace disabling capabilities for administrative purposes.
 
 ## Output Formats
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ For development or if Homebrew isn't available:
 
    ```bash
    # View test plan templates
-   slcli templates list
+   slcli template list
 
    # View workflows
-   slcli workflows list
+   slcli workflow list
 
    # View notebooks
    slcli notebook list
@@ -92,17 +92,17 @@ For development or if Homebrew isn't available:
 
    ```bash
    # Create a new template
-   slcli templates init --name "My Test Template" --template-group "Production"
+   slcli template init --name "My Test Template" --template-group "Production"
 
    # Create a new workflow
-   slcli workflows init --name "My Workflow" --description "Custom workflow"
+   slcli workflow init --name "My Workflow" --description "Custom workflow"
    ```
 
 4. **Get help for any command:**
    ```bash
    slcli --help
-   slcli templates --help
-   slcli workflows --help
+   slcli template --help
+   slcli workflow --help
    slcli notebook --help
    ```
 
@@ -133,7 +133,7 @@ slcli logout
 
 ## Test Plan Template Management
 
-The `templates` command group allows you to manage test plan templates in SystemLink.
+The `template` command group allows you to manage test plan templates in SystemLink.
 
 ### Initialize a new template
 
@@ -141,13 +141,13 @@ Create a new test plan template JSON file with the complete schema structure:
 
 ```bash
 # Interactive mode (prompts for required fields)
-slcli templates init
+slcli template init
 
 # Specify required fields directly
-slcli templates init --name "Battery Test Template" --template-group "Production Tests"
+slcli template init --name "Battery Test Template" --template-group "Production Tests"
 
 # Custom output file
-slcli templates init --name "My Template" --template-group "Development" --output custom-template.json
+slcli template init --name "My Template" --template-group "Development" --output custom-template.json
 ```
 
 The `init` command creates a JSON file with:
@@ -161,25 +161,25 @@ The `init` command creates a JSON file with:
 
 ```bash
 # Table format (default)
-slcli templates list
+slcli template list
 
 # JSON format for programmatic use
-slcli templates list --format json
+slcli template list --format json
 
 # Filter by workspace
-slcli templates list --workspace "Production Workspace"
+slcli template list --workspace "Production Workspace"
 ```
 
 ### Export a template to a local JSON file
 
 ```bash
-slcli templates export --id <template_id> --output template.json
+slcli template export --id <template_id> --output template.json
 ```
 
 ### Import a template from a local JSON file
 
 ```bash
-slcli templates import --file template.json
+slcli template import --file template.json
 ```
 
 The import command provides detailed error reporting for partial failures, including specific error types like `WorkspaceNotFoundOrNoAccess`.
@@ -187,12 +187,12 @@ The import command provides detailed error reporting for partial failures, inclu
 ### Delete a template
 
 ```bash
-slcli templates delete --id <template_id>
+slcli template delete --id <template_id>
 ```
 
 ## Workflow Management
 
-The `workflows` command group allows you to manage workflows in SystemLink. All workflow commands use the beta feature flag automatically.
+The `workflow` command group allows you to manage workflows in SystemLink. All workflow commands use the beta feature flag automatically.
 
 ### Initialize a new workflow
 
@@ -200,13 +200,13 @@ Create a new workflow JSON file with a complete state machine structure:
 
 ```bash
 # Interactive mode (prompts for required fields)
-slcli workflows init
+slcli workflow init
 
 # Specify fields directly
-slcli workflows init --name "Battery Test Workflow" --description "Workflow for battery testing procedures"
+slcli workflow init --name "Battery Test Workflow" --description "Workflow for battery testing procedures"
 
 # Custom output file
-slcli workflows init --name "My Workflow" --description "Custom workflow" --output custom-workflow.json
+slcli workflow init --name "My Workflow" --description "Custom workflow" --output custom-workflow.json
 ```
 
 The `init` command creates a JSON file with:
@@ -220,37 +220,37 @@ The `init` command creates a JSON file with:
 
 ```bash
 # Table format (default)
-slcli workflows list
+slcli workflow list
 
 # JSON format for programmatic use
-slcli workflows list --format json
+slcli workflow list --format json
 
 # Filter by workspace
-slcli workflows list --workspace "Production Workspace"
+slcli workflow list --workspace "Production Workspace"
 ```
 
 ### Export a workflow to a local JSON file
 
 ```bash
-slcli workflows export --id <workflow_id> --output workflow.json
+slcli workflow export --id <workflow_id> --output workflow.json
 ```
 
 ### Import a workflow from a local JSON file
 
 ```bash
-slcli workflows import --file workflow.json
+slcli workflow import --file workflow.json
 ```
 
 ### Update an existing workflow
 
 ```bash
-slcli workflows update --id <workflow_id> --file updated-workflow.json
+slcli workflow update --id <workflow_id> --file updated-workflow.json
 ```
 
 ### Delete a workflow
 
 ```bash
-slcli workflows delete --id <workflow_id>
+slcli workflow delete --id <workflow_id>
 ```
 
 ## Notebook Management
@@ -339,13 +339,13 @@ SystemLink CLI supports both human-readable table output and machine-readable JS
 
 ```bash
 # Human-readable table
-slcli templates list
-slcli workflows list
+slcli template list
+slcli workflow list
 slcli notebook list
 
 # Machine-readable JSON
-slcli templates list --format json
-slcli workflows list --format json
+slcli template list --format json
+slcli workflow list --format json
 slcli notebook list --format json
 ```
 

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -8,6 +8,7 @@ import keyring
 from .notebook_click import register_notebook_commands
 from .templates_click import register_templates_commands
 from .workflows_click import register_workflows_commands
+from .workspace_click import register_workspace_commands
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -74,3 +75,4 @@ def logout():
 register_templates_commands(cli)
 register_notebook_commands(cli)
 register_workflows_commands(cli)
+register_workspace_commands(cli)

--- a/slcli/templates_click.py
+++ b/slcli/templates_click.py
@@ -20,14 +20,14 @@ from .utils import (
 
 
 def register_templates_commands(cli):
-    """Register the 'templates' command group and its subcommands."""
+    """Register the 'template' command group and its subcommands."""
 
     @cli.group()
-    def templates():
+    def template():
         """Manage test plan templates."""
         pass
 
-    @templates.command(name="init")
+    @template.command(name="init")
     @click.option(
         "--name",
         "-n",
@@ -150,7 +150,7 @@ def register_templates_commands(cli):
             click.echo(f"✗ Error creating template file: {exc}", err=True)
             raise click.ClickException(f"Error creating template file: {exc}")
 
-    @templates.command(name="list")
+    @template.command(name="list")
     @click.option(
         "--format",
         "-f",
@@ -221,7 +221,7 @@ def register_templates_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
-    @templates.command(name="export")
+    @template.command(name="export")
     @click.option(
         "--id",
         "-i",
@@ -259,7 +259,7 @@ def register_templates_commands(cli):
                 click.echo(f"✗ Error: {exc}", err=True)
                 raise click.ClickException(str(exc))
 
-    @templates.command(name="import")
+    @template.command(name="import")
     @click.option(
         "--file",
         "-f",
@@ -353,7 +353,7 @@ def register_templates_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
-    @templates.command(name="delete")
+    @template.command(name="delete")
     @click.option(
         "--id",
         "-i",

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -175,15 +175,6 @@ def get_ssl_verify() -> bool:
     return True
 
 
-def get_workspace_map() -> Dict[str, str]:
-    """Return a mapping of workspace id to workspace name."""
-    url = f"{get_base_url()}/niuser/v1/workspaces"
-    resp = requests.get(url, headers=get_headers(), verify=get_ssl_verify())
-    resp.raise_for_status()
-    ws_data = resp.json()
-    return {ws.get("id"): ws.get("name", ws.get("id")) for ws in ws_data.get("workspaces", [])}
-
-
 def get_workspace_id_by_name(name: str) -> str:
     """Return the workspace id for a given workspace name (case-sensitive). Raises if not found."""
     ws_map = get_workspace_map()
@@ -191,6 +182,22 @@ def get_workspace_id_by_name(name: str) -> str:
         if ws_name == name:
             return ws_id
     raise ValueError(f"Workspace name '{name}' not found.")
+
+
+def get_workspace_map() -> Dict[str, str]:
+    """Get a mapping of workspace IDs to names.
+
+    Returns:
+        Dictionary mapping workspace ID to workspace name
+    """
+    try:
+        url = f"{get_base_url()}/niuser/v1/workspaces?take=1000"
+        resp = make_api_request("GET", url, payload=None, handle_errors=False)
+        data = resp.json()
+        workspaces = data.get("workspaces", [])
+        return {ws.get("id"): ws.get("name") for ws in workspaces if ws.get("id")}
+    except Exception:
+        return {}
 
 
 # --- File I/O Utilities ---

--- a/slcli/workflows_click.py
+++ b/slcli/workflows_click.py
@@ -23,14 +23,14 @@ from .utils import (
 
 
 def register_workflows_commands(cli):
-    """Register the 'workflows' command group and its subcommands."""
+    """Register the 'workflow' command group and its subcommands."""
 
     @cli.group()
-    def workflows():
+    def workflow():
         """Manage workflows."""
         pass
 
-    @workflows.command(name="init")
+    @workflow.command(name="init")
     @click.option(
         "--name",
         "-n",
@@ -216,7 +216,7 @@ def register_workflows_commands(cli):
             click.echo(f"✗ Error creating workflow file: {exc}", err=True)
             raise click.ClickException(f"Error creating workflow file: {exc}")
 
-    @workflows.command(name="list")
+    @workflow.command(name="list")
     @click.option(
         "--format",
         "-f",
@@ -286,7 +286,7 @@ def register_workflows_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
-    @workflows.command(name="export")
+    @workflow.command(name="export")
     @click.option(
         "--id",
         "-i",
@@ -321,7 +321,7 @@ def register_workflows_commands(cli):
                 click.echo(f"✗ Error: {exc}", err=True)
                 raise click.ClickException(str(exc))
 
-    @workflows.command(name="import")
+    @workflow.command(name="import")
     @click.option(
         "--file",
         "-f",
@@ -417,7 +417,7 @@ def register_workflows_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
-    @workflows.command(name="delete")
+    @workflow.command(name="delete")
     @click.option(
         "--id",
         "-i",
@@ -455,7 +455,7 @@ def register_workflows_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
-    @workflows.command(name="update")
+    @workflow.command(name="update")
     @click.option(
         "--id",
         "-i",

--- a/slcli/workspace_click.py
+++ b/slcli/workspace_click.py
@@ -328,10 +328,8 @@ def _get_workspace_notebooks(workspace_id: str) -> list:
         payload = {"take": 1000, "filter": f'workspace = "{workspace_id}"'}
         resp = make_api_request("POST", url, payload)
         data = resp.json()
-        notebooks = data.get("notebooks", [])  # Changed from "notebook" to "notebooks"
+        notebooks = data.get("notebooks", [])
         # Convert to consistent format
         return [{"id": nb.get("id"), "name": nb.get("name")} for nb in notebooks]
     except Exception:
-        # Notebook API might not be available or endpoint might be different
-        # Return empty list to allow the command to continue
         return []

--- a/slcli/workspace_click.py
+++ b/slcli/workspace_click.py
@@ -1,0 +1,337 @@
+"""CLI commands for managing SystemLink workspaces."""
+
+import json
+import sys
+from typing import Optional
+
+import click
+
+from .utils import (
+    ExitCodes,
+    format_success,
+    get_base_url,
+    handle_api_error,
+    make_api_request,
+)
+
+
+def register_workspace_commands(cli):
+    """Register the 'workspace' command group and its subcommands."""
+
+    @cli.group()
+    def workspace():
+        """Manage workspaces (list, disable, info)."""
+        pass
+
+    @workspace.command(name="list")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--include-disabled",
+        is_flag=True,
+        help="Include disabled workspaces in the results",
+    )
+    @click.option(
+        "--name",
+        "-n",
+        help="Filter workspaces by name",
+    )
+    def list_workspaces(
+        format: str = "table", include_disabled: bool = False, name: Optional[str] = None
+    ):
+        """List workspaces."""
+        url = f"{get_base_url()}/niuser/v1/workspaces"
+
+        try:
+            # Build URL with query parameters
+            query_params = []
+            query_params.append("take=1000")
+            if name:
+                query_params.append(f"name={name}")
+
+            if query_params:
+                url += "?" + "&".join(query_params)
+
+            resp = make_api_request("GET", url, payload=None)
+            data = resp.json()
+            workspaces = data.get("workspaces", []) if isinstance(data, dict) else []
+
+            # Filter workspaces by enabled status if needed
+            if not include_disabled:
+                workspaces = [ws for ws in workspaces if ws.get("enabled", True)]
+
+            if format == "json":
+                click.echo(json.dumps(workspaces, indent=2))
+                sys.exit(ExitCodes.SUCCESS)
+
+            # Table format
+            if not workspaces:
+                click.echo("No workspaces found.")
+                sys.exit(ExitCodes.SUCCESS)
+
+            # Display table
+            click.echo("┌" + "─" * 38 + "┬" + "─" * 32 + "┬" + "─" * 10 + "┬" + "─" * 10 + "┐")
+            click.echo(f"│ {'ID':<36} │ {'Name':<30} │ {'Enabled':<8} │ {'Default':<8} │")
+            click.echo("├" + "─" * 38 + "┼" + "─" * 32 + "┼" + "─" * 10 + "┼" + "─" * 10 + "┤")
+
+            for workspace in workspaces:
+                ws_id = workspace.get("id", "")[:36]
+                ws_name = workspace.get("name", "")[:30]
+                enabled = "✓" if workspace.get("enabled", True) else "✗"
+                default = "✓" if workspace.get("default", False) else ""
+
+                click.echo(f"│ {ws_id:<36} │ {ws_name:<30} │ {enabled:<8} │ {default:<8} │")
+
+            click.echo("└" + "─" * 38 + "┴" + "─" * 32 + "┴" + "─" * 10 + "┴" + "─" * 10 + "┘")
+            click.echo(f"\nTotal: {len(workspaces)} workspace(s)")
+
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @workspace.command(name="disable")
+    @click.option(
+        "--id",
+        "-i",
+        required=True,
+        help="ID of the workspace to disable",
+    )
+    @click.confirmation_option(prompt="Are you sure you want to disable this workspace?")
+    def disable_workspace(id: str):
+        """Disable a workspace."""
+        try:
+            # Get workspace info before disabling for confirmation
+            workspace_info_url = f"{get_base_url()}/niuser/v1/workspaces?take=1000"
+            resp = make_api_request("GET", workspace_info_url)
+            data = resp.json()
+            workspaces = data.get("workspaces", [])
+
+            # Find the workspace to get its details
+            workspace_to_disable = None
+            for ws in workspaces:
+                if ws.get("id") == id:
+                    workspace_to_disable = ws
+                    break
+
+            if not workspace_to_disable:
+                click.echo(f"✗ Workspace with ID '{id}' not found", err=True)
+                sys.exit(ExitCodes.NOT_FOUND)
+
+            workspace_name = workspace_to_disable.get("name", id)
+
+            # Check if workspace is already disabled
+            if not workspace_to_disable.get("enabled", True):
+                click.echo(f"✗ Workspace '{workspace_name}' is already disabled", err=True)
+                sys.exit(ExitCodes.GENERAL_ERROR)
+
+            # Update the workspace to disable it
+            update_url = f"{get_base_url()}/niuser/v1/workspaces/{id}"
+            update_payload = {"name": workspace_name, "enabled": False}
+
+            make_api_request("PUT", update_url, update_payload)
+
+            format_success(
+                f"Workspace '{workspace_name}' disabled successfully",
+                {"id": id, "name": workspace_name, "enabled": False},
+            )
+
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @workspace.command(name="info")
+    @click.option(
+        "--id",
+        "-i",
+        help="ID of the workspace to get info for",
+    )
+    @click.option(
+        "--name",
+        "-n",
+        help="Name of the workspace to get info for",
+    )
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def info_workspace(id: Optional[str] = None, name: Optional[str] = None, format: str = "table"):
+        """Get detailed information about a workspace and its contents."""
+        if not id and not name:
+            click.echo("✗ Must provide either --id or --name", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
+
+        try:
+            # Get workspace info
+            workspace_info_url = f"{get_base_url()}/niuser/v1/workspaces?take=1000"
+            resp = make_api_request("GET", workspace_info_url)
+            data = resp.json()
+            workspaces = data.get("workspaces", [])
+
+            # Find the workspace
+            target_workspace = None
+            if id:
+                target_workspace = next((ws for ws in workspaces if ws.get("id") == id), None)
+            elif name:
+                target_workspace = next((ws for ws in workspaces if ws.get("name") == name), None)
+
+            if not target_workspace:
+                identifier = id if id else name
+                click.echo(f"✗ Workspace '{identifier}' not found", err=True)
+                sys.exit(ExitCodes.NOT_FOUND)
+
+            workspace_id = target_workspace.get("id")
+            workspace_name = target_workspace.get("name")
+
+            # Get workspace contents
+            templates = _get_workspace_templates(workspace_id)
+            workflows = _get_workspace_workflows(workspace_id)
+            notebooks = _get_workspace_notebooks(workspace_id)
+
+            workspace_info = {
+                "workspace": {
+                    "id": workspace_id,
+                    "name": workspace_name,
+                    "enabled": target_workspace.get("enabled", True),
+                    "default": target_workspace.get("default", False),
+                },
+                "contents": {
+                    "templates": templates,
+                    "workflows": workflows,
+                    "notebooks": notebooks,
+                },
+                "summary": {
+                    "total_templates": len(templates),
+                    "total_workflows": len(workflows),
+                    "total_notebooks": len(notebooks),
+                },
+            }
+
+            if format == "json":
+                click.echo(json.dumps(workspace_info, indent=2))
+                return
+
+            # Table format
+            click.echo(f"Workspace Information: {workspace_name}")
+            click.echo("=" * 50)
+            click.echo(f"ID: {workspace_id}")
+            click.echo(f"Name: {workspace_name}")
+            click.echo(f"Enabled: {'✓' if target_workspace.get('enabled', True) else '✗'}")
+            click.echo(f"Default: {'✓' if target_workspace.get('default', False) else '✗'}")
+
+            # Templates section
+            click.echo(f"\nTest Plan Templates ({len(templates)})")
+            click.echo("-" * 30)
+            if templates:
+                click.echo("┌" + "─" * 42 + "┬" + "─" * 38 + "┐")
+                click.echo(f"│ {'Name':<40} │ {'ID':<36} │")
+                click.echo("├" + "─" * 42 + "┼" + "─" * 38 + "┤")
+                for template in templates:
+                    name = template.get("name", "")[:40]
+                    template_id = template.get("id", "")[:36]
+                    click.echo(f"│ {name:<40} │ {template_id:<36} │")
+                click.echo("└" + "─" * 42 + "┴" + "─" * 38 + "┘")
+            else:
+                click.echo("No test plan templates found.")
+
+            # Workflows section
+            click.echo(f"\nWorkflows ({len(workflows)})")
+            click.echo("-" * 30)
+            if workflows:
+                click.echo("┌" + "─" * 42 + "┬" + "─" * 38 + "┐")
+                click.echo(f"│ {'Name':<40} │ {'ID':<36} │")
+                click.echo("├" + "─" * 42 + "┼" + "─" * 38 + "┤")
+                for workflow in workflows:
+                    name = workflow.get("name", "")[:40]
+                    workflow_id = workflow.get("id", "")[:36]
+                    click.echo(f"│ {name:<40} │ {workflow_id:<36} │")
+                click.echo("└" + "─" * 42 + "┴" + "─" * 38 + "┘")
+            else:
+                click.echo("No workflows found.")
+
+            # Notebooks section
+            click.echo(f"\nNotebooks ({len(notebooks)})")
+            click.echo("-" * 30)
+            if notebooks:
+                click.echo("┌" + "─" * 42 + "┬" + "─" * 38 + "┐")
+                click.echo(f"│ {'Name':<40} │ {'ID':<36} │")
+                click.echo("├" + "─" * 42 + "┼" + "─" * 38 + "┤")
+                for notebook in notebooks:
+                    name = notebook.get("name", "")[:40]
+                    notebook_id = notebook.get("id", "")[:36]
+                    click.echo(f"│ {name:<40} │ {notebook_id:<36} │")
+                click.echo("└" + "─" * 42 + "┴" + "─" * 38 + "┘")
+            else:
+                click.echo("No notebooks found.")
+
+        except Exception as exc:
+            handle_api_error(exc)
+
+
+def _get_workspace_map():
+    """Get a mapping of workspace IDs to names."""
+    try:
+        url = f"{get_base_url()}/niuser/v1/workspaces"
+        resp = make_api_request("GET", url)
+        data = resp.json()
+        workspaces = data.get("workspaces", [])
+        return {ws.get("id"): ws.get("name") for ws in workspaces if ws.get("id")}
+    except Exception:
+        return {}
+
+
+def _get_workspace_templates(workspace_id: str) -> list:
+    """Get test plan templates in a workspace."""
+    try:
+        url = f"{get_base_url()}/niworkorder/v1/query-testplan-templates"
+        payload = {
+            "take": 1000,
+            "projection": ["ID", "NAME"],
+            "filter": f'workspace == "{workspace_id}"',
+        }
+        resp = make_api_request("POST", url, payload)
+        data = resp.json()
+        return data.get("testPlanTemplates", [])
+    except Exception:
+        return []
+
+
+def _get_workspace_workflows(workspace_id: str) -> list:
+    """Get workflows in a workspace."""
+    try:
+        url = f"{get_base_url()}/niworkorder/v1/query-workflows?ff-userdefinedworkflowsfortestplaninstances=true"
+        payload = {
+            "take": 1000,
+            "projection": ["ID", "NAME", "WORKSPACE"],
+        }
+        resp = make_api_request("POST", url, payload)
+        data = resp.json()
+        workflows = data.get("workflows", [])
+        # Filter workflows by workspace since the API doesn't support filter parameter
+        workspace_workflows = [wf for wf in workflows if wf.get("workspace") == workspace_id]
+        return workspace_workflows
+    except Exception:
+        return []
+
+
+def _get_workspace_notebooks(workspace_id: str) -> list:
+    """Get notebooks in a workspace."""
+    try:
+        url = f"{get_base_url()}/ninotebook/v1/notebook/query"
+        payload = {"take": 1000, "filter": f'workspace = "{workspace_id}"'}
+        resp = make_api_request("POST", url, payload)
+        data = resp.json()
+        notebooks = data.get("notebooks", [])  # Changed from "notebook" to "notebooks"
+        # Convert to consistent format
+        return [{"id": nb.get("id"), "name": nb.get("name")} for nb in notebooks]
+    except Exception:
+        # Notebook API might not be available or endpoint might be different
+        # Return empty list to allow the command to continue
+        return []

--- a/tests/unit/test_templates_click.py
+++ b/tests/unit/test_templates_click.py
@@ -68,7 +68,7 @@ def test_list_templates_success(monkeypatch, runner):
     monkeypatch.setattr("requests.get", mock_get)
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
-    result = runner.invoke(cli, ["templates", "list"])
+    result = runner.invoke(cli, ["template", "list"])
     assert result.exit_code == 0
     assert "Template1" in result.output
 
@@ -112,7 +112,7 @@ def test_list_templates_with_workspace_filter(monkeypatch, runner):
     cli = make_cli()
 
     # Test filtering by workspace name
-    result = runner.invoke(cli, ["templates", "list", "--workspace", "Workspace1"])
+    result = runner.invoke(cli, ["template", "list", "--workspace", "Workspace1"])
     assert result.exit_code == 0
     assert "Template1" in result.output
     assert "Template2" not in result.output
@@ -145,7 +145,7 @@ def test_list_templates_empty(monkeypatch, runner):
     monkeypatch.setattr("requests.get", mock_get)
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
-    result = runner.invoke(cli, ["templates", "list"])
+    result = runner.invoke(cli, ["template", "list"])
     assert result.exit_code == 0
     assert "No test plan templates found." in result.output
 
@@ -167,7 +167,7 @@ def test_export_template_success(monkeypatch, runner, tmp_path):
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
     output_file = tmp_path / "out.json"
-    result = runner.invoke(cli, ["templates", "export", "--id", "t1", "--output", str(output_file)])
+    result = runner.invoke(cli, ["template", "export", "--id", "t1", "--output", str(output_file)])
     assert result.exit_code == 0
     assert output_file.read_text().startswith("{")
     assert "exported to" in result.output
@@ -197,7 +197,7 @@ def test_export_template_auto_filename(monkeypatch, runner, tmp_path):
 
     try:
         cli = make_cli()
-        result = runner.invoke(cli, ["templates", "export", "--id", "t1"])
+        result = runner.invoke(cli, ["template", "export", "--id", "t1"])
         assert result.exit_code == 0
 
         # Check that the auto-generated filename was created
@@ -225,7 +225,7 @@ def test_export_template_not_found(monkeypatch, runner):
 
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
-    result = runner.invoke(cli, ["templates", "export", "--id", "notfound", "--output", "out.json"])
+    result = runner.invoke(cli, ["template", "export", "--id", "notfound", "--output", "out.json"])
     assert result.exit_code != 0
     assert "not found" in result.output
 
@@ -250,7 +250,7 @@ def test_import_template_success(monkeypatch, runner, tmp_path):
     cli = make_cli()
     input_file = tmp_path / "in.json"
     input_file.write_text(json.dumps({"id": "t1", "name": "Template1"}))
-    result = runner.invoke(cli, ["templates", "import", "--file", str(input_file)])
+    result = runner.invoke(cli, ["template", "import", "--file", str(input_file)])
     assert result.exit_code == 0
     assert "imported successfully" in result.output
 
@@ -303,7 +303,7 @@ def test_import_template_partial_failure(monkeypatch, runner, tmp_path):
     cli = make_cli()
     input_file = tmp_path / "in.json"
     input_file.write_text(json.dumps({"id": "t1", "name": "Test Template"}))
-    result = runner.invoke(cli, ["templates", "import", "--file", str(input_file)])
+    result = runner.invoke(cli, ["template", "import", "--file", str(input_file)])
     assert result.exit_code == 1
     assert "Template import failed" in result.output
     assert "WorkspaceNotFoundOrNoAccess" in result.output
@@ -328,7 +328,7 @@ def test_delete_template_success(monkeypatch, runner):
 
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
-    result = runner.invoke(cli, ["templates", "delete", "--id", "t1"])
+    result = runner.invoke(cli, ["template", "delete", "--id", "t1"])
     assert result.exit_code == 0
     assert "deleted successfully" in result.output
 
@@ -353,6 +353,6 @@ def test_delete_template_failure(monkeypatch, runner):
 
     monkeypatch.setattr("requests.post", mock_post)
     cli = make_cli()
-    result = runner.invoke(cli, ["templates", "delete", "--id", "bad"])
+    result = runner.invoke(cli, ["template", "delete", "--id", "bad"])
     assert result.exit_code != 0
     assert "Failed to delete" in result.output

--- a/tests/unit/test_workflows_click.py
+++ b/tests/unit/test_workflows_click.py
@@ -76,7 +76,7 @@ def test_list_workflows_success(monkeypatch, runner):
     monkeypatch.setattr("requests.get", mock_get)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["workflows", "list"])
+    result = runner.invoke(cli, ["workflow", "list"])
     assert result.exit_code == 0
     assert "Test Workflow" in result.output
     assert "Test Workspace" in result.output
@@ -119,7 +119,7 @@ def test_list_workflows_with_workspace_filter(monkeypatch, runner):
     monkeypatch.setattr("requests.get", mock_get)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["workflows", "list", "--workspace", "Test"])
+    result = runner.invoke(cli, ["workflow", "list", "--workspace", "Test"])
     assert result.exit_code == 0
     assert "Test Workflow" in result.output
 
@@ -152,7 +152,7 @@ def test_list_workflows_empty(monkeypatch, runner):
     monkeypatch.setattr("requests.get", mock_get)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["workflows", "list"])
+    result = runner.invoke(cli, ["workflow", "list"])
     assert result.exit_code == 0
     assert "No workflows found" in result.output
 
@@ -181,7 +181,7 @@ def test_export_workflow_success(monkeypatch, runner):
     cli = make_cli()
     with runner.isolated_filesystem():
         result = runner.invoke(
-            cli, ["workflows", "export", "--id", "wf123", "--output", "test.json"]
+            cli, ["workflow", "export", "--id", "wf123", "--output", "test.json"]
         )
         assert result.exit_code == 0
         assert "Workflow exported to test.json" in result.output
@@ -212,7 +212,7 @@ def test_export_workflow_not_found(monkeypatch, runner):
     cli = make_cli()
     with runner.isolated_filesystem():
         result = runner.invoke(
-            cli, ["workflows", "export", "--id", "nonexistent", "--output", "test.json"]
+            cli, ["workflow", "export", "--id", "nonexistent", "--output", "test.json"]
         )
         assert result.exit_code == 1
         assert "not found" in result.output
@@ -265,7 +265,7 @@ def test_import_workflow_success(monkeypatch, runner):
         with open("test_workflow.json", "w") as f:
             json.dump(workflow_data, f)
 
-        result = runner.invoke(cli, ["workflows", "import", "--file", "test_workflow.json"])
+        result = runner.invoke(cli, ["workflow", "import", "--file", "test_workflow.json"])
         assert result.exit_code == 0
         assert "Workflow imported successfully" in result.output
 
@@ -361,7 +361,7 @@ def test_import_workflow_failure(monkeypatch, runner):
         with open("test_workflow.json", "w") as f:
             json.dump(workflow_data, f)
 
-        result = runner.invoke(cli, ["workflows", "import", "--file", "test_workflow.json"])
+        result = runner.invoke(cli, ["workflow", "import", "--file", "test_workflow.json"])
         assert result.exit_code == 1
         assert "Workflow import failed" in result.output
         assert "One or more errors occurred" in result.output
@@ -391,7 +391,7 @@ def test_delete_workflow_success(monkeypatch, runner):
     monkeypatch.setattr("requests.post", mock_post)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["workflows", "delete", "--id", "wf123"])
+    result = runner.invoke(cli, ["workflow", "delete", "--id", "wf123"])
     assert result.exit_code == 0
     assert "deleted successfully" in result.output
 
@@ -467,7 +467,7 @@ def test_delete_workflow_failure(monkeypatch, runner):
     monkeypatch.setattr("requests.post", mock_post)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["workflows", "delete", "--id", "nonexistent"])
+    result = runner.invoke(cli, ["workflow", "delete", "--id", "nonexistent"])
     assert result.exit_code != 0
     assert "Failed to delete workflow" in result.output
 
@@ -508,7 +508,7 @@ def test_update_workflow_success(monkeypatch, runner):
             json.dump(workflow_data, f)
 
         result = runner.invoke(
-            cli, ["workflows", "update", "--id", "wf123", "--file", "updated_workflow.json"]
+            cli, ["workflow", "update", "--id", "wf123", "--file", "updated_workflow.json"]
         )
         assert result.exit_code == 0
         assert "updated successfully" in result.output

--- a/tests/unit/test_workspace_click.py
+++ b/tests/unit/test_workspace_click.py
@@ -1,0 +1,340 @@
+"""Unit tests for workspace CLI commands."""
+
+import json
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from slcli.workspace_click import register_workspace_commands
+
+
+def patch_keyring(monkeypatch):
+    """Patch keyring to return test values."""
+    monkeypatch.setattr(
+        "slcli.utils.keyring.get_password",
+        lambda service, key: "test-key" if key == "SYSTEMLINK_API_KEY" else "https://test.com",
+    )
+
+
+def make_cli():
+    """Create CLI instance with workspace commands for testing."""
+
+    @click.group()
+    def test_cli():
+        pass
+
+    register_workspace_commands(test_cli)
+    return test_cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def mock_requests(monkeypatch, method, response_json, status_code=200):
+    """Mock requests module for testing."""
+
+    class MockResponse:
+        def __init__(self):
+            self.status_code = status_code
+
+        def json(self):
+            return response_json
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise Exception("HTTP error")
+
+    monkeypatch.setattr("requests." + method, lambda *a, **kw: MockResponse())
+
+
+def test_list_workspaces_success(monkeypatch, runner):
+    """Test listing workspaces with a successful response."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {
+                            "id": "ws1",
+                            "name": "Workspace 1",
+                            "enabled": True,
+                            "default": True,
+                        },
+                        {
+                            "id": "ws2",
+                            "name": "Workspace 2",
+                            "enabled": False,
+                            "default": False,
+                        },
+                    ]
+                }
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "list"])
+    assert result.exit_code == 0
+    assert "Workspace 1" in result.output
+    assert "Workspace 2" not in result.output  # Disabled workspace filtered out
+
+
+def test_list_workspaces_include_disabled(monkeypatch, runner):
+    """Test listing workspaces including disabled ones."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {
+                            "id": "ws1",
+                            "name": "Workspace 1",
+                            "enabled": True,
+                            "default": True,
+                        },
+                        {
+                            "id": "ws2",
+                            "name": "Workspace 2",
+                            "enabled": False,
+                            "default": False,
+                        },
+                    ]
+                }
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "list", "--include-disabled"])
+    assert result.exit_code == 0
+    assert "Workspace 1" in result.output
+    assert "Workspace 2" in result.output  # Disabled workspace included
+
+
+def test_list_workspaces_json_format(monkeypatch, runner):
+    """Test listing workspaces with JSON output."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {
+                            "id": "ws1",
+                            "name": "Workspace 1",
+                            "enabled": True,
+                            "default": True,
+                        }
+                    ]
+                }
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "list", "--format", "json"])
+    assert result.exit_code == 0
+
+    # Parse JSON output
+    output_data = json.loads(result.output)
+    assert len(output_data) == 1
+    assert output_data[0]["name"] == "Workspace 1"
+
+
+def test_list_workspaces_empty(monkeypatch, runner):
+    """Test listing workspaces when none exist."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"workspaces": []}
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "list"])
+    assert result.exit_code == 0
+    assert "No workspaces found." in result.output
+
+
+def test_disable_workspace_success(monkeypatch, runner):
+    """Test disabling a workspace successfully."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {"id": "test-ws-id", "name": "Test Workspace", "enabled": True},
+                        {"id": "other-ws", "name": "Other Workspace", "enabled": True},
+                    ]
+                }
+
+        return R()
+
+    def mock_put(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"id": "test-ws-id", "name": "Test Workspace", "enabled": False}
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    monkeypatch.setattr("requests.put", mock_put)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "disable", "--id", "test-ws-id"], input="y\n")
+    assert result.exit_code == 0
+    assert "Workspace 'Test Workspace' disabled successfully" in result.output
+
+
+def test_disable_workspace_not_found(monkeypatch, runner):
+    """Test disabling a workspace that doesn't exist."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"workspaces": []}
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "disable", "--id", "nonexistent-id"], input="y\n")
+    assert result.exit_code == 3  # NOT_FOUND exit code
+    assert "Workspace with ID 'nonexistent-id' not found" in result.output
+
+
+def test_disable_workspace_already_disabled(monkeypatch, runner):
+    """Test disabling a workspace that is already disabled."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {"id": "test-ws-id", "name": "Test Workspace", "enabled": False},
+                    ]
+                }
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "disable", "--id", "test-ws-id"], input="y\n")
+    assert result.exit_code == 1  # GENERAL_ERROR exit code
+    assert "Workspace 'Test Workspace' is already disabled" in result.output
+
+
+def test_info_workspace_success(monkeypatch, runner):
+    """Test getting workspace info successfully."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "workspaces": [
+                        {
+                            "id": "test-ws-id",
+                            "name": "Test Workspace",
+                            "enabled": True,
+                            "default": False,
+                        },
+                    ]
+                }
+
+        return R()
+
+    def mock_post(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                if "testplan-templates" in str(a):
+                    return {"testPlanTemplates": [{"id": "template-1", "name": "Test Template"}]}
+                elif "workflows" in str(a):
+                    return {
+                        "workflows": [
+                            {"id": "workflow-1", "name": "Test Workflow", "workspace": "test-ws-id"}
+                        ]
+                    }
+                else:
+                    return {"notebooks": [{"id": "notebook-1", "name": "Test Notebook"}]}
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+    monkeypatch.setattr("requests.post", mock_post)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "info", "--id", "test-ws-id"])
+    assert result.exit_code == 0
+    assert "Workspace Information: Test Workspace" in result.output
+    assert "Test Plan Templates (1)" in result.output
+    assert "Workflows (1)" in result.output
+
+
+def test_info_workspace_not_found(monkeypatch, runner):
+    """Test getting info for workspace that doesn't exist."""
+    patch_keyring(monkeypatch)
+
+    def mock_get(*a, **kw):
+        class R:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"workspaces": []}
+
+        return R()
+
+    monkeypatch.setattr("requests.get", mock_get)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workspace", "info", "--name", "nonexistent"])
+    assert result.exit_code == 3  # NOT_FOUND exit code
+    assert "Workspace 'nonexistent' not found" in result.output


### PR DESCRIPTION
Adds comprehensive workspace management capabilities with read-only operations and administrative functions.

**Key Changes**:
- **New workspace commands**: `list`, `info`, and `disable` for workspace administration
- **Consistent table formatting**: Updated all list commands (templates, workflows, notebooks, workspaces) to use unified box-drawing character styling
- **Command naming**: Renamed all commands from plural to singular forms (`templates` → `template`, `workflows` → `workflow`, etc.)
- **Enhanced utilities**: Added workspace mapping functions and improved error handling
- **Documentation**: Updated README with workspace management section and CLI best practices
- **Test coverage**: Added comprehensive test suite for workspace operations (9 tests)

**Workspace Features**:
- List workspaces with filtering (by name, include disabled)
- Get detailed workspace info (contents: templates, workflows, notebooks)
- Disable workspaces with confirmation prompts
- JSON and table output formats for all commands
