### PR TITLE
Add workflow preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,41 @@ slcli workflow update --id <workflow_id> --file updated-workflow.json
 slcli workflow delete --id <workflow_id>
 ```
 
+### Preview a workflow (Mermaid diagram)
+
+Generate a visual state diagram (Mermaid) for an existing workflow or a local JSON definition:
+
+```bash
+# Preview remote workflow in browser (HTML)
+slcli workflow preview --id <workflow_id>
+
+# Save raw Mermaid source (.mmd) for a remote workflow
+slcli workflow preview --id <workflow_id> --format mmd --output workflow.mmd
+
+# Preview a local JSON file
+slcli workflow preview --file my-workflow.json
+
+# Read workflow JSON from stdin
+cat my-workflow.json | slcli workflow preview --file - --format mmd --output wf.mmd
+
+# Disable emoji and legend (clean export)
+slcli workflow preview --id <workflow_id> --no-emoji --no-legend --format html --output wf.html
+
+# Generate HTML without opening a browser
+slcli workflow preview --id <workflow_id> --no-open --output wf.html
+```
+
+Options:
+
+- `--id / --file` (mutually exclusive): Choose remote workflow or local JSON (use `-` for stdin)
+- `--format`: `html` (default) or `mmd`
+- `--output/-o`: Write to file; otherwise HTML opens in browser
+- `--no-emoji`: Remove emoji from action labels
+- `--no-legend`: Suppress legend block in HTML output
+- `--no-open`: Do not open browser when producing HTML without `--output`
+
+Legend (HTML only) explains: action type emojis, privilege sets, truncated notebook IDs, icon class (⚡️), and hidden actions.
+
 ## Function Management
 
 The `function` command group provides comprehensive management of WebAssembly (WASM) function definitions and executions in SystemLink. Functions are compiled WebAssembly modules that can be executed remotely with parameters.

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -270,7 +270,7 @@ def register_notebook_commands(cli: Any) -> None:
         pass
 
     @notebook.command(name="update")
-    @click.option("--id", "notebook_id", required=True, help="Notebook ID to update")
+    @click.option("--id", "-i", "notebook_id", required=True, help="Notebook ID to update")
     @click.option(
         "--metadata",
         type=click.Path(exists=True, dir_okay=False),
@@ -430,7 +430,7 @@ def register_notebook_commands(cli: Any) -> None:
             handle_api_error(exc)
 
     @notebook.command(name="download")
-    @click.option("--id", "notebook_id", help="Notebook ID")
+    @click.option("--id", "-i", "notebook_id", help="Notebook ID")
     @click.option("--name", "notebook_name", help="Notebook name")
     @click.option("--workspace", default="Default", help="Workspace name (default: Default)")
     @click.option("--output", required=False, help="Output file path (defaults to notebook name)")
@@ -597,7 +597,7 @@ def register_notebook_commands(cli: Any) -> None:
             handle_api_error(exc)
 
     @notebook.command(name="delete")
-    @click.option("--id", "notebook_id", required=True, help="Notebook ID to delete")
+    @click.option("--id", "-i", "notebook_id", required=True, help="Notebook ID to delete")
     def delete_notebook(notebook_id: str = "") -> None:
         """Delete a notebook by ID."""
         try:

--- a/slcli/templates_click.py
+++ b/slcli/templates_click.py
@@ -177,6 +177,7 @@ def register_templates_commands(cli: Any) -> None:
                         "lab": "// Example: Battery Pack Lab",
                         "startTestStateId": "// UUID for initial test state",
                     },
+                    "workflowId": "// Optional: UUID of associated workflow (link to workflow preview)",
                 }
             ]
         }

--- a/slcli/templates_click.py
+++ b/slcli/templates_click.py
@@ -177,7 +177,7 @@ def register_templates_commands(cli: Any) -> None:
                         "lab": "// Example: Battery Pack Lab",
                         "startTestStateId": "// UUID for initial test state",
                     },
-                    "workflowId": "// Optional: UUID of associated workflow (link to workflow preview)",
+                    "workflowId": "// Optional: UUID of associated workflow",
                 }
             ]
         }

--- a/slcli/user_click.py
+++ b/slcli/user_click.py
@@ -412,7 +412,7 @@ def register_user_commands(cli):
             handle_api_error(exc)
 
     @user.command(name="get")
-    @click.option("--id", "user_id", help="User ID to retrieve")
+    @click.option("--id", "-i", "user_id", help="User ID to retrieve")
     @click.option("--email", "user_email", help="User email to retrieve")
     @click.option(
         "--format",
@@ -665,7 +665,7 @@ def register_user_commands(cli):
             handle_api_error(exc)
 
     @user.command(name="update")
-    @click.option("--id", "user_id", required=True, help="User ID to update")
+    @click.option("--id", "-i", "user_id", required=True, help="User ID to update")
     @click.option("--first-name", help="User's first name")
     @click.option("--last-name", help="User's last name")
     @click.option("--email", help="User's email address")
@@ -740,7 +740,7 @@ def register_user_commands(cli):
             handle_api_error(exc)
 
     @user.command(name="delete")
-    @click.option("--id", "user_id", required=True, help="User ID to delete")
+    @click.option("--id", "-i", "user_id", required=True, help="User ID to delete")
     @click.confirmation_option(
         prompt="Are you sure you want to delete this user? This action cannot be undone."
     )

--- a/slcli/workflow_preview.py
+++ b/slcli/workflow_preview.py
@@ -5,7 +5,7 @@ Separated from workflows_click.py to keep command module concise.
 
 from __future__ import annotations
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Tuple
 
 # Public-ish constants (imported by tests / commands)
 ACTION_TYPE_EMOJI: Dict[str, str] = {
@@ -14,8 +14,7 @@ ACTION_TYPE_EMOJI: Dict[str, str] = {
     "SCHEDULE": "📅",
     "JOB": "🛠️",
 }
-
-LEGEND_ROWS: List[tuple[str, str]] = [
+LEGEND_ROWS: List[Tuple[str, str]] = [
     ("🧑", "Manual action"),
     ("📓", "Notebook action"),
     ("📅", "Schedule action"),

--- a/slcli/workflow_preview.py
+++ b/slcli/workflow_preview.py
@@ -1,0 +1,218 @@
+"""Workflow preview (Mermaid diagram) generation utilities.
+
+Separated from workflows_click.py to keep command module concise.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+# Public-ish constants (imported by tests / commands)
+ACTION_TYPE_EMOJI: Dict[str, str] = {
+    "MANUAL": "🧑",
+    "NOTEBOOK": "📓",
+    "SCHEDULE": "📅",
+    "JOB": "🛠️",
+}
+
+LEGEND_ROWS: List[tuple[str, str]] = [
+    ("🧑", "Manual action"),
+    ("📓", "Notebook action"),
+    ("📅", "Schedule action"),
+    ("🛠️", "Job action"),
+    ("(priv1, priv2)", "Privileges required"),
+    ("NB abcdef..", "Truncated Notebook ID"),
+    ("⚡️ NAME", "UI icon class"),
+    ("hidden", "Hidden (not shown in UI)"),
+]
+
+
+def sanitize_mermaid_label(label: str) -> str:
+    """Sanitize label text for Mermaid diagram compatibility.
+
+    Args:
+        label: Raw label text
+    Returns:
+        Sanitized label safe for inclusion inside Mermaid stateDiagram labels
+    """
+    if not label:
+        return label
+    sanitized = label.replace("[", "(").replace("]", ")").replace("🔗", "")
+    sanitized = sanitized.replace("/", "-").replace("\\", "-")
+    sanitized = sanitized.replace('"', "'").replace("`", "'")
+    sanitized = sanitized.replace(":", " ")
+    sanitized = sanitized.replace(";", ",")
+    sanitized = sanitized.replace("|", " ")
+    sanitized = sanitized.replace("&", "and")
+    sanitized = " ".join(sanitized.split())
+    return sanitized
+
+
+def generate_mermaid_diagram(workflow_data: Dict[str, Any], enable_emoji: bool = True) -> str:
+    """Generate Mermaid stateDiagram-v2 source for a workflow.
+
+    Args:
+        workflow_data: Parsed workflow JSON dict
+        enable_emoji: Whether to include emoji for action types
+    """
+    states = workflow_data.get("states", [])
+    actions = workflow_data.get("actions", [])
+    type_emojis = ACTION_TYPE_EMOJI if enable_emoji else {}
+
+    action_lookup: Dict[str, Dict[str, Any]] = {}
+    for action in actions:
+        action_name = action["name"]
+        execution_action = action.get("executionAction", {})
+        action_info = {
+            "display": action.get("displayText", action_name),
+            "type": execution_action.get("type", ""),
+            "privileges": action.get("privilegeSpecificity", []),
+            "icon": action.get("iconClass"),
+            "notebook_id": execution_action.get("notebookId"),
+        }
+        action_lookup[action_name] = action_info
+        action_lookup[action_name.strip()] = action_info
+
+    lines: List[str] = ["stateDiagram-v2", ""]
+
+    for state in states:
+        state_name = state["name"]
+        substates = state.get("substates", [])
+        if not substates:
+            lines.append(f"    {state_name}")
+            continue
+        for substate in substates:
+            sub_name = substate["name"]
+            display = substate.get("displayText") or state_name.replace("_", " ").title()
+            metadata_parts: List[str] = []
+            if state.get("dashboardAvailable"):
+                metadata_parts.append("Dashboard")
+            available_actions = substate.get("availableActions", [])
+            visible_actions = len([a for a in available_actions if a.get("showInUI", True)])
+            hidden_actions = len([a for a in available_actions if not a.get("showInUI", True)])
+            total_actions = len(available_actions)
+            if total_actions:
+                if hidden_actions:
+                    metadata_parts.append(f"{visible_actions}+{hidden_actions} actions")
+                else:
+                    metadata_parts.append(
+                        f"{visible_actions} action{'s' if visible_actions != 1 else ''}"
+                    )
+            if metadata_parts:
+                label = f"{display}\\n({', '.join(metadata_parts)})"
+            else:
+                label = display
+            if sub_name == state_name:
+                lines.append(f"    {state_name} : {label}")
+            else:
+                lines.append(f"    {state_name}_{sub_name} : {state_name}\\n{label}")
+            # Transitions
+            for a in available_actions:
+                action_name = a.get("action", "")
+                next_state = a.get("nextState", "")
+                next_sub = a.get("nextSubstate", "")
+                show_in_ui = a.get("showInUI", True)
+                if not next_state:
+                    continue
+                info = (
+                    action_lookup.get(action_name) or action_lookup.get(action_name.strip()) or {}
+                )
+                emoji = type_emojis.get(info.get("type", ""), "")
+                segs: List[str] = []
+                if emoji:
+                    segs.append(emoji)
+                segs.append(info.get("display", action_name))
+                if info.get("type"):
+                    segs.append(f"({info['type']})")
+                privs = info.get("privileges", [])
+                if privs:
+                    segs.append(f"({', '.join(privs)})")
+                nb = info.get("notebook_id")
+                if info.get("type") == "NOTEBOOK" and nb:
+                    segs.append(f"NB {nb[:8]}...")
+                icon = info.get("icon")
+                if icon:
+                    segs.append(f"⚡️ {icon}")
+                segs = [sanitize_mermaid_label(s) for s in segs if s]
+                action_label = "\\n".join(segs)
+                source = state_name if sub_name == state_name else f"{state_name}_{sub_name}"
+                if next_sub and next_sub == next_state:
+                    target = next_state
+                elif next_sub:
+                    target = f"{next_state}_{next_sub}"
+                else:
+                    target = next_state
+                if show_in_ui:
+                    lines.append(f"    {source} --> {target} : {action_label}")
+                else:
+                    lines.append(f"    {source} --> {target} : {action_label}\\nhidden")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_legend_html() -> str:
+    """Return legend HTML using LEGEND_ROWS constant."""
+    rows = "\n".join(f"                <tr><td>{k}</td><td>{v}</td></tr>" for k, v in LEGEND_ROWS)
+    return (
+        '    <div class="legend" style="text-align:left; max-width:400px; margin:0 0 20px 0; background:#fafafa; border:1px solid #ddd; padding:12px; border-radius:6px; font-size:0.9em;">\n'
+        "            <strong>Legend</strong>\n"
+        '            <table class="legend-table">\n'
+        f"{rows}\n"
+        "            </table>\n"
+        "        </div>"
+    )
+
+
+def generate_html_with_mermaid(
+    workflow_data: Dict[str, Any], mermaid_code: str, include_legend: bool = True
+) -> str:
+    """Generate HTML document for a workflow diagram.
+
+    Args:
+        workflow_data: Workflow JSON
+        mermaid_code: Mermaid diagram source
+        include_legend: Whether to include legend block
+    """
+    workflow_name = workflow_data.get("name", "Workflow")
+    workflow_description = workflow_data.get("description", "")
+    legend_block = build_legend_html() if include_legend else ""
+    return f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <title>Workflow Preview: {workflow_name}</title>
+    <script src=\"https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js\"></script>
+    <style>
+        body {{ font-family: Arial, sans-serif; margin: 20px; background-color: #f5f5f5; }}
+        .container {{ max-width: 1200px; margin: 0 auto; background-color: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+        .header {{ margin-bottom: 20px; border-bottom: 1px solid #eee; padding-bottom: 10px; }}
+        .workflow-title {{ color: #333; margin: 0; }}
+        .workflow-description {{ color: #666; margin: 5px 0 0 0; }}
+        .diagram-container {{ text-align: center; margin: 20px 0; }}
+        .metadata {{ margin-top: 20px; font-size: 0.9em; color: #666; }}
+        .legend-table {{ width: 100%; border-collapse: collapse; margin: 8px 0 0 0; }}
+        .legend-table td {{ padding: 4px 8px; border-bottom: 1px solid #eee; vertical-align: top; }}
+        .legend-table td:first-child {{ font-family: monospace; font-weight: bold; width: 120px; }}
+    </style>
+</head>
+<body>
+    <div class=\"container\">
+        <div class=\"header\">
+            <h1 class=\"workflow-title\">{workflow_name}</h1>
+            {f'<p class=\"workflow-description\">{workflow_description}</p>' if workflow_description else ''}
+        </div>
+        <div class=\"diagram-container\">
+            <div class=\"mermaid\">\n{mermaid_code}\n            </div>
+        </div>
+{legend_block}
+        <div class=\"metadata\">
+            <h3>Workflow Details</h3>
+            <p><strong>States:</strong> {len(workflow_data.get('states', []))}</p>
+            <p><strong>Actions:</strong> {len(workflow_data.get('actions', []))}</p>
+            {f'<p><strong>Workspace:</strong> {workflow_data.get("workspace", "N/A")}</p>' if workflow_data.get("workspace") else ''}
+        </div>
+    </div>
+    <script>mermaid.initialize({{ startOnLoad: true, theme: 'default', fontFamily: 'Arial, sans-serif' }});</script>
+</body>
+</html>"""

--- a/slcli/workflow_preview.py
+++ b/slcli/workflow_preview.py
@@ -175,6 +175,17 @@ def generate_html_with_mermaid(
     workflow_name = workflow_data.get("name", "Workflow")
     workflow_description = workflow_data.get("description", "")
     legend_block = build_legend_html() if include_legend else ""
+    # Precompute optional HTML fragments to avoid nested f-strings inside expression braces
+    description_html = (
+        f'<p class="workflow-description">{workflow_description}</p>'
+        if workflow_description
+        else ""
+    )
+    workspace_value = workflow_data.get("workspace")
+    if workspace_value:
+        workspace_html = f"<p><strong>Workspace:</strong> {workspace_value}</p>"
+    else:
+        workspace_html = ""
     return f"""<!DOCTYPE html>
 <html lang=\"en\">
 <head>
@@ -199,7 +210,7 @@ def generate_html_with_mermaid(
     <div class=\"container\">
         <div class=\"header\">
             <h1 class=\"workflow-title\">{workflow_name}</h1>
-            {f'<p class=\"workflow-description\">{workflow_description}</p>' if workflow_description else ''}
+                {description_html}
         </div>
         <div class=\"diagram-container\">
             <div class=\"mermaid\">\n{mermaid_code}\n            </div>
@@ -209,7 +220,7 @@ def generate_html_with_mermaid(
             <h3>Workflow Details</h3>
             <p><strong>States:</strong> {len(workflow_data.get('states', []))}</p>
             <p><strong>Actions:</strong> {len(workflow_data.get('actions', []))}</p>
-            {f'<p><strong>Workspace:</strong> {workflow_data.get("workspace", "N/A")}</p>' if workflow_data.get("workspace") else ''}
+            {workspace_html}
         </div>
     </div>
     <script>mermaid.initialize({{ startOnLoad: true, theme: 'default', fontFamily: 'Arial, sans-serif' }});</script>

--- a/slcli/workflows_click.py
+++ b/slcli/workflows_click.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, Union, Any
 
 import click
 import requests
+
 from . import workflow_preview
 from .cli_utils import validate_output_format
 from .universal_handlers import UniversalResponseHandler, FilteredResponse

--- a/slcli/workflows_click.py
+++ b/slcli/workflows_click.py
@@ -3,6 +3,9 @@
 import json
 import os
 import sys
+import tempfile
+import webbrowser
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 import click
@@ -125,7 +128,7 @@ def register_workflows_commands(cli):
             click.echo(f"✗ Error resolving workspace '{workspace}': {exc}", err=True)
             raise click.ClickException(f"Error resolving workspace '{workspace}': {exc}")
 
-        # Create workflow structure based on the correct API schema
+        # Create workflow structure matching the workflow-template.json reference
         workflow_data = {
             "name": name,
             "description": description,
@@ -142,6 +145,51 @@ def register_workflows_commands(cli):
                     "displayText": "Complete",
                     "privilegeSpecificity": ["Close"],
                     "executionAction": {"type": "MANUAL", "action": "COMPLETE"},
+                },
+                {
+                    "name": "RUN_NOTEBOOK",
+                    "displayText": "Run Notebook",
+                    "iconClass": None,
+                    "i18n": [],
+                    "privilegeSpecificity": ["ExecuteTest"],
+                    "executionAction": {
+                        "action": "RUN_NOTEBOOK",
+                        "type": "NOTEBOOK",
+                        "notebookId": "df2140b3-f184-4327-af07-6048d073449d",
+                        "parameters": {
+                            "partNumber": "<partNumber>",
+                            "dut": "<dutId>",
+                            "operator": "<assignedTo>",
+                            "testProgram": "<testProgram>",
+                            "location": "<properties.region>-<properties.facility>-<properties.lab>",
+                        },
+                    },
+                },
+                {
+                    "name": "PLAN_SCHEDULE",
+                    "displayText": "Schedule Test Plan",
+                    "iconClass": "SCHEDULE",
+                    "i18n": [],
+                    "privilegeSpecificity": [],
+                    "executionAction": {"action": "PLAN_SCHEDULE", "type": "SCHEDULE"},
+                },
+                {
+                    "name": "RUN_JOB",
+                    "displayText": "Run Job",
+                    "iconClass": "DEPLOY",
+                    "i18n": [],
+                    "privilegeSpecificity": [],
+                    "executionAction": {
+                        "action": "RUN_JOB",
+                        "type": "JOB",
+                        "jobs": [
+                            {
+                                "functions": ["state.apply"],
+                                "arguments": [["<properties.startTestStateId>"]],
+                                "metadata": {},
+                            }
+                        ],
+                    },
                 },
             ],
             "states": [
@@ -164,7 +212,18 @@ def register_workflows_commands(cli):
                     "dashboardAvailable": False,
                     "defaultSubstate": "REVIEWED",
                     "substates": [
-                        {"name": "REVIEWED", "displayText": "Reviewed", "availableActions": []}
+                        {
+                            "name": "REVIEWED",
+                            "displayText": "Reviewed",
+                            "availableActions": [
+                                {
+                                    "action": "PLAN_SCHEDULE",
+                                    "nextState": "SCHEDULED",
+                                    "nextSubstate": "SCHEDULED",
+                                    "showInUI": True,
+                                }
+                            ],
+                        }
                     ],
                 },
                 {
@@ -181,7 +240,13 @@ def register_workflows_commands(cli):
                                     "nextState": "IN_PROGRESS",
                                     "nextSubstate": "IN_PROGRESS",
                                     "showInUI": True,
-                                }
+                                },
+                                {
+                                    "action": "RUN_NOTEBOOK",
+                                    "nextState": "IN_PROGRESS",
+                                    "nextSubstate": "IN_PROGRESS",
+                                    "showInUI": True,
+                                },
                             ],
                         }
                     ],
@@ -196,17 +261,11 @@ def register_workflows_commands(cli):
                             "displayText": "In progress",
                             "availableActions": [
                                 {
-                                    "action": "START",
-                                    "nextState": "IN_PROGRESS",
-                                    "nextSubstate": "IN_PROGRESS",
-                                    "showInUI": True,
-                                },
-                                {
                                     "action": "COMPLETE",
                                     "nextState": "PENDING_APPROVAL",
                                     "nextSubstate": "PENDING_APPROVAL",
                                     "showInUI": True,
-                                },
+                                }
                             ],
                         }
                     ],
@@ -219,7 +278,14 @@ def register_workflows_commands(cli):
                         {
                             "name": "PENDING_APPROVAL",
                             "displayText": "Pending approval",
-                            "availableActions": [],
+                            "availableActions": [
+                                {
+                                    "action": "RUN_JOB",
+                                    "nextState": "CLOSED",
+                                    "nextSubstate": "CLOSED",
+                                    "showInUI": True,
+                                }
+                            ],
                         }
                     ],
                 },
@@ -603,6 +669,420 @@ def register_workflows_commands(cli):
         except Exception as exc:
             handle_api_error(exc)
 
+    @workflow.command(name="preview")
+    @click.option(
+        "--id",
+        "-i",
+        "workflow_id",
+        help="Workflow ID to preview",
+    )
+    @click.option(
+        "--file",
+        "-f",
+        "input_file",
+        help="Local JSON file to preview",
+    )
+    @click.option(
+        "--output",
+        "-o",
+        help="Output file path (default: open in browser)",
+    )
+    @click.option(
+        "--format",
+        type=click.Choice(["html", "mmd", "svg"]),
+        default="html",
+        show_default=True,
+        help="Output format",
+    )
+    def preview_workflow(workflow_id, input_file, output, format):
+        """Generate a Mermaid diagram preview of workflow states and transitions."""
+        # Validate that exactly one of --id or --file is provided
+        if not workflow_id and not input_file:
+            click.echo("✗ Error: Must specify either --id or --file", err=True)
+            sys.exit(1)
+        if workflow_id and input_file:
+            click.echo("✗ Error: Cannot specify both --id and --file", err=True)
+            sys.exit(1)
+
+        try:
+            # Load workflow data
+            if workflow_id:
+                # Fetch workflow by ID
+                url = f"{get_base_url()}/niworkorder/v1/workflows/{workflow_id}?ff-userdefinedworkflowsfortestplaninstances=true"
+                resp = make_api_request("GET", url)
+                workflow_data = resp.json()
+
+                if not workflow_data:
+                    click.echo(f"✗ Workflow with ID {workflow_id} not found.", err=True)
+                    sys.exit(1)
+            else:
+                # Load from local file
+                workflow_data = load_json_file(input_file)
+
+            # Generate Mermaid diagram
+            mermaid_code = _generate_mermaid_diagram(workflow_data)
+
+            if format == "mmd":
+                # Save as .mmd file
+                if not output:
+                    output = f"workflow-{workflow_data.get('name', 'preview')}.mmd"
+                with open(output, "w", encoding="utf-8") as f:
+                    f.write(mermaid_code)
+                click.echo(f"✓ Mermaid diagram saved to {output}")
+            elif format == "svg":
+                # Note: SVG generation would require Mermaid CLI to be installed
+                click.echo(
+                    "✗ SVG format requires Mermaid CLI. Use 'npm install -g @mermaid-js/mermaid-cli' first.",
+                    err=True,
+                )
+                sys.exit(1)
+            else:
+                # Generate HTML and open in browser
+                html_content = _generate_html_with_mermaid(workflow_data, mermaid_code)
+
+                if output:
+                    # Save to specified file
+                    with open(output, "w", encoding="utf-8") as f:
+                        f.write(html_content)
+                    click.echo(f"✓ HTML preview saved to {output}")
+                else:
+                    # Create temporary file and open in browser
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".html", delete=False, encoding="utf-8"
+                    ) as f:
+                        f.write(html_content)
+                        temp_file = f.name
+
+                    # Open in default browser
+                    webbrowser.open(f"file://{Path(temp_file).absolute()}")
+                    click.echo(f"✓ Opening workflow preview in browser...")
+
+        except Exception as exc:
+            handle_api_error(exc)
+
+
+def _sanitize_mermaid_label(label: str) -> str:
+    """Sanitize label text for Mermaid diagram compatibility."""
+    if not label:
+        return label
+
+    # Replace problematic characters for Mermaid syntax
+    sanitized = label.replace("[", "(")
+    sanitized = sanitized.replace("]", ")")
+    sanitized = sanitized.replace("🔗", "")
+    # Keep 📓 notebook emoji now that we add a legend; it's safe in labels
+    sanitized = sanitized.replace("/", "-")
+    sanitized = sanitized.replace("\\", "-")
+    sanitized = sanitized.replace('"', "'")
+    sanitized = sanitized.replace("`", "'")
+    sanitized = sanitized.replace(":", " ")
+    sanitized = sanitized.replace(";", ",")
+    sanitized = sanitized.replace("|", " ")
+    sanitized = sanitized.replace("&", "and")
+
+    # Remove any remaining problematic characters and clean up whitespace
+    sanitized = " ".join(sanitized.split())  # Normalize whitespace
+
+    return sanitized
+
+
+def _generate_mermaid_diagram(workflow_data: Dict) -> str:
+    """Generate Mermaid state diagram from workflow data."""
+    states = workflow_data.get("states", [])
+    actions = workflow_data.get("actions", [])
+
+    # Emoji mapping for action types (kept simple & widely supported)
+    type_emojis: Dict[str, str] = {
+        "MANUAL": "🧑",
+        "NOTEBOOK": "📓",
+        "SCHEDULE": "📅",
+        "JOB": "🛠️",
+    }
+
+    # Create action lookup for display text and type, handling potential whitespace issues
+    action_lookup = {}
+    for action in actions:
+        action_name = action["name"]
+        action_display = action.get("displayText", action_name)
+        execution_action = action.get("executionAction", {})
+        action_type = execution_action.get("type", "")
+
+        # Collect additional action metadata
+        privileges = action.get("privilegeSpecificity", [])
+        icon_class = action.get("iconClass")
+        notebook_id = execution_action.get("notebookId")
+
+        # Create action info with all metadata
+        action_info = {
+            "display": action_display,
+            "type": action_type,
+            "privileges": privileges,
+            "icon": icon_class,
+            "notebook_id": notebook_id,
+        }
+
+        # Store both trimmed and untrimmed versions to handle inconsistencies
+        action_lookup[action_name] = action_info
+        action_lookup[action_name.strip()] = action_info
+
+    lines = ["stateDiagram-v2", ""]
+
+    # Add states and their substates
+    for state in states:
+        state_name = state["name"]
+        substates = state.get("substates", [])
+
+        if not substates:
+            # Simple state with no substates
+            lines.append(f"    {state_name}")
+        else:
+            # State with substates
+            for substate in substates:
+                substate_name = substate["name"]
+                substate_display = substate.get("displayText")
+
+                # Build metadata for the state
+                metadata_parts = []
+
+                # Add dashboard availability
+                if state.get("dashboardAvailable"):
+                    metadata_parts.append("Dashboard")
+
+                # Add action count (visible + hidden)
+                available_actions = substate.get("availableActions", [])
+                visible_actions = len([a for a in available_actions if a.get("showInUI", True)])
+                hidden_actions = len([a for a in available_actions if not a.get("showInUI", True)])
+                total_actions = len(available_actions)
+
+                if total_actions > 0:
+                    if hidden_actions > 0:
+                        metadata_parts.append(f"{visible_actions}+{hidden_actions} actions")
+                    else:
+                        metadata_parts.append(
+                            f"{visible_actions} action{'s' if visible_actions != 1 else ''}"
+                        )
+
+                # Create display text
+                if substate_display:
+                    display_text = substate_display
+                else:
+                    # Use state name formatted nicely (convert SNAKE_CASE to Title Case)
+                    display_text = state_name.replace("_", " ").title()
+
+                # Add metadata if any (restore multiline formatting with explicit \n sequences)
+                if metadata_parts:
+                    full_display = f"{display_text}\\n({', '.join(metadata_parts)})"
+                else:
+                    full_display = display_text
+
+                # Add substate definition (restore multiline variant)
+                if substate_name == state_name:
+                    # Default substate uses the state name
+                    lines.append(f"    {state_name} : {full_display}")
+                else:
+                    # Named substate with parent state on first line
+                    lines.append(
+                        f"    {state_name}_{substate_name} : {state_name}\\n{full_display}"
+                    )
+
+                # Add transitions from this substate
+                available_actions = substate.get("availableActions", [])
+                for action in available_actions:
+                    action_name = action.get("action", "")
+                    next_state = action.get("nextState", "")
+                    next_substate = action.get("nextSubstate", "")
+                    show_in_ui = action.get("showInUI", True)
+
+                    if next_state:
+                        # Handle potential whitespace issues in action names
+                        action_info = action_lookup.get(
+                            action_name, action_lookup.get(action_name.strip(), {})
+                        )
+
+                        if isinstance(action_info, dict):
+                            action_display = action_info.get("display", action_name)
+                            action_type = action_info.get("type", "")
+                            privileges = action_info.get("privileges", [])
+                            icon = action_info.get("icon")
+                            notebook_id = action_info.get("notebook_id")
+
+                            # Build enhanced action label with multiline formatting
+                            # Collect label segments; each becomes a separate Mermaid line
+                            emoji = type_emojis.get(action_type, "")
+                            label_segments: list[str] = (
+                                [emoji, action_display] if emoji else [action_display]
+                            )
+
+                            # Add action type as separate line
+                            if action_type:
+                                label_segments.append(f"({action_type})")
+
+                            # Add privileges if any (keep grouped)
+                            if privileges:
+                                priv_str = ", ".join(privileges)
+                                label_segments.append(f"({priv_str})")
+
+                            # Add notebook info for NOTEBOOK actions
+                            if action_type == "NOTEBOOK" and notebook_id:
+                                short_id = notebook_id[:8] + "..."
+                                label_segments.append(f"NB {short_id}")
+
+                            # Add icon indicator
+                            if icon:
+                                # Use lightning emoji to indicate icon class succinctly
+                                label_segments.append(f"⚡️ {icon}")
+
+                            # Sanitize each segment; join using explicit \n escapes so Mermaid
+                            # renders them as multi-line label content.
+                            sanitized_segments = [
+                                _sanitize_mermaid_label(seg) for seg in label_segments if seg
+                            ]
+                            full_action_label = "\\n".join(sanitized_segments)
+                        else:
+                            # Fallback for backwards compatibility
+                            full_action_label = action_info if action_info else action_name
+
+                        # Determine source and target node names
+                        source_node = (
+                            state_name
+                            if substate_name == state_name
+                            else f"{state_name}_{substate_name}"
+                        )
+
+                        if next_substate and next_substate == next_state:
+                            target_node = next_state
+                        elif next_substate:
+                            target_node = f"{next_state}_{next_substate}"
+                        else:
+                            target_node = next_state
+
+                        # Add transition (use only supported arrow syntax for stateDiagram)
+                        if show_in_ui:
+                            lines.append(
+                                f"    {source_node} --> {target_node} : {full_action_label}"
+                            )
+                        else:
+                            # Use same arrow; append hidden marker in lowercase for clarity
+                            # Append hidden marker as additional multiline segment
+                            hidden_label = f"{full_action_label}\\nhidden"
+                            lines.append(f"    {source_node} --> {target_node} : {hidden_label}")
+
+    # Legend now omitted from Mermaid source (added only in HTML export)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_html_with_mermaid(workflow_data: Dict, mermaid_code: str) -> str:
+    """Generate HTML page with embedded Mermaid diagram."""
+    workflow_name = workflow_data.get("name", "Workflow")
+    workflow_description = workflow_data.get("description", "")
+
+    html_template = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workflow Preview: {workflow_name}</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+    <style>
+        body {{
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            background-color: #f5f5f5;
+        }}
+        .container {{
+            max-width: 1200px;
+            margin: 0 auto;
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .header {{
+            margin-bottom: 20px;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 10px;
+        }}
+        .workflow-title {{
+            color: #333;
+            margin: 0;
+        }}
+        .workflow-description {{
+            color: #666;
+            margin: 5px 0 0 0;
+        }}
+        .diagram-container {{
+            text-align: center;
+            margin: 20px 0;
+        }}
+        .metadata {{
+            margin-top: 20px;
+            font-size: 0.9em;
+            color: #666;
+        }}
+        .legend-table {{
+            width: 100%;
+            border-collapse: collapse;
+            margin: 8px 0 0 0;
+        }}
+        .legend-table td {{
+            padding: 4px 8px;
+            border-bottom: 1px solid #eee;
+            vertical-align: top;
+        }}
+        .legend-table td:first-child {{
+            font-family: monospace;
+            font-weight: bold;
+            width: 120px;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 class="workflow-title">{workflow_name}</h1>
+            {f'<p class="workflow-description">{workflow_description}</p>' if workflow_description else ''}
+        </div>
+        
+        <div class="diagram-container">
+            <div class="mermaid">
+{mermaid_code}
+            </div>
+        </div>
+    <div class="legend" style="text-align:left; max-width:400px; margin:0 0 20px 0; background:#fafafa; border:1px solid #ddd; padding:12px; border-radius:6px; font-size:0.9em;">
+            <strong>Legend</strong>
+            <table class="legend-table">
+                <tr><td>🧑</td><td>Manual action</td></tr>
+                <tr><td>📓</td><td>Notebook action</td></tr>
+                <tr><td>📅</td><td>Schedule action</td></tr>
+                <tr><td>🛠️</td><td>Job action</td></tr>
+                <tr><td>(priv1, priv2)</td><td>Privileges required</td></tr>
+                <tr><td>NB abcdef..</td><td>Truncated Notebook ID</td></tr>
+                <tr><td>⚡️ NAME</td><td>UI icon class</td></tr>
+                <tr><td>hidden</td><td>Hidden (not shown in UI)</td></tr>
+            </table>
+        </div>
+        
+        <div class="metadata">
+            <h3>Workflow Details</h3>
+            <p><strong>States:</strong> {len(workflow_data.get('states', []))}</p>
+            <p><strong>Actions:</strong> {len(workflow_data.get('actions', []))}</p>
+            {f'<p><strong>Workspace:</strong> {workflow_data.get("workspace", "N/A")}</p>' if workflow_data.get("workspace") else ''}
+        </div>
+    </div>
+    
+    <script>
+        mermaid.initialize({{ 
+            startOnLoad: true,
+            theme: 'default',
+            fontFamily: 'Arial, sans-serif'
+        }});
+    </script>
+</body>
+</html>"""
+
+    return html_template
+
 
 def _handle_workflow_error_response(response_data, operation_name):
     """Parse and display detailed workflow error responses.
@@ -628,15 +1108,6 @@ def _handle_workflow_delete_response(response_data, workflow_id):
 
     # Handle successful deletion response format: {"ids": ["1023"]}
     if "ids" in response_data:
-        deleted_ids = response_data.get("ids", [])
-        if workflow_id in deleted_ids:
-            click.echo(f"✓ Workflow {workflow_id} deleted successfully.")
-            return
-        else:
-            # Workflow ID not in the successful deletion list - unexpected
-            click.echo(f"✗ Unexpected response for workflow {workflow_id}:", err=True)
-            click.echo(f"  Successfully deleted: {', '.join(deleted_ids)}", err=True)
-            sys.exit(1)
         deleted_ids = response_data.get("ids", [])
         if workflow_id in deleted_ids:
             click.echo(f"✓ Workflow {workflow_id} deleted successfully.")

--- a/tests/unit/test_workflows_click.py
+++ b/tests/unit/test_workflows_click.py
@@ -512,3 +512,253 @@ def test_update_workflow_success(monkeypatch, runner):
         )
         assert result.exit_code == 0
         assert "updated successfully" in result.output
+
+
+# --- New tests for workflow preview / Mermaid generation --- #
+
+
+def _sample_workflow_for_mermaid():  # helper (not a test)
+    return {
+        "name": "SampleWF",
+        "description": "Sample workflow for mermaid generation",
+        "workspace": "ws123",
+        "actions": [
+            {
+                "name": "PING",
+                "displayText": "Ping",
+                "privilegeSpecificity": ["Submit"],
+                "iconClass": "RESUME",
+                "executionAction": {"type": "MANUAL", "action": "PING"},
+            },
+            {
+                "name": "GO",
+                "displayText": "Go",
+                "privilegeSpecificity": ["ExecuteTest"],
+                "iconClass": "RUN",
+                "executionAction": {
+                    "type": "NOTEBOOK",
+                    "action": "GO",
+                    "notebookId": "abcdef1234567890",
+                },
+            },
+            {
+                "name": "PLAN",
+                "displayText": "Plan-Schedule",
+                "privilegeSpecificity": [],
+                "executionAction": {"type": "SCHEDULE", "action": "PLAN"},
+            },
+            {
+                "name": "UNPLAN",
+                "displayText": "Unplan-Schedule",
+                "privilegeSpecificity": [],
+                "executionAction": {"type": "UNSCHEDULE", "action": "UNPLAN"},
+            },
+        ],
+        "states": [
+            {
+                "name": "NEW",
+                "dashboardAvailable": True,
+                "defaultSubstate": "NEW",
+                "substates": [
+                    {
+                        "name": "NEW",
+                        "displayText": "New",
+                        "availableActions": [
+                            {
+                                "action": "PING",
+                                "nextState": "READY",
+                                "nextSubstate": "READY",
+                                "showInUI": True,
+                            },
+                            {
+                                "action": "GO",
+                                "nextState": "DONE",
+                                "nextSubstate": "DONE",
+                                "showInUI": False,  # hidden action
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "READY",
+                "dashboardAvailable": False,
+                "defaultSubstate": "READY",
+                "substates": [
+                    {
+                        "name": "READY",
+                        "displayText": "Ready",
+                        "availableActions": [
+                            {
+                                "action": "PLAN",
+                                "nextState": "SCHEDULED",
+                                "nextSubstate": "SCHEDULED",
+                                "showInUI": True,
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "SCHEDULED",
+                "dashboardAvailable": False,
+                "defaultSubstate": "SCHEDULED",
+                "substates": [
+                    {
+                        "name": "SCHEDULED",
+                        "displayText": "Sched",
+                        "availableActions": [
+                            {
+                                "action": "UNPLAN",
+                                "nextState": "READY",
+                                "nextSubstate": "READY",
+                                "showInUI": True,
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "DONE",
+                "dashboardAvailable": False,
+                "defaultSubstate": "DONE",
+                "substates": [{"name": "DONE", "displayText": "Done", "availableActions": []}],
+            },
+        ],
+    }
+
+
+def test_generate_mermaid_basic():
+    from slcli.workflows_click import _generate_mermaid_diagram
+
+    wf = _sample_workflow_for_mermaid()
+    code = _generate_mermaid_diagram(wf)
+    # Basic structure
+    assert code.startswith("stateDiagram-v2"), code
+    # Multiline state label present (dashboard metadata line)
+    assert "(1 action" in code or "1 action" in code  # depending on hidden count formatting
+    # Emoji for MANUAL action
+    assert "🧑" in code
+    # Notebook action hidden with hidden marker
+    assert "hidden" in code
+    # Icon lightning indicator
+    assert "⚡️" in code
+    # No legend inside Mermaid source
+    assert "LEGEND :" not in code
+
+
+def test_generate_mermaid_hidden_action_marker():
+    from slcli.workflows_click import _generate_mermaid_diagram
+
+    wf = _sample_workflow_for_mermaid()
+    code = _generate_mermaid_diagram(wf)
+    # Hidden action should have newline then 'hidden'
+    assert any(line.strip().endswith("hidden") for line in code.splitlines())
+
+
+def test_generate_html_contains_external_legend():
+    from slcli.workflows_click import _generate_mermaid_diagram, _generate_html_with_mermaid
+
+    wf = _sample_workflow_for_mermaid()
+    mermaid = _generate_mermaid_diagram(wf)
+    html = _generate_html_with_mermaid(wf, mermaid)
+    assert '<div class="legend"' in html
+    assert "⚡️" in html  # icon legend entry
+    assert "🧑 Manual action" in html
+    # Ensure legend items are not accidentally inside Mermaid code block
+    mermaid_section = html.split('<div class="mermaid">', 1)[1].split("</div>", 1)[0]
+    assert "Manual action" not in mermaid_section
+
+
+def test_preview_mmd_output(monkeypatch, runner):
+    """End-to-end preview with --format mmd should not embed legend and should include emojis."""
+    patch_keyring(monkeypatch)
+
+    # Mock GET workflow fetch
+    workflow_payload = _sample_workflow_for_mermaid()
+
+    class R:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return workflow_payload
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: R())
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli, ["workflow", "preview", "--id", "wf123", "--format", "mmd", "--output", "out.mmd"]
+        )
+        assert result.exit_code == 0, result.output
+        with open("out.mmd", "r", encoding="utf-8") as f:
+            mmd = f.read()
+        assert "LEGEND :" not in mmd
+        assert "🧑" in mmd
+        assert "⚡️" in mmd
+
+
+def test_preview_html_output(monkeypatch, runner):
+    """End-to-end preview HTML should include external legend but not legend inside mermaid code."""
+    patch_keyring(monkeypatch)
+
+    workflow_payload = _sample_workflow_for_mermaid()
+
+    class R:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return workflow_payload
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: R())
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["workflow", "preview", "--id", "wf123", "--format", "html", "--output", "out.html"],
+        )
+        assert result.exit_code == 0, result.output
+        html = open("out.html", "r", encoding="utf-8").read()
+        assert '<div class="legend"' in html
+        assert "🧑 Manual action" in html
+        assert "⚡️ NAME UI icon class" in html  # legend entry
+        mermaid_section = html.split('<div class="mermaid">', 1)[1].split("</div>", 1)[0]
+        assert "Manual action" not in mermaid_section
+
+
+def test_mermaid_sanitization_and_truncation():
+    """Verify sanitization of problematic characters and notebook ID truncation."""
+    from slcli.workflows_click import _generate_mermaid_diagram
+
+    wf = _sample_workflow_for_mermaid()
+    wf["actions"][0]["displayText"] = "Ping:Check /test [alpha]"  # colon, slash, brackets
+    wf["actions"][0]["privilegeSpecificity"] = ["Execute:Test", "Run/It"]
+    code = _generate_mermaid_diagram(wf)
+    # Colon -> space, slash -> -, [ ] -> ( )
+    assert "Ping Check -test (alpha)" in code
+    # Privileges group sanitized
+    assert "(Execute Test, Run-It)" in code
+    # Notebook ID truncated to first 8 chars + ...
+    assert "NB abcdef12..." in code
+
+
+def test_mermaid_privileges_multiple():
+    from slcli.workflows_click import _generate_mermaid_diagram
+
+    wf = _sample_workflow_for_mermaid()
+    wf["actions"][1]["privilegeSpecificity"] = ["PrivA", "PrivB"]
+    code = _generate_mermaid_diagram(wf)
+    assert "(PrivA, PrivB)" in code
+
+
+def test_mermaid_action_without_icon():
+    from slcli.workflows_click import _generate_mermaid_diagram
+
+    wf = _sample_workflow_for_mermaid()
+    wf["actions"][1].pop("iconClass", None)
+    code = _generate_mermaid_diagram(wf)
+    # Ensure lightning present at least once (PING has icon)
+    assert "⚡️" in code

--- a/tests/unit/test_workflows_click.py
+++ b/tests/unit/test_workflows_click.py
@@ -725,11 +725,11 @@ def test_preview_html_output(monkeypatch, runner):
         assert result.exit_code == 0, result.output
         html = open("out.html", "r", encoding="utf-8").read()
         assert '<div class="legend"' in html
-    assert "🧑</td><td>Manual action" in html
-    # Icon class legend row has two separate cells as well
-    assert "⚡️ NAME</td><td>UI icon class" in html  # legend entry
-    mermaid_section = html.split('<div class="mermaid">', 1)[1].split("</div>", 1)[0]
-    assert "Manual action" not in mermaid_section
+        assert "🧑</td><td>Manual action" in html
+        # Icon class legend row has two separate cells as well
+        assert "⚡️ NAME</td><td>UI icon class" in html  # legend entry
+        mermaid_section = html.split('<div class="mermaid">', 1)[1].split("</div>", 1)[0]
+        assert "Manual action" not in mermaid_section
 
 
 def test_mermaid_sanitization_and_truncation():


### PR DESCRIPTION
Adds a rich workflow preview feature with Mermaid diagram generation and supporting CLI options, refactors logic into a dedicated module, and updates tests/docs.

### Key Changes
- New command: `slcli workflow preview` supporting:
  - Sources: `--id` (fetch from API) or `--file` / `--file -` (stdin)
  - Output formats: `--format html|mmd`
  - Flags: `--no-emoji`, `--no-legend`, `--no-open`
  - Proper exit codes via `ExitCodes`
- Mermaid generation:
  - Emojis for action types, icon indicator, hidden action marker
  - Privilege list display, notebook ID truncation, label sanitization (colons, slashes, brackets)
  - External legend (HTML only) with structured table
- Refactor: Extraction of preview logic into `workflow_preview.py`; deprecated internal wrappers removed
- Extended workflow init template with RUN_NOTEBOOK, PLAN_SCHEDULE, RUN_JOB actions and richer transitions
- Tests updated to import from `slcli.workflow_preview` directly; all preview tests passing
- README section documenting preview usage and flags
- Formatting, lint fixes, and removal of obsolete code paths (SVG support dropped)

### Verification
- Unit tests added/updated for diagram generation, HTML output, flags, stdin, sanitization
- Lint and Black pass
- Manual invocation confirmed (HTML + MMD)