### PR TITLE
feat: notebook execution commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,9 @@
 - SystemLink Test Monitor Service: https://dev-api.lifecyclesolutions.ni.com/nitestmonitor/swagger/v2/nitestmonitor-v2.yml
 - SystemLink User Service: https://dev-api.lifecyclesolutions.ni.com/niuser/swagger/v1/niuser.yaml
 - Work Order Service: https://dev-api.lifecyclesolutions.ni.com/niworkorder/swagger/v1/niworkorder.json
+- Notebook Execution Service: https://dev-api.lifecyclesolutions.ni.com/ninbexecution/swagger/v1-ninbexecution.json
+- Notebook Execution Artifact Service: https://dev-api.lifecyclesolutions.ni.com/ninbexecution/swagger/v1-ninbartifact.json
+- SystemLink Notebook Service: https://dev-api.lifecyclesolutions.ni.com/ninotebook/swagger/v1/ninotebook.yaml
 
 ### Implementation Pattern
 - Create typed response models based on OpenAPI schemas when implementing new API clients

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ After installation, restart your shell or source the completion file. See [docs/
    # View workflows
    slcli workflow list
 
-   # View notebooks
-   slcli notebook list
+    # View notebooks
+    slcli notebook manage list
 
    # View users
    slcli user list
@@ -903,69 +903,104 @@ The CLI will automatically load these environment variables from the `.env` file
 
 ## Notebook Management
 
-The `notebook` command group allows you to manage Jupyter notebooks in SystemLink.
+The `notebook` command group is organized into logical subgroups to mirror function command structure:
 
-### List all notebooks in a workspace
+- `slcli notebook init` – scaffold a local notebook file.
+- `slcli notebook manage <subcommand>` – list, create, update, download, delete remote notebooks.
+- `slcli notebook execute list` – list notebook execution records (supports --workspace, --notebook-id, --status, --take, --format json|table).
+
+Legacy top-level aliases (e.g. `slcli notebook list`) have been removed; always use the `manage` subgroup for server operations.
+
+### Initialize a local notebook
+
+```bash
+# Create a new local notebook file
+slcli notebook init --name MyLocalNotebook.ipynb
+```
+
+### List notebooks in a workspace
+
+# List notebook executions
+
+```bash
+# List recent executions (table with pagination)
+slcli notebook execute list
+
+# Filter by workspace
+slcli notebook execute list --workspace MyWorkspace
+
+# Filter by notebook ID
+slcli notebook execute list --notebook-id 123e4567-e89b-12d3-a456-426614174000
+
+# Filter by status (case-insensitive input mapped to service tokens)
+slcli notebook execute list --status timed_out
+slcli notebook execute list --status in_progress
+
+# JSON output (no interactive pagination)
+slcli notebook execute list --format json --take 100
+```
+
+Valid statuses for --status: in_progress, queued, failed, succeeded, canceled, timed_out.
 
 ```bash
 # List all notebooks (table format - default)
-slcli notebook list
+slcli notebook manage list
 
-# List notebooks in specific workspace
-slcli notebook list --workspace MyWorkspace
+# List notebooks in a specific workspace
+slcli notebook manage list --workspace MyWorkspace
 
 # JSON format for programmatic use
-slcli notebook list --format json
+slcli notebook manage list --format json
 
-# Control pagination (table format only)
-slcli notebook list --take 50
+# Control pagination (table output only)
+slcli notebook manage list --take 50
 ```
 
 ### Download notebook content and/or metadata
 
 ```bash
-# Download notebook content (.ipynb) by ID:
-slcli notebook download --id <notebook_id> --output mynotebook.ipynb
+# Download notebook content (.ipynb) by ID
+slcli notebook manage download --id <notebook_id> --output mynotebook.ipynb
 
-# Download notebook content by name:
-slcli notebook download --name MyNotebook --output mynotebook.ipynb
+# Download notebook content by name
+slcli notebook manage download --name MyNotebook --output mynotebook.ipynb
 
-# Download notebook metadata as JSON:
-slcli notebook download --id <notebook_id> --type metadata --output metadata.json
+# Download notebook metadata as JSON
+slcli notebook manage download --id <notebook_id> --type metadata --output metadata.json
 
-# Download both content and metadata:
-slcli notebook download --id <notebook_id> --type both --output mynotebook.ipynb
+# Download both content and metadata
+slcli notebook manage download --id <notebook_id> --type both --output mynotebook.ipynb
 ```
 
 ### Create a new notebook
 
 ```bash
-# Create from existing .ipynb file:
-slcli notebook create --file mynotebook.ipynb --name MyNotebook
-slcli notebook create --file mynotebook.ipynb --workspace MyWorkspace --name MyNotebook
+# Create from existing .ipynb file
+slcli notebook manage create --file mynotebook.ipynb --name MyNotebook
+slcli notebook manage create --file mynotebook.ipynb --workspace MyWorkspace --name MyNotebook
 
-# Create an empty notebook:
-slcli notebook create --name MyNotebook
-slcli notebook create --workspace MyWorkspace --name MyNotebook
+# Create an empty notebook
+slcli notebook manage create --name MyNotebook
+slcli notebook manage create --workspace MyWorkspace --name MyNotebook
 ```
 
 ### Update notebook metadata and/or content
 
 ```bash
-# Update metadata only:
-slcli notebook update --id <notebook_id> --metadata metadata.json
+# Update metadata only
+slcli notebook manage update --id <notebook_id> --metadata metadata.json
 
-# Update content only:
-slcli notebook update --id <notebook_id> --content mynotebook.ipynb
+# Update content only
+slcli notebook manage update --id <notebook_id> --content mynotebook.ipynb
 
-# Update both metadata and content:
-slcli notebook update --id <notebook_id> --metadata metadata.json --content mynotebook.ipynb
+# Update both metadata and content
+slcli notebook manage update --id <notebook_id> --metadata metadata.json --content mynotebook.ipynb
 ```
 
 ### Delete a notebook
 
 ```bash
-slcli notebook delete --id <notebook_id>
+slcli notebook manage delete --id <notebook_id>
 ```
 
 ## User Management
@@ -1245,12 +1280,12 @@ SystemLink CLI supports both human-readable table output and machine-readable JS
 # Human-readable table
 slcli template list
 slcli workflow list
-slcli notebook list
+slcli notebook manage list
 
 # Machine-readable JSON
 slcli template list --format json
 slcli workflow list --format json
-slcli notebook list --format json
+slcli notebook manage list --format json
 ```
 
 ## Flag Conventions

--- a/tests/e2e/test_notebook_e2e.py
+++ b/tests/e2e/test_notebook_e2e.py
@@ -15,16 +15,25 @@ class TestNotebookE2E:
 
     def test_notebook_list_basic(self, cli_runner, cli_helper):
         """Test basic notebook list functionality."""
-        result = cli_runner(["notebook", "list", "--format", "json"])
+        result = cli_runner(["notebook", "manage", "list", "--format", "json"])
         cli_helper.assert_success(result)
-
         notebooks = cli_helper.get_json_output(result)
         assert isinstance(notebooks, list)
 
     def test_notebook_list_with_workspace_filter(self, cli_runner, cli_helper, e2e_config):
         """Test notebook list with workspace filtering."""
         workspace = e2e_config["workspace"]
-        result = cli_runner(["notebook", "list", "--workspace", workspace, "--format", "json"])
+        result = cli_runner(
+            [
+                "notebook",
+                "manage",
+                "list",
+                "--workspace",
+                workspace,
+                "--format",
+                "json",
+            ]
+        )
         cli_helper.assert_success(result)
 
         notebooks = cli_helper.get_json_output(result)
@@ -46,6 +55,7 @@ class TestNotebookE2E:
             result = cli_runner(
                 [
                     "notebook",
+                    "manage",
                     "create",
                     "--file",
                     temp_file,
@@ -69,7 +79,15 @@ class TestNotebookE2E:
 
             # Verify notebook exists by listing
             result = cli_runner(
-                ["notebook", "list", "--workspace", configured_workspace, "--format", "json"]
+                [
+                    "notebook",
+                    "manage",
+                    "list",
+                    "--workspace",
+                    configured_workspace,
+                    "--format",
+                    "json",
+                ]
             )
             cli_helper.assert_success(result)
             notebooks = cli_helper.get_json_output(result)
@@ -79,12 +97,20 @@ class TestNotebookE2E:
             assert created_notebook["id"] == notebook_id
 
             # Delete notebook
-            result = cli_runner(["notebook", "delete", "--id", notebook_id])
+            result = cli_runner(["notebook", "manage", "delete", "--id", notebook_id])
             cli_helper.assert_success(result, "Notebook deleted")
 
             # Verify notebook is deleted
             result = cli_runner(
-                ["notebook", "list", "--workspace", configured_workspace, "--format", "json"]
+                [
+                    "notebook",
+                    "manage",
+                    "list",
+                    "--workspace",
+                    configured_workspace,
+                    "--format",
+                    "json",
+                ]
             )
             cli_helper.assert_success(result)
             notebooks = cli_helper.get_json_output(result)
@@ -114,6 +140,7 @@ class TestNotebookE2E:
             result = cli_runner(
                 [
                     "notebook",
+                    "manage",
                     "create",
                     "--file",
                     temp_file,
@@ -142,6 +169,7 @@ class TestNotebookE2E:
             result = cli_runner(
                 [
                     "notebook",
+                    "manage",
                     "download",
                     "--id",
                     notebook_id,
@@ -169,7 +197,7 @@ class TestNotebookE2E:
 
             # Cleanup
             Path(download_path).unlink(missing_ok=True)
-            cli_runner(["notebook", "delete", "--id", notebook_id], check=False)
+            cli_runner(["notebook", "manage", "delete", "--id", notebook_id], check=False)
 
         finally:
             Path(temp_file).unlink(missing_ok=True)
@@ -190,6 +218,7 @@ class TestNotebookE2E:
             result = cli_runner(
                 [
                     "notebook",
+                    "manage",
                     "create",
                     "--file",
                     temp_file,
@@ -208,6 +237,7 @@ class TestNotebookE2E:
             result = cli_runner(
                 [
                     "notebook",
+                    "manage",
                     "download",
                     "--name",
                     notebook_name,
@@ -229,12 +259,20 @@ class TestNotebookE2E:
 
             # Get notebook ID for cleanup
             result = cli_runner(
-                ["notebook", "list", "--workspace", configured_workspace, "--format", "json"]
+                [
+                    "notebook",
+                    "manage",
+                    "list",
+                    "--workspace",
+                    configured_workspace,
+                    "--format",
+                    "json",
+                ]
             )
             notebooks = cli_helper.get_json_output(result)
             notebook = cli_helper.find_resource_by_name(notebooks, notebook_name)
             if notebook:
-                cli_runner(["notebook", "delete", "--id", notebook["id"]], check=False)
+                cli_runner(["notebook", "manage", "delete", "--id", notebook["id"]], check=False)
 
         finally:
             Path(temp_file).unlink(missing_ok=True)
@@ -243,7 +281,8 @@ class TestNotebookE2E:
     def test_notebook_pagination(self, cli_runner, cli_helper):
         """Test notebook list pagination."""
         # Test with small take value to trigger pagination
-        result = cli_runner(["notebook", "list", "--take", "5", "--format", "table"])
+
+        result = cli_runner(["notebook", "manage", "list", "--take", "5", "--format", "table"])
         cli_helper.assert_success(result)
 
         # Should either show notebooks or "No notebooks found"
@@ -253,14 +292,22 @@ class TestNotebookE2E:
         """Test error handling for invalid operations."""
         # Test download with invalid ID
         result = cli_runner(
-            ["notebook", "download", "--id", "invalid-notebook-id-12345", "--type", "content"],
+            [
+                "notebook",
+                "manage",
+                "download",
+                "--id",
+                "invalid-notebook-id-12345",
+                "--type",
+                "content",
+            ],
             check=False,
         )
         cli_helper.assert_failure(result)
 
         # Test delete with invalid ID
         result = cli_runner(
-            ["notebook", "delete", "--id", "invalid-notebook-id-12345"], check=False
+            ["notebook", "manage", "delete", "--id", "invalid-notebook-id-12345"], check=False
         )
         cli_helper.assert_failure(result)
 
@@ -270,7 +317,15 @@ class TestNotebookE2E:
 
         # Create empty notebook
         result = cli_runner(
-            ["notebook", "create", "--name", notebook_name, "--workspace", configured_workspace]
+            [
+                "notebook",
+                "manage",
+                "create",
+                "--name",
+                notebook_name,
+                "--workspace",
+                configured_workspace,
+            ]
         )
         cli_helper.assert_success(result, "Notebook created")
 
@@ -284,4 +339,4 @@ class TestNotebookE2E:
 
         if notebook_id:
             # Cleanup
-            cli_runner(["notebook", "delete", "--id", notebook_id], check=False)
+            cli_runner(["notebook", "manage", "delete", "--id", notebook_id], check=False)

--- a/tests/unit/test_notebook_click.py
+++ b/tests/unit/test_notebook_click.py
@@ -46,7 +46,7 @@ def test_notebook_list(monkeypatch):
     import slcli.utils
 
     monkeypatch.setattr(slcli.utils, "get_workspace_map", lambda: {})
-    result = runner.invoke(cli, ["notebook", "list"])
+    result = runner.invoke(cli, ["notebook", "manage", "list"])
     if result.exit_code != 0:
         print(result.output)
     assert result.exit_code == 0
@@ -74,7 +74,17 @@ def test_notebook_download_by_id(monkeypatch):
         tmp.close()
         result = runner.invoke(
             cli,
-            ["notebook", "download", "--id", "abc123", "--output", tmp.name, "--type", "content"],
+            [
+                "notebook",
+                "manage",
+                "download",
+                "--id",
+                "abc123",
+                "--output",
+                tmp.name,
+                "--type",
+                "content",
+            ],
         )
         assert result.exit_code == 0
         with open(tmp.name, "rb") as f:
@@ -123,7 +133,7 @@ def test_notebook_upload(monkeypatch):
         tmp.write(b"test-nb")
         tmp.close()
         result = runner.invoke(
-            cli, ["notebook", "create", "--file", tmp.name, "--name", "TestNotebook"]
+            cli, ["notebook", "manage", "create", "--file", tmp.name, "--name", "TestNotebook"]
         )
         assert result.exit_code == 0
         assert "uploaded123" in result.output

--- a/tests/unit/test_notebook_execute_list.py
+++ b/tests/unit/test_notebook_execute_list.py
@@ -1,0 +1,148 @@
+"""Unit tests for slcli notebook execute list command."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from click.testing import CliRunner
+
+from slcli.main import cli
+from .test_utils import patch_keyring
+
+
+def _invoke(args: List[str]) -> Any:
+    runner = CliRunner()
+    return runner.invoke(cli, args)
+
+
+def test_notebook_execute_list_basic(monkeypatch):
+    """List executions with no filters."""
+    patch_keyring(monkeypatch)
+    import slcli.notebook_click
+
+    executions = [
+        {
+            "id": "exe1",
+            "notebookId": "nb1",
+            "workspaceId": "w1",
+            "status": "SUCCEEDED",
+            "queuedAt": "2025-09-01T10:00:00Z",
+        },
+        {
+            "id": "exe2",
+            "notebookId": "nb2",
+            "workspaceId": "w2",
+            "status": "FAILED",
+            "queuedAt": "2025-09-01T11:00:00Z",
+        },
+    ]
+
+    def mock_query_execs(workspace_id=None, status=None, notebook_id=None):  # noqa: D401
+        assert workspace_id is None
+        assert status is None
+        assert notebook_id is None
+        return executions
+
+    monkeypatch.setattr(slcli.notebook_click, "_query_notebook_executions", mock_query_execs)
+    import slcli.utils
+
+    monkeypatch.setattr(
+        slcli.utils, "get_workspace_map", lambda: {"w1": "Workspace1", "w2": "Workspace2"}
+    )
+    result = _invoke(
+        ["notebook", "execute", "list", "--format", "json"]
+    )  # JSON to avoid pagination
+    if result.exit_code != 0:
+        print(result.output)
+    assert result.exit_code == 0
+    # Should output array of executions
+    assert "exe1" in result.output and "exe2" in result.output
+
+
+def test_notebook_execute_list_status_mapping(monkeypatch):
+    """Status mapping: user passes timed_out -> service TIMEDOUT."""
+    patch_keyring(monkeypatch)
+    import slcli.notebook_click
+
+    captured_params: Dict[str, Any] = {}
+
+    def mock_query_execs(workspace_id=None, status=None, notebook_id=None):  # noqa: D401
+        captured_params.update(
+            {"workspace_id": workspace_id, "status": status, "notebook_id": notebook_id}
+        )
+        return []
+
+    monkeypatch.setattr(slcli.notebook_click, "_query_notebook_executions", mock_query_execs)
+    import slcli.utils
+
+    monkeypatch.setattr(slcli.utils, "get_workspace_map", lambda: {})
+    result = _invoke(
+        ["notebook", "execute", "list", "--status", "timed_out", "--format", "json"]
+    )  # no output data; ensure mapping
+    assert result.exit_code == 0
+    assert captured_params["status"] == "TIMEDOUT"  # mapped form
+
+
+def test_notebook_execute_list_invalid_status(monkeypatch):
+    """Invalid status results in exit code 2 (INVALID_INPUT)."""
+    patch_keyring(monkeypatch)
+    import slcli.notebook_click
+
+    def mock_query_execs(workspace_id=None, status=None, notebook_id=None):  # pragma: no cover
+        return []
+
+    monkeypatch.setattr(slcli.notebook_click, "_query_notebook_executions", mock_query_execs)
+    import slcli.utils
+
+    monkeypatch.setattr(slcli.utils, "get_workspace_map", lambda: {})
+    result = _invoke(
+        ["notebook", "execute", "list", "--status", "bogus", "--format", "json"]
+    )  # invalid
+    assert result.exit_code == 2
+    assert "Invalid status" in result.output
+
+
+def test_notebook_execute_list_with_filters(monkeypatch):
+    """Workspace + notebook ID + status filters propagate to query helper."""
+    patch_keyring(monkeypatch)
+    import slcli.notebook_click
+
+    received: Dict[str, Any] = {}
+
+    def mock_get_workspace_id_with_fallback(val: str) -> str:  # noqa: D401
+        return "workspace-guid-123" if val == "MyWS" else val
+
+    def mock_query_execs(workspace_id=None, status=None, notebook_id=None):  # noqa: D401
+        received.update(
+            {"workspace_id": workspace_id, "status": status, "notebook_id": notebook_id}
+        )
+        return []
+
+    monkeypatch.setattr(slcli.notebook_click, "_query_notebook_executions", mock_query_execs)
+    monkeypatch.setattr(
+        slcli.notebook_click, "get_workspace_id_with_fallback", mock_get_workspace_id_with_fallback
+    )
+    import slcli.utils
+
+    monkeypatch.setattr(slcli.utils, "get_workspace_map", lambda: {"workspace-guid-123": "MyWS"})
+    result = _invoke(
+        [
+            "notebook",
+            "execute",
+            "list",
+            "--workspace",
+            "MyWS",
+            "--notebook-id",
+            "nb-xyz",
+            "--status",
+            "in_progress",
+            "--format",
+            "json",
+        ]
+    )
+    assert result.exit_code == 0
+    assert received == {
+        "workspace_id": "workspace-guid-123",
+        "status": "INPROGRESS",
+        "notebook_id": "nb-xyz",
+    }


### PR DESCRIPTION
Overview:

```bash
$ slcli notebook
Usage: slcli notebook [OPTIONS] COMMAND [ARGS]...

  Manage notebooks (local init, remote manage, execution).

Options:
  -h, --help  Show this message and exit.

Commands:
  execute  Notebook execution operations.
  init     Create a local Jupyter notebook skeleton.
  manage   Remote notebook CRUD operations.
```

```bash
$ slcli notebook manage
Usage: slcli notebook manage [OPTIONS] COMMAND [ARGS]...

  Remote notebook CRUD operations.

Options:
  -h, --help  Show this message and exit.

Commands:
  create    Create a new notebook in the specified workspace.
  delete    Delete a notebook by ID.
  download  Download a notebook's content, metadata, or both by ID or name.
  get       Get detailed information about a specific notebook.
  list      List all notebooks.
  update    Update a notebook's metadata, content, or both by ID.
```

```bash
$ slcli notebook execute
Usage: slcli notebook execute [OPTIONS] COMMAND [ARGS]...

  Notebook execution operations.

Options:
  -h, --help  Show this message and exit.

Commands:
  cancel  Cancel a running notebook execution.
  get     Get detailed information about a notebook execution.
  list    List notebook executions.
  retry   Retry a failed notebook execution.
  start   Start a notebook execution and return immediately.
  sync    Execute a notebook and wait until completion.
```
