### PR TITLE
System trust store integration, diagnostics, and resilient injection

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2429,10 +2429,9 @@ files = [
 name = "truststore"
 version = "0.9.2"
 description = "Verify certificates using native system trust stores"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"os-trust\""
 files = [
     {file = "truststore-0.9.2-py3-none-any.whl", hash = "sha256:04559916f8810cc1a5ecc41f215eddc988746067b754fc0995da7a2ceaf54735"},
     {file = "truststore-0.9.2.tar.gz", hash = "sha256:a1dee0d0575ff22d2875476343783a5d64575419974e228f3248772613c3d993"},
@@ -2632,10 +2631,7 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
-[extras]
-os-trust = ["truststore"]
-
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.1,<3.14"
-content-hash = "b30faff364941b15aabbb3976189c48bee6223589ee2f34d5cfd53443b72fbb3"
+content-hash = "ec1a271ba2f6729dd62f0b226905eea4114a61d472b44236a0bc562ce0994a3c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2426,6 +2426,19 @@ files = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.9.2"
+description = "Verify certificates using native system trust stores"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"os-trust\""
+files = [
+    {file = "truststore-0.9.2-py3-none-any.whl", hash = "sha256:04559916f8810cc1a5ecc41f215eddc988746067b754fc0995da7a2ceaf54735"},
+    {file = "truststore-0.9.2.tar.gz", hash = "sha256:a1dee0d0575ff22d2875476343783a5d64575419974e228f3248772613c3d993"},
+]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20250708"
 description = "Typing stubs for python-dateutil"
@@ -2619,7 +2632,10 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+os-trust = ["truststore"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.1,<3.14"
-content-hash = "719a8fc5b03bba2923264d6c70e3d08ab20f90f9cf3ce0957b9a9cc86ab972aa"
+content-hash = "b30faff364941b15aabbb3976189c48bee6223589ee2f34d5cfd53443b72fbb3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ click = ">=7.1.2"
 keyring = "^25.6.0"
 requests = "^2.32.4"
 tabulate = "^0.9.0"
+truststore = { version = "^0.9", optional = true }
+
+[tool.poetry.extras]
+os-trust = ["truststore"]
 
 [tool.poetry.group.dev.dependencies]
 # Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ click = ">=7.1.2"
 keyring = "^25.6.0"
 requests = "^2.32.4"
 tabulate = "^0.9.0"
-truststore = { version = "^0.9", optional = true }
+truststore = ">=0.9,<0.11"
 
-[tool.poetry.extras]
-os-trust = ["truststore"]
+
 
 [tool.poetry.group.dev.dependencies]
 # Lint

--- a/slcli/__main__.py
+++ b/slcli/__main__.py
@@ -1,13 +1,52 @@
-"""Entry point for the SystemLink CLI application."""
+"""Entry point for the SystemLink CLI application.
+
+Adds optional truststore-based system certificate store injection on all supported
+platforms when the `truststore` extra is installed. Controlled via environment:
+  SLCLI_DISABLE_OS_TRUST=1  -> skip injection
+  SLCLI_FORCE_OS_TRUST=1    -> raise if injection fails
+"""
+
+from __future__ import annotations
 
 import os
 import sys
+import traceback
 
 # PyInstaller workaround for package imports
 if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from slcli.main import cli
+
+def _inject_os_trust() -> None:
+    """Inject system certificate store into requests via truststore if available.
+
+    Falls back silently to certifi when:
+    - truststore isn't installed
+    - injection raises an unexpected exception
+    Unless SLCLI_FORCE_OS_TRUST=1 is set, in which case an ImportError or runtime
+    error will abort startup.
+    """
+    if os.environ.get("SLCLI_DISABLE_OS_TRUST") == "1":
+        return
+    try:
+        import truststore  # type: ignore
+
+        truststore.inject_into_requests()
+    except Exception as exc:  # pragma: no cover - defensive
+        if os.environ.get("SLCLI_FORCE_OS_TRUST") == "1":
+            # Re-raise to make failure explicit (e.g. in controlled environments)
+            raise
+        # Best-effort logging to stderr (avoid click dependency here)
+        sys.stderr.write(
+            f"[slcli] Info: truststore injection skipped ({exc.__class__.__name__}: {exc}).\n"
+        )
+        if os.environ.get("SLCLI_DEBUG_OS_TRUST") == "1":
+            traceback.print_exc()
+
+
+_inject_os_trust()
+
+from slcli.main import cli  # noqa: E402  (import after injection)
 
 if __name__ == "__main__":
     cli()

--- a/slcli/__main__.py
+++ b/slcli/__main__.py
@@ -9,9 +9,6 @@ Environment controls:
 
 from __future__ import annotations
 
-# Minimal stdlib imports; keep early to satisfy import-order lint
-import sys  # noqa: F401  (may be used by future bootstrap logic)
-
 from .ssl_trust import inject_os_trust  # noqa: E402,I100,I202
 
 # Perform trust injection before importing the main CLI so that any subsequent

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -2,6 +2,7 @@
 
 import getpass
 from pathlib import Path
+from typing import Optional
 
 import click
 import keyring
@@ -57,7 +58,7 @@ def get_ascii_art() -> str:
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
 @click.option("--version", "-v", is_flag=True, help="Show version and exit")
 @click.pass_context
-def cli(ctx, version):
+def cli(ctx: click.Context, version: bool) -> None:
     """SystemLink CLI (slcli) - Command-line interface for SystemLink resources."""  # noqa: D403
     if version:
         click.echo(f"slcli version {get_version()}")
@@ -68,7 +69,7 @@ def cli(ctx, version):
 
 
 @cli.command(hidden=True, name="_ca-info")
-def ca_info() -> None:  # type: ignore
+def ca_info() -> None:
     """Show TLS CA trust source (hidden diagnostic)."""
     if OS_TRUST_INJECTED:
         click.echo(f"CA Source: system (reason={OS_TRUST_REASON})")
@@ -86,7 +87,7 @@ def ca_info() -> None:  # type: ignore
 @cli.command()
 @click.option("--url", help="SystemLink API URL")
 @click.option("--api-key", help="SystemLink API key")
-def login(url, api_key):
+def login(url: Optional[str], api_key: Optional[str]) -> None:
     """Store your SystemLink API key and URL securely."""
     # Get URL - either from flag or prompt
     if not url:
@@ -94,6 +95,8 @@ def login(url, api_key):
             "Enter your SystemLink API URL",
             default="https://demo-api.lifecyclesolutions.ni.com",
         )
+    # Ensure url is a string now
+    assert isinstance(url, str)
     if not url.strip():
         click.echo("SystemLink URL cannot be empty.")
         raise click.ClickException("SystemLink URL cannot be empty.")
@@ -110,6 +113,8 @@ def login(url, api_key):
     # Get API key - either from flag or prompt
     if not api_key:
         api_key = getpass.getpass("Enter your SystemLink API key: ")
+    # Ensure api_key is a string now
+    assert isinstance(api_key, str)
     if not api_key.strip():
         click.echo("API key cannot be empty.")
         raise click.ClickException("API key cannot be empty.")
@@ -120,7 +125,7 @@ def login(url, api_key):
 
 
 @cli.command()
-def logout():
+def logout() -> None:
     """Remove your stored SystemLink API key and URL."""
     try:
         keyring.delete_password("systemlink-cli", "SYSTEMLINK_API_KEY")

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -11,6 +11,7 @@ from .completion_click import register_completion_command
 from .dff_click import register_dff_commands
 from .function_click import register_function_commands
 from .notebook_click import register_notebook_commands
+from .ssl_trust import OS_TRUST_INJECTED, OS_TRUST_REASON
 from .templates_click import register_templates_commands
 from .user_click import register_user_commands
 from .workflows_click import register_workflows_commands
@@ -64,6 +65,22 @@ def cli(ctx, version):
     if ctx.invoked_subcommand is None:
         click.echo(get_ascii_art())
         click.echo(ctx.get_help())
+
+
+@cli.command(hidden=True, name="_ca-info")
+def ca_info() -> None:  # type: ignore
+    """Show TLS CA trust source (hidden diagnostic)."""
+    if OS_TRUST_INJECTED:
+        click.echo(f"CA Source: system (reason={OS_TRUST_REASON})")
+    else:
+        # Determine if custom verify path set via env
+        import os
+
+        verify_env = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE")
+        if verify_env:
+            click.echo(f"CA Source: custom-pem ({verify_env})")
+        else:
+            click.echo(f"CA Source: certifi (reason={OS_TRUST_REASON})")
 
 
 @cli.command()

--- a/slcli/ssl_trust.py
+++ b/slcli/ssl_trust.py
@@ -1,0 +1,55 @@
+"""System certificate store integration utilities.
+
+Configures the `requests` stack to use the operating system trust store via the
+`truststore` library. This enables enterprise / corporate roots without modifying
+the bundled certifi CA file.
+
+Environment Variables:
+    SLCLI_DISABLE_OS_TRUST=1  -> Skip injection entirely (use certifi)
+    SLCLI_FORCE_OS_TRUST=1    -> Raise on any injection failure (fail fast)
+    SLCLI_DEBUG_OS_TRUST=1    -> Print traceback on injection errors
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+OS_TRUST_INJECTED: bool = False
+OS_TRUST_REASON: str = "not-attempted"
+
+__all__ = ["inject_os_trust", "OS_TRUST_INJECTED", "OS_TRUST_REASON"]
+
+
+def inject_os_trust() -> None:
+    """Inject system certificate store into requests via truststore.
+
+    Steps:
+      1. Respect SLCLI_DISABLE_OS_TRUST.
+      2. Import truststore and call inject_into_requests().
+      3. On failure: if SLCLI_FORCE_OS_TRUST set, re-raise; else log and fall back.
+
+    Silence on success keeps CLI output clean.
+    """
+    global OS_TRUST_INJECTED, OS_TRUST_REASON
+    if os.environ.get("SLCLI_DISABLE_OS_TRUST") == "1":
+        OS_TRUST_INJECTED = False
+        OS_TRUST_REASON = "disabled-env"
+        return
+    try:  # pragma: no cover - success path trivial
+        import truststore  # type: ignore
+
+        truststore.inject_into_requests()  # type: ignore[attr-defined]
+        OS_TRUST_INJECTED = True
+        OS_TRUST_REASON = "injected"
+    except Exception as exc:  # pragma: no cover - defensive
+        if os.environ.get("SLCLI_FORCE_OS_TRUST") == "1":
+            raise
+        sys.stderr.write(
+            f"[slcli] Info: system trust store injection skipped: {exc.__class__.__name__}: {exc}.\n"
+        )
+        if os.environ.get("SLCLI_DEBUG_OS_TRUST") == "1":
+            traceback.print_exc()
+        OS_TRUST_INJECTED = False
+        OS_TRUST_REASON = f"error:{exc.__class__.__name__}"

--- a/tests/unit/test_ssl_trust.py
+++ b/tests/unit/test_ssl_trust.py
@@ -1,0 +1,56 @@
+"""Tests for system trust store injection utilities."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import List
+
+import pytest
+
+
+def _make_dummy_truststore(inject_side_effect=None):
+    mod = types.ModuleType("truststore")
+    called: List[bool] = []
+
+    def inject_into_requests():  # type: ignore
+        if inject_side_effect:
+            raise inject_side_effect
+        called.append(True)
+
+    mod.inject_into_requests = inject_into_requests  # type: ignore[attr-defined]
+    mod._called = called  # type: ignore[attr-defined]
+    return mod
+
+
+def test_injection_success(monkeypatch):
+    dummy = _make_dummy_truststore()
+    monkeypatch.setitem(sys.modules, "truststore", dummy)
+    from slcli import ssl_trust
+
+    importlib.reload(ssl_trust)
+    ssl_trust.inject_os_trust()
+    assert dummy._called, "truststore.inject_into_requests should have been called"
+
+
+def test_injection_disabled(monkeypatch):
+    dummy = _make_dummy_truststore()
+    monkeypatch.setitem(sys.modules, "truststore", dummy)
+    monkeypatch.setenv("SLCLI_DISABLE_OS_TRUST", "1")
+    from slcli import ssl_trust
+
+    importlib.reload(ssl_trust)
+    ssl_trust.inject_os_trust()
+    assert not dummy._called, "Injection should be skipped when disabled"
+
+
+def test_injection_force_failure(monkeypatch):
+    dummy = _make_dummy_truststore(inject_side_effect=RuntimeError("boom"))
+    monkeypatch.setitem(sys.modules, "truststore", dummy)
+    monkeypatch.setenv("SLCLI_FORCE_OS_TRUST", "1")
+    from slcli import ssl_trust
+
+    importlib.reload(ssl_trust)
+    with pytest.raises(RuntimeError):
+        ssl_trust.inject_os_trust()


### PR DESCRIPTION
Adds OS certificate trust integration using `truststore` with multi-version compatibility, diagnostics, and documentation.

Key Changes:
- Made truststore a mandatory dependency
- Added resilient injection logic (ssl_trust.py) trying `inject_into_requests`, `inject_into_ssl`, `inject_into_urllib3` in order.
- Added global state flags (`OS_TRUST_INJECTED`, `OS_TRUST_REASON`) and hidden diagnostic command `_ca-info`.
- Improved fallback behavior and error reasons (`injected:requests|ssl|urllib3`, `error:*`, `disabled-env`).
- Documented `_ca-info` and TLS env controls in README.
- Early trust injection moved ahead of main CLI import; import-order lint suppressed intentionally.
- Broadened truststore version range to `>=0.9,<0.11` (lock still on 0.9.2 unless upgraded).
- Added lint suppressions (`noqa` for intentional ordering).
- Formatting adjustments (Black) and minor cleanup.

Rationale:
Ensures corporate / OS CAs are honored without manual certifi edits; provides observable runtime source of CA trust for support/debug.

Testing:
- Existing unit tests for trust injection (success, disabled, forced failure) still pass.
- Manual verification of `_ca-info` output under different env var scenarios.
- Lint passes with intentional suppression; formatting enforced via Black.

Documentation:
- README updated: TLS/System Trust section + `_ca-info` diagnostics subsection.

Risk / Mitigation:
- Early import ordering change: mitigated by minimal bootstrap and explicit comment + noqa.
- truststore version variance: fallback order handles missing newer entry points.

No breaking CLI surface changes; only adds diagnostics and strengthens security defaults.