### PR TITLE
Rename DFF command to customfield and add editor enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ After installation, restart your shell or source the completion file. See [docs/
    slcli workspace list
 
    # View custom field configurations
-   slcli customfields list
+   slcli customfield list
    ```
 
 # View auth policies and templates
@@ -171,7 +171,7 @@ Available samples:
    slcli workflow init --name "My Workflow" --description "Custom workflow"
 
    # Launch custom fields web editor
-   slcli customfields edit
+   slcli customfield edit
    ```
 
 4. **Get help for any command:**
@@ -180,7 +180,7 @@ Available samples:
    slcli template --help
    slcli workflow --help
    slcli notebook --help
-   slcli customfields --help
+   slcli customfield --help
    slcli feed --help
    slcli auth policy --help
    slcli auth template --help
@@ -315,9 +315,9 @@ slcli logout
 SystemLink CLI supports both **SystemLink Enterprise (SLE)** and **SystemLink Server (SLS)**:
 
 | Platform | Notebook Execution | Custom Fields/Templates/Workflows |
-| -------- | ------------------ | ----------------------- |
-| **SLE**  | ✓ Full support     | ✓ Full support          |
-| **SLS**  | ✓ Path-based API   | ✗ Not available         |
+| -------- | ------------------ | --------------------------------- |
+| **SLE**  | ✓ Full support     | ✓ Full support                    |
+| **SLS**  | ✓ Path-based API   | ✗ Not available                   |
 
 ### Platform Detection
 
@@ -1308,28 +1308,22 @@ Manage static web applications (pack, publish and remote management) using the `
 The `webapp` group provides a small local scaffold and .nipkg packer, and also manages WebApp resources on the SystemLink server.
 
 - `slcli webapp init [--directory PATH] [--force]`
-
   - Scaffold a sample webapp (`index.html`) in `./app` inside the target directory. Use `--force` to overwrite an existing file.
 
 - `slcli webapp pack <FOLDER> [--output FILE.nipkg]`
-
   - Pack a folder into a `.nipkg`. The `.nipkg` uses a Debian-style `ar` layout (members: `debian-binary`, `control.tar.gz`, `data.tar.gz`).
 
 - `slcli webapp publish <SOURCE> [--id ID] [--name NAME] [--workspace WORKSPACE]`
-
   - Publish a `.nipkg` (or folder) to the WebApp service. Provide either `--id` to upload into an existing webapp, or `--name` to create a new resource and upload the content. `--workspace` selects the workspace for newly created webapps.
   - When publishing a folder, the CLI creates a temporary `.nipkg` inside a context-managed temporary directory so the packaged file is available during upload and is cleaned up automatically.
 
 - `slcli webapp list [--workspace WORKSPACE] [--filter FILTER] [--take N] [--format table|json]`
-
   - List webapps. Defaults to interactive paging for `table` output (25 rows/page) and returns all results for `--format json`.
 
 - `slcli webapp get --id ID`
-
   - Show webapp metadata.
 
 - `slcli webapp delete --id ID`
-
   - Delete a webapp.
 
 - `slcli webapp open --id ID`
@@ -1552,7 +1546,7 @@ slcli tag delete "my-tag-path"
 
 ## Custom Fields Management
 
-The `customfields` command group allows you to manage custom fields in SystemLink, including configurations, groups, fields, and tables. Custom fields provide a web-based editor for visual editing of JSON configurations.
+The `customfield` command group allows you to manage custom fields in SystemLink, including configurations, groups, fields, and tables. Custom fields provide a web-based editor for visual editing of JSON configurations.
 
 ### Configuration Management
 
@@ -1560,13 +1554,13 @@ Manage custom field configurations:
 
 ```bash
 # List all configurations
-slcli customfields list
+slcli customfield list
 
 # JSON format for programmatic use
-slcli customfields list --format json
+slcli customfield list --format json
 
 # Filter by workspace
-slcli customfields list --workspace "Production Workspace"
+slcli customfield list --workspace "Production Workspace"
 
 # Get a specific configuration
 slcli customfields get --id <config_id>
@@ -1601,7 +1595,7 @@ slcli customfields delete --id <config_id> -g <group_id> --field-id <field_id>
 slcli customfields delete --id <config_id> --no-recursive
 
 # Initialize a new configuration template
-slcli customfields init --name "My Config" --workspace "MyWorkspace" --resource-type workorder:workorder
+slcli customfield init --name "My Config" --workspace "MyWorkspace" --resource-type workorder:workorder
 ```
 
 ### Web Editor

--- a/README.md
+++ b/README.md
@@ -1563,36 +1563,36 @@ slcli customfield list --format json
 slcli customfield list --workspace "Production Workspace"
 
 # Get a specific configuration
-slcli customfields get --id <config_id>
+slcli customfield get --id <config_id>
 
 # Export a configuration to JSON file
-slcli customfields export --id <config_id> --output config.json
+slcli customfield export --id <config_id> --output config.json
 
 # Create configurations from JSON file
-slcli customfields create --file config.json
+slcli customfield create --file config.json
 
 # Update configurations from JSON file
-slcli customfields update --file config.json
+slcli customfield update --file config.json
 
 # Delete a configuration (recursive by default - deletes dependent groups/fields)
-slcli customfields delete --id <config_id>
+slcli customfield delete --id <config_id>
 
 # Delete multiple configurations
-slcli customfields delete --id <config_id1> --id <config_id2>
+slcli customfield delete --id <config_id1> --id <config_id2>
 
 # Delete groups (standalone or multiple)
-slcli customfields delete --group-id <group_id>
-slcli customfields delete -g <group_id1> -g <group_id2>
+slcli customfield delete --group-id <group_id>
+slcli customfield delete -g <group_id1> -g <group_id2>
 
 # Delete fields
-slcli customfields delete --field-id <field_id>
-slcli customfields delete --fid <field_id1> --fid <field_id2>
+slcli customfield delete --field-id <field_id>
+slcli customfield delete --fid <field_id1> --fid <field_id2>
 
 # Delete mixed types in one command
-slcli customfields delete --id <config_id> -g <group_id> --field-id <field_id>
+slcli customfield delete --id <config_id> -g <group_id> --field-id <field_id>
 
 # Non-recursive delete (only deletes specified items, not dependent items)
-slcli customfields delete --id <config_id> --no-recursive
+slcli customfield delete --id <config_id> --no-recursive
 
 # Initialize a new configuration template
 slcli customfield init --name "My Config" --workspace "MyWorkspace" --resource-type workorder:workorder
@@ -1604,16 +1604,16 @@ Launch a local web-based editor for visual editing of custom field JSON files:
 
 ```bash
 # Launch web editor with default settings (port 8080)
-slcli customfields edit
+slcli customfield edit
 
 # Load a specific configuration by ID from the server
-slcli customfields edit --id <configuration-id>
+slcli customfield edit --id <configuration-id>
 
 # Custom port
-slcli customfields edit --port 9000
+slcli customfield edit --port 9000
 
 # Don't auto-open browser
-slcli customfields edit --no-browser
+slcli customfield edit --no-browser
 ```
 
 The web editor (Monaco-based):

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ After installation, restart your shell or source the completion file. See [docs/
    # View workspaces
    slcli workspace list
 
-   # View dynamic form field configurations
-   slcli dff list
+   # View custom field configurations
+   slcli customfields list
    ```
 
 # View auth policies and templates
@@ -170,8 +170,8 @@ Available samples:
    # Create a new workflow
    slcli workflow init --name "My Workflow" --description "Custom workflow"
 
-   # Launch DFF web editor
-   slcli dff edit
+   # Launch custom fields web editor
+   slcli customfields edit
    ```
 
 4. **Get help for any command:**
@@ -180,7 +180,7 @@ Available samples:
    slcli template --help
    slcli workflow --help
    slcli notebook --help
-   slcli dff --help
+   slcli customfields --help
    slcli feed --help
    slcli auth policy --help
    slcli auth template --help
@@ -314,7 +314,7 @@ slcli logout
 
 SystemLink CLI supports both **SystemLink Enterprise (SLE)** and **SystemLink Server (SLS)**:
 
-| Platform | Notebook Execution | DFF/Templates/Workflows |
+| Platform | Notebook Execution | Custom Fields/Templates/Workflows |
 | -------- | ------------------ | ----------------------- |
 | **SLE**  | ✓ Full support     | ✓ Full support          |
 | **SLS**  | ✓ Path-based API   | ✗ Not available         |
@@ -334,7 +334,7 @@ slcli info --format json
 ### Platform-Specific Notes
 
 - **Notebook Execution on SLS**: Uses notebook path (e.g., `_shared/reports/notebook.ipynb`) instead of notebook ID
-- **Feature Gating**: Commands for DFF, templates, workflows, and functions show clear error messages when run on SLS
+- **Feature Gating**: Commands for custom fields, templates, workflows, and functions show clear error messages when run on SLS
 - **Environment Override**: Set `SYSTEMLINK_PLATFORM=SLE` or `SYSTEMLINK_PLATFORM=SLS` to explicitly specify the platform
 
 ## Test Plan Template Management
@@ -1550,87 +1550,88 @@ slcli tag get-value "my-tag-path" --include-aggregates
 slcli tag delete "my-tag-path"
 ```
 
-## Dynamic Form Fields (DFF) Management
+## Custom Fields Management
 
-The `dff` command group allows you to manage dynamic form fields in SystemLink, including configurations, groups, fields, and tables. DFF provides a web-based editor for visual editing of JSON configurations.
+The `customfields` command group allows you to manage custom fields in SystemLink, including configurations, groups, fields, and tables. Custom fields provide a web-based editor for visual editing of JSON configurations.
 
 ### Configuration Management
 
-Manage dynamic form field configurations:
+Manage custom field configurations:
 
 ```bash
 # List all configurations
-slcli dff list
+slcli customfields list
 
 # JSON format for programmatic use
-slcli dff list --format json
+slcli customfields list --format json
 
 # Filter by workspace
-slcli dff list --workspace "Production Workspace"
+slcli customfields list --workspace "Production Workspace"
 
 # Get a specific configuration
-slcli dff get --id <config_id>
+slcli customfields get --id <config_id>
 
 # Export a configuration to JSON file
-slcli dff export --id <config_id> --output config.json
+slcli customfields export --id <config_id> --output config.json
 
 # Create configurations from JSON file
-slcli dff create --file config.json
+slcli customfields create --file config.json
 
 # Update configurations from JSON file
-slcli dff update --file config.json
+slcli customfields update --file config.json
 
 # Delete a configuration (recursive by default - deletes dependent groups/fields)
-slcli dff delete --id <config_id>
+slcli customfields delete --id <config_id>
 
 # Delete multiple configurations
-slcli dff delete --id <config_id1> --id <config_id2>
+slcli customfields delete --id <config_id1> --id <config_id2>
 
 # Delete groups (standalone or multiple)
-slcli dff delete --group-id <group_id>
-slcli dff delete -g <group_id1> -g <group_id2>
+slcli customfields delete --group-id <group_id>
+slcli customfields delete -g <group_id1> -g <group_id2>
 
 # Delete fields
-slcli dff delete --field-id <field_id>
-slcli dff delete --fid <field_id1> --fid <field_id2>
+slcli customfields delete --field-id <field_id>
+slcli customfields delete --fid <field_id1> --fid <field_id2>
 
 # Delete mixed types in one command
-slcli dff delete --id <config_id> -g <group_id> --field-id <field_id>
+slcli customfields delete --id <config_id> -g <group_id> --field-id <field_id>
 
 # Non-recursive delete (only deletes specified items, not dependent items)
-slcli dff delete --id <config_id> --no-recursive
+slcli customfields delete --id <config_id> --no-recursive
 
 # Initialize a new configuration template
-slcli dff init --name "My Config" --workspace "MyWorkspace" --resource-type workorder:workorder
+slcli customfields init --name "My Config" --workspace "MyWorkspace" --resource-type workorder:workorder
 ```
 
 ### Web Editor
 
-Launch a local web-based editor for visual editing of DFF JSON files:
+Launch a local web-based editor for visual editing of custom field JSON files:
 
 ```bash
-# Launch web editor with default settings (port 8080, ./dff-editor directory)
-slcli dff edit
+# Launch web editor with default settings (port 8080)
+slcli customfields edit
 
 # Load a specific configuration by ID from the server
-slcli dff edit --id <configuration-id>
+slcli customfields edit --id <configuration-id>
 
-# Custom port and directory
-slcli dff edit --port 9000 --output-dir ./my_editor
+# Custom port
+slcli customfields edit --port 9000
 
 # Don't auto-open browser
-slcli dff edit --no-open-browser
+slcli customfields edit --no-browser
 ```
 
 The web editor (Monaco-based):
 
-- Hosts a local HTTP server for editing DFF configurations
+- Hosts a local HTTP server for editing custom field configurations
 - Provides a VS Code-like editor with JSON validation, formatting, and find/replace
 - Includes a tree view, add dialogs for configurations/groups/fields, and schema validation
 - Supports loading/saving to the SystemLink server from the UI
-- Creates standalone editor files in the specified directory for reuse
+- Supports i18n (internationalization) field editing for multiple locales
+- Supports interactive enum value editing for SELECT and MULTISELECT field types
 
-**Note**: The web editor creates a self-contained directory with all necessary HTML, CSS, and JavaScript files. This directory can be moved or shared independently.
+**Note**: The web editor provides a professional editing experience for managing custom field configurations with real-time validation and server integration.
 
 ## File Management
 

--- a/dff-editor/README.md
+++ b/dff-editor/README.md
@@ -14,7 +14,7 @@ This directory contains a standalone web editor for SystemLink Custom Fields con
 1. Start the editor server:
 
 ```bash
-slcli customfields edit --port 8080
+slcli customfield edit --port 8080
 ```
 
 2. Open your browser to: http://localhost:8080

--- a/dff-editor/README.md
+++ b/dff-editor/README.md
@@ -1,6 +1,6 @@
-# Dynamic Form Fields Editor
+# Custom Fields Editor
 
-This directory contains a standalone web editor for SystemLink Dynamic Form Fields configurations with a modern, VS Code-like interface.
+This directory contains a standalone web editor for SystemLink Custom Fields configurations with a VS Code-like interface.
 
 ## Files
 
@@ -14,7 +14,7 @@ This directory contains a standalone web editor for SystemLink Dynamic Form Fiel
 1. Start the editor server:
 
 ```bash
-slcli dff edit --output-dir dff-editor --port 8080
+slcli customfields edit --port 8080
 ```
 
 2. Open your browser to: http://localhost:8080
@@ -28,7 +28,7 @@ slcli dff edit --output-dir dff-editor --port 8080
 ### Monaco Editor
 
 - Syntax highlighting and IntelliSense for JSON
-- Real-time validation against DFF schema
+- Real-time validation against custom fields schema
 - Auto-formatting (Alt+F) and validate (Alt+V)
 - Find/Replace (Ctrl+F / Ctrl+H)
 - Minimap, dark theme, format on paste/type

--- a/dff-editor/editor.js
+++ b/dff-editor/editor.js
@@ -1110,144 +1110,6 @@ function showEditDialog(type, configIdx, viewIdx = null) {
     overlay.classList.add('active');
 }
 
-function showEditDialog(type, configIdx, viewIdx = null) {
-    modalType = `edit-${type}`;
-    const overlay = document.getElementById('modalOverlay');
-    const title = document.getElementById('modalTitle');
-    const body = document.getElementById('modalBody');
-    
-    // Helper to safely create form groups
-    function createFormGroup(labelText, inputId, inputType, value, placeholder = '', helpText = '') {
-        const group = document.createElement('div');
-        group.className = 'form-group';
-        
-        const label = document.createElement('label');
-        label.textContent = labelText;
-        group.appendChild(label);
-        
-        if (inputType === 'select') {
-            const select = document.createElement('select');
-            select.id = inputId;
-            const options = ['STRING', 'NUMBER', 'BOOLEAN', 'DATE', 'DATETIME', 'SELECT', 'MULTISELECT', 'TEXT'];
-            options.forEach(opt => {
-                const option = document.createElement('option');
-                option.value = opt;
-                option.textContent = opt.charAt(0) + opt.slice(1).toLowerCase();
-                if (opt === value) option.selected = true;
-                select.appendChild(option);
-            });
-            group.appendChild(select);
-        } else if (inputType === 'checkbox') {
-            const checkbox = document.createElement('input');
-            checkbox.type = 'checkbox';
-            checkbox.id = inputId;
-            checkbox.checked = !!value;
-            group.appendChild(checkbox);
-        } else {
-            const input = document.createElement('input');
-            input.type = inputType;
-            input.id = inputId;
-            input.placeholder = placeholder;
-            input.value = String(value || '');
-            group.appendChild(input);
-        }
-        
-        if (helpText) {
-            const small = document.createElement('small');
-            small.textContent = helpText;
-            group.appendChild(small);
-        }
-        
-        return group;
-    }
-    
-    function createCheckboxGroup(labelText, inputId, checked) {
-        const group = document.createElement('div');
-        group.className = 'form-group checkbox-group';
-        
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.id = inputId;
-        checkbox.checked = !!checked;
-        group.appendChild(checkbox);
-        
-        const label = document.createElement('label');
-        label.htmlFor = inputId;
-        label.textContent = labelText;
-        group.appendChild(label);
-        
-        return group;
-    }
-    
-    if (type === 'view' && viewIdx !== null) {
-        const conf = currentConfig.configurations?.[configIdx];
-        const view = conf?.views?.[viewIdx];
-        if (!view) {
-            showStatus('View not found', 'error');
-            return;
-        }
-        
-        title.textContent = 'Edit View';
-        body.innerHTML = '';
-        
-        body.appendChild(createFormGroup('Key *', 'viewKey', 'text', view.key || '', 'e.g., defaultView', 'Unique identifier'));
-        body.appendChild(createFormGroup('Display Text *', 'viewDisplayText', 'text', view.displayText || '', 'e.g., Default View', 'Text shown to users'));
-        body.appendChild(createFormGroup('Help Text', 'viewHelpText', 'text', view.helpText || '', 'Optional help text'));
-        body.appendChild(createFormGroup('Order', 'viewOrder', 'number', view.order || 10, '', 'Display order (lower numbers appear first)'));
-        body.appendChild(createFormGroup('Display Locations (comma-separated)', 'viewDisplayLocations', 'text', (view.displayLocations || []).join(', '), 'e.g., compact, full, split, global', 'Valid values: compact, full, split, global'));
-        body.appendChild(createFormGroup('Group Keys (comma-separated)', 'viewGroups', 'text', (view.groups || []).join(', '), 'e.g., group1, group2', 'Keys of groups to include in this view'));
-        body.appendChild(createCheckboxGroup('Editable', 'viewEditable', view.editable));
-        body.appendChild(createCheckboxGroup('Visible', 'viewVisible', view.visible));
-        
-        // Store indices in modal for use during submit
-        overlay.dataset.editType = 'view';
-        overlay.dataset.configIdx = configIdx;
-        overlay.dataset.viewIdx = viewIdx;
-        
-    } else if (type === 'group') {
-        const group = currentConfig.groups?.[configIdx];
-        if (!group) {
-            showStatus('Group not found', 'error');
-            return;
-        }
-        
-        title.textContent = 'Edit Group';
-        body.innerHTML = '';
-        
-        body.appendChild(createFormGroup('Key *', 'groupKey', 'text', group.key || '', 'e.g., basicInfo', 'Unique identifier (lowercase, no spaces)'));
-        body.appendChild(createFormGroup('Display Text *', 'groupDisplayText', 'text', group.displayText || '', 'e.g., Basic Information', 'Text shown to users'));
-        body.appendChild(createFormGroup('Help Text', 'groupHelpText', 'text', group.helpText || '', 'Optional help text'));
-        body.appendChild(createFormGroup('Workspace ID *', 'groupWorkspace', 'text', group.workspace || '', 'e.g., workspace-123'));
-        body.appendChild(createFormGroup('Field Keys (comma-separated)', 'groupFieldKeys', 'text', (group.fields || []).join(', '), 'e.g., field1, field2', 'Optional: Keys of fields to include'));
-        
-        overlay.dataset.editType = 'group';
-        overlay.dataset.groupIdx = configIdx;
-        
-    } else if (type === 'field') {
-        const field = currentConfig.fields?.[configIdx];
-        if (!field) {
-            showStatus('Field not found', 'error');
-            return;
-        }
-        
-        title.textContent = 'Edit Field';
-        body.innerHTML = '';
-        
-        body.appendChild(createFormGroup('Key *', 'fieldKey', 'text', field.key || '', 'e.g., deviceId', 'Unique identifier (lowercase, no spaces)'));
-        body.appendChild(createFormGroup('Display Text *', 'fieldDisplayText', 'text', field.displayText || '', 'e.g., Device Identifier', 'Text shown to users'));
-        body.appendChild(createFormGroup('Help Text', 'fieldHelpText', 'text', field.helpText || '', 'Optional help text'));
-        body.appendChild(createFormGroup('Placeholder', 'fieldPlaceholder', 'text', field.placeHolder || '', 'Optional placeholder text'));
-        body.appendChild(createFormGroup('Workspace ID *', 'fieldWorkspace', 'text', field.workspace || '', 'e.g., workspace-123'));
-        body.appendChild(createFormGroup('Field Type *', 'fieldType', 'select', field.fieldType || 'STRING', '', ''));
-        body.appendChild(createCheckboxGroup('Required field', 'fieldRequired', field.required));
-        
-        overlay.dataset.editType = 'field';
-        overlay.dataset.fieldIdx = configIdx;
-    }
-    
-    overlay.classList.add('active');
-}
-
 function getCurrentWorkspace() {
     if (!currentConfig) return '';
     if (currentConfig.configuration && currentConfig.configuration.workspace) {
@@ -1929,17 +1791,85 @@ function addI18nEntry(existingEntry = null) {
     entryDiv.className = 'i18n-entry';
     entryDiv.id = entryId;
     entryDiv.style.cssText = 'padding: 10px; margin-bottom: 10px; border: 1px solid #3e3e42; border-radius: 3px; background: #252526;';
-    entryDiv.innerHTML = `
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-            <label style="margin: 0; font-weight: bold;">Locale</label>
-            <button type="button" class="danger" style="padding: 2px 8px; font-size: 11px;" onclick="removeI18nEntry('${entryId}')">Remove</button>
-        </div>
-        <input type="text" class="i18n-locale" placeholder="e.g., de-DE, fr-FR, es-ES" value="${localeValue}" style="width: 100%; margin-bottom: 8px;">
-        <label style="display: block; margin-bottom: 5px;">Display Text</label>
-        <input type="text" class="i18n-displayText" placeholder="Translated display text" value="${displayTextValue}" style="width: 100%; margin-bottom: 8px;">
-        <label style="display: block; margin-bottom: 5px;">Help Text</label>
-        <input type="text" class="i18n-helpText" placeholder="Translated help text" value="${helpTextValue}" style="width: 100%;">
-    `;
+
+    // Header row with "Locale" label and "Remove" button
+    const headerDiv = document.createElement('div');
+    headerDiv.style.cssText = 'display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;';
+
+    const localeLabel = document.createElement('label');
+    localeLabel.style.margin = '0';
+    localeLabel.style.fontWeight = 'bold';
+    localeLabel.textContent = 'Locale';
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'danger';
+    removeButton.style.cssText = 'padding: 2px 8px; font-size: 11px;';
+    removeButton.textContent = 'Remove';
+    removeButton.onclick = function () {
+        removeI18nEntry(entryId);
+    };
+
+    headerDiv.appendChild(localeLabel);
+    headerDiv.appendChild(removeButton);
+    entryDiv.appendChild(headerDiv);
+
+    // Locale select dropdown
+    const localeInput = document.createElement('select');
+    localeInput.className = 'i18n-locale';
+    localeInput.style.cssText = 'width: 100%; margin-bottom: 8px;';
+    
+    // Add language options
+    const languages = [
+        { value: '', label: 'Select a language...' },
+        { value: 'en', label: 'English (English)' },
+        { value: 'fr', label: 'French (Français)' },
+        { value: 'de', label: 'German (Deutsch)' },
+        { value: 'ja', label: 'Japanese (日本語)' },
+        { value: 'zh', label: 'Chinese (中文)' }
+    ];
+    
+    languages.forEach(lang => {
+        const option = document.createElement('option');
+        option.value = lang.value;
+        option.textContent = lang.label;
+        if (lang.value === localeValue) {
+            option.selected = true;
+        }
+        localeInput.appendChild(option);
+    });
+    
+    entryDiv.appendChild(localeInput);
+
+    // Display Text label and input
+    const displayTextLabel = document.createElement('label');
+    displayTextLabel.style.display = 'block';
+    displayTextLabel.style.marginBottom = '5px';
+    displayTextLabel.textContent = 'Display Text';
+    entryDiv.appendChild(displayTextLabel);
+
+    const displayTextInput = document.createElement('input');
+    displayTextInput.type = 'text';
+    displayTextInput.className = 'i18n-displayText';
+    displayTextInput.placeholder = 'Translated display text';
+    displayTextInput.style.cssText = 'width: 100%; margin-bottom: 8px;';
+    displayTextInput.value = displayTextValue;
+    entryDiv.appendChild(displayTextInput);
+
+    // Help Text label and input
+    const helpTextLabel = document.createElement('label');
+    helpTextLabel.style.display = 'block';
+    helpTextLabel.style.marginBottom = '5px';
+    helpTextLabel.textContent = 'Help Text';
+    entryDiv.appendChild(helpTextLabel);
+
+    const helpTextInput = document.createElement('input');
+    helpTextInput.type = 'text';
+    helpTextInput.className = 'i18n-helpText';
+    helpTextInput.placeholder = 'Translated help text';
+    helpTextInput.style.cssText = 'width: 100%;';
+    helpTextInput.value = helpTextValue;
+    entryDiv.appendChild(helpTextInput);
     
     i18nList.appendChild(entryDiv);
 }
@@ -2002,10 +1932,24 @@ function addEnumValue(existingValue = '') {
     entryDiv.className = 'enum-value-entry';
     entryDiv.id = valueId;
     entryDiv.style.cssText = 'display: flex; gap: 8px; margin-bottom: 8px; align-items: center;';
-    entryDiv.innerHTML = `
-        <input type="text" class="enum-value" placeholder="Enter value" value="${existingValue}" style="flex: 1;">
-        <button type="button" class="danger" style="padding: 4px 8px; font-size: 11px;" onclick="removeEnumValue('${valueId}')">Remove</button>
-    `;
+    
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'enum-value';
+    input.placeholder = 'Enter value';
+    input.style.flex = '1';
+    input.value = existingValue;
+    
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'danger';
+    button.style.padding = '4px 8px';
+    button.style.fontSize = '11px';
+    button.textContent = 'Remove';
+    button.addEventListener('click', () => removeEnumValue(valueId));
+    
+    entryDiv.appendChild(input);
+    entryDiv.appendChild(button);
     
     enumList.appendChild(entryDiv);
 }

--- a/dff-editor/editor.js
+++ b/dff-editor/editor.js
@@ -1782,7 +1782,7 @@ function addI18nEntry(existingEntry = null) {
     const i18nList = document.getElementById('i18nList');
     if (!i18nList) return;
     
-    const entryId = 'i18n-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+    const entryId = 'i18n-' + Date.now() + '-' + Math.random().toString(36).slice(2, 11);
     const localeValue = existingEntry?.locale || '';
     const displayTextValue = existingEntry?.displayText || '';
     const helpTextValue = existingEntry?.helpText || '';
@@ -1926,7 +1926,7 @@ function addEnumValue(existingValue = '') {
     const enumList = document.getElementById('enumValuesList');
     if (!enumList) return;
     
-    const valueId = 'enum-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+    const valueId = 'enum-' + Date.now() + '-' + Math.random().toString(36).slice(2, 11);
     
     const entryDiv = document.createElement('div');
     entryDiv.className = 'enum-value-entry';

--- a/dff-editor/editor.js
+++ b/dff-editor/editor.js
@@ -556,7 +556,7 @@ function refreshTree() {
     if (config.configurations && config.configurations.length > 0) {
         config.configurations.forEach((conf, i) => {
             const confLabel = conf.displayText || conf.name || conf.key || ('Configuration ' + (i + 1));
-            html += `<div class="tree-node indent-1" onclick="selectTreeNode('config-${i}')"><span class="tree-icon">⚙️</span><span>${confLabel}</span><button class="edit-btn" onclick="event.stopPropagation(); showEditDialog('config', ${i})">✎</button></div>`;
+            html += `<div class="tree-node indent-1" onclick="selectTreeNode('config-${i}')"><span class="tree-icon">⚙️</span><span>${confLabel}</span></div>`;
             // Show views under each configuration
             if (conf.views && conf.views.length > 0) {
                 conf.views.forEach((view, vi) => {

--- a/dff-editor/index.html
+++ b/dff-editor/index.html
@@ -91,6 +91,22 @@
         button.danger:hover { background: #f1343e; }
         button.success { background: #107c10; }
         button.success:hover { background: #0e6b0e; }
+        .edit-btn {
+            background: #6c8ebf;
+            color: white;
+            border: none;
+            padding: 2px 6px;
+            border-radius: 2px;
+            cursor: pointer;
+            font-size: 12px;
+            margin-left: auto;
+            opacity: 0;
+            transition: opacity 0.2s, background 0.2s;
+        }
+        .tree-node:hover .edit-btn {
+            opacity: 1;
+        }
+        .edit-btn:hover { background: #85a8d4; }
         .status-bar {
             background: #007acc;
             color: white;

--- a/dff-editor/index.html
+++ b/dff-editor/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dynamic Form Fields Editor</title>
+    <title>Custom Fields Editor</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.45.0/min/vs/editor/editor.main.min.css">
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -221,7 +221,7 @@
 <body>
     <div class="app-container">
         <div class="header">
-                <h1>Dynamic Form Fields Editor</h1>
+                <h1>Custom Fields Editor</h1>
             <div class="header-actions">
                 <button id="loadFromServerBtn" onclick="loadFromServer()">Load from Server</button>
                 <button id="saveToServerBtn" class="success" onclick="saveToServer()">Apply to Server</button>

--- a/docs/DFF_WEB_EDITOR.md
+++ b/docs/DFF_WEB_EDITOR.md
@@ -1,8 +1,8 @@
-# DFF Web Editor Implementation Guide
+# Custom Fields Web Editor Implementation Guide
 
 ## Overview
 
-The SystemLink CLI now includes a production-ready, Monaco Editor-based web interface for managing Dynamic Form Fields configurations.
+The SystemLink CLI now includes a production-ready, Monaco Editor-based web interface for managing Custom Fields configurations.
 
 ## Architecture
 
@@ -22,7 +22,7 @@ dff-editor/                # Source assets (packaged with CLI)
 ### ✅ Monaco Editor Foundation
 
 - Full Monaco Editor 0.45.0 integration via CDN
-- JSON schema validation for DFF configurations
+- JSON schema validation for custom fields configurations
 - Syntax highlighting, IntelliSense, auto-completion
 - Find/Replace, minimap, format on paste/type
 - Dark theme matching VS Code
@@ -49,12 +49,12 @@ dff-editor/                # Source assets (packaged with CLI)
 - Unique key enforcement
 - Reference integrity checks
 - Enum validation (resourceType, fieldType)
-- Schema compliance with SystemLink DFF API
+- Schema compliance with SystemLink Custom Fields API
 
 ### ✅ Server Integration
 
-- Load from Server (GET /api/dff/configurations)
-- Apply to Server (POST /api/dff/configurations)
+- Load from Server (GET /api/customfields/configurations)
+- Apply to Server (POST /api/customfields/configurations)
 - Dynamic server URL (uses current origin)
 - Confirmation dialogs before destructive operations
 - Error handling with clear messages
@@ -110,7 +110,7 @@ else:
 **editor.js** (~730 lines) provides:
 
 - **Monaco Setup**: Schema definition, editor initialization, event handlers
-- **Validation Engine**: JSON validation + custom DFF rules
+- **Validation Engine**: JSON validation + custom fields rules
 - **Tree Rendering**: Dynamic sidebar generation from parsed config
 - **Modal System**: Reusable dialog framework for add/edit operations
 - **Server Communication**: Fetch-based API calls with error handling
@@ -146,23 +146,23 @@ The editor validates against this JSON schema:
 ### Basic Usage
 
 ```bash
-# Default: port 8080, ./dff-editor directory
-poetry run slcli dff edit
+# Default: port 8080
+poetry run slcli customfields edit
 
-# Custom port and directory
-poetry run slcli dff edit --port 9000 --output-dir my-editor
+# Custom port
+poetry run slcli customfields edit --port 9000
 
 # Suppress auto-browser open
-poetry run slcli dff edit --no-browser
+poetry run slcli customfields edit --no-browser
 
 # Load a configuration from the server by ID
-poetry run slcli dff edit --id d772cb8c-db2a-4201-81b8-6c3777e81f22
+poetry run slcli customfields edit --id d772cb8c-db2a-4201-81b8-6c3777e81f22
 
-# Load from server and use custom output directory
-poetry run slcli dff edit --id config-uuid --output-dir my-editor --port 9000
+# Load from server with custom port
+poetry run slcli customfields edit --id config-uuid --port 9000
 
-# Load from server but save to specific file
-poetry run slcli dff edit --id config-uuid --file my-config.json
+# Load from a local file
+poetry run slcli customfields edit --file my-config.json
 ```
 
 ### Development Workflow
@@ -318,7 +318,7 @@ const dffSchema = {
 
 - **Documentation**: [dff-editor/README.md](../dff-editor/README.md)
 - **Examples**: Use "Load Example" button in editor
-- **CLI Help**: `slcli dff edit --help`
+- **CLI Help**: `slcli customfields edit --help`
 - **Issues**: Report via GitHub issues
 
 ---

--- a/docs/DFF_WEB_EDITOR.md
+++ b/docs/DFF_WEB_EDITOR.md
@@ -53,7 +53,7 @@ dff-editor/                # Source assets (packaged with CLI)
 
 ### ✅ Server Integration
 
-- Load from Server (GET /api/customfields/configurations)
+- Load from Server (GET /api/customfield/configurations)
 - Apply to Server (POST /api/customfields/configurations)
 - Dynamic server URL (uses current origin)
 - Confirmation dialogs before destructive operations

--- a/docs/DFF_WEB_EDITOR.md
+++ b/docs/DFF_WEB_EDITOR.md
@@ -53,8 +53,8 @@ dff-editor/                # Source assets (packaged with CLI)
 
 ### ✅ Server Integration
 
-- Load from Server (GET /api/customfield/configurations)
-- Apply to Server (POST /api/customfields/configurations)
+- Load from Server (GET /api/dff/configurations)
+- Apply to Server (POST /api/dff/configurations)
 - Dynamic server URL (uses current origin)
 - Confirmation dialogs before destructive operations
 - Error handling with clear messages
@@ -147,22 +147,22 @@ The editor validates against this JSON schema:
 
 ```bash
 # Default: port 8080
-poetry run slcli customfields edit
+poetry run slcli customfield edit
 
 # Custom port
-poetry run slcli customfields edit --port 9000
+poetry run slcli customfield edit --port 9000
 
 # Suppress auto-browser open
-poetry run slcli customfields edit --no-browser
+poetry run slcli customfield edit --no-browser
 
 # Load a configuration from the server by ID
-poetry run slcli customfields edit --id d772cb8c-db2a-4201-81b8-6c3777e81f22
+poetry run slcli customfield edit --id d772cb8c-db2a-4201-81b8-6c3777e81f22
 
 # Load from server with custom port
-poetry run slcli customfields edit --id config-uuid --port 9000
+poetry run slcli customfield edit --id config-uuid --port 9000
 
 # Load from a local file
-poetry run slcli customfields edit --file my-config.json
+poetry run slcli customfield edit --file my-config.json
 ```
 
 ### Development Workflow
@@ -318,7 +318,7 @@ const dffSchema = {
 
 - **Documentation**: [dff-editor/README.md](../dff-editor/README.md)
 - **Examples**: Use "Load Example" button in editor
-- **CLI Help**: `slcli customfields edit --help`
+- **CLI Help**: `slcli customfield edit --help`
 - **Issues**: Report via GitHub issues
 
 ---

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -1,4 +1,4 @@
-"""CLI commands for managing SystemLink Dynamic Form Fields."""
+"""CLI commands for managing SystemLink Custom Fields."""
 
 import json
 import sys
@@ -27,7 +27,7 @@ from .workspace_utils import (
     resolve_workspace_filter,
 )
 
-# Valid resource types for Dynamic Form Fields
+# Valid resource types for Custom Fields
 VALID_RESOURCE_TYPES = [
     "workorder:workorder",
     "workitem:workitem",
@@ -36,7 +36,7 @@ VALID_RESOURCE_TYPES = [
     "testmonitor:product",
 ]
 
-# Valid field types for Dynamic Form Fields
+# Valid field types for Custom Fields
 VALID_FIELD_TYPES = [
     "Text",
     "Number",
@@ -305,12 +305,12 @@ def _query_all_configurations(
 
 
 def register_dff_commands(cli: Any) -> None:
-    """Register the 'dff' command group and its subcommands."""
+    """Register the 'customfields' command group and its subcommands."""
 
-    @cli.group()
+    @cli.group(name="customfields")
     @click.pass_context
     def dff(ctx: click.Context) -> None:
-        """Manage dynamic form field configurations."""
+        """Manage custom field (DFF) configurations."""
         # Check for platform feature availability
         # Only check if a subcommand is being invoked (not just --help)
         if ctx.invoked_subcommand is not None:
@@ -336,7 +336,7 @@ def register_dff_commands(cli: Any) -> None:
     def list_configurations(
         workspace: Optional[str] = None, take: int = 25, format: str = "table"
     ) -> None:
-        """List dynamic form field configurations."""
+        """List custom field configurations."""
         try:
             # Get workspace map once and reuse it
             workspace_map = get_workspace_map()
@@ -362,7 +362,7 @@ def register_dff_commands(cli: Any) -> None:
                 format_config_row,
                 ["Workspace", "Name", "Configuration ID"],
                 [36, 40, 36],
-                "No dynamic form field configurations found.",
+                "No custom field configurations found.",
                 enable_pagination=True,
             )
 
@@ -386,7 +386,7 @@ def register_dff_commands(cli: Any) -> None:
         help="Output format: table or json",
     )
     def get_configuration(config_id: str, format: str = "json") -> None:
-        """Get a specific dynamic form field configuration by ID."""
+        """Get a specific custom field configuration by ID."""
         url = f"{get_base_url()}/nidynamicformfields/v1/resolved-configuration"
 
         try:
@@ -431,7 +431,7 @@ def register_dff_commands(cli: Any) -> None:
         help="Input JSON file with configuration data",
     )
     def create_configuration(input_file: str) -> None:
-        """Create dynamic form field configurations from a JSON file."""
+        """Create custom field configurations from a JSON file."""
         url = f"{get_base_url()}/nidynamicformfields/v1/configurations"
 
         try:
@@ -479,7 +479,7 @@ def register_dff_commands(cli: Any) -> None:
 
             if resp.status_code == 201:
                 # Full success
-                click.echo("✓ Dynamic form field configurations created successfully.")
+                click.echo("✓ Custom field configurations created successfully.")
                 created_configs = response_data.get("configurations", [])
                 for config in created_configs:
                     click.echo(f"  - {config.get('name', 'Unknown')}: {config.get('id', '')}")
@@ -549,7 +549,7 @@ def register_dff_commands(cli: Any) -> None:
         help="Input JSON file with updated configuration data",
     )
     def update_configuration(input_file: str) -> None:
-        """Update dynamic form field configurations from a JSON file."""
+        """Update custom field configurations from a JSON file."""
         url = f"{get_base_url()}/nidynamicformfields/v1/update-configurations"
 
         try:
@@ -597,7 +597,7 @@ def register_dff_commands(cli: Any) -> None:
 
                         sys.exit(ExitCodes.GENERAL_ERROR)
                     else:
-                        click.echo("✓ Dynamic form field configurations updated successfully.")
+                        click.echo("✓ Custom field configurations updated successfully.")
                         for config in updated_configs:
                             click.echo(
                                 f"  - {config.get('name', 'Unknown')}: {config.get('id', '')}"
@@ -663,7 +663,7 @@ def register_dff_commands(cli: Any) -> None:
         field_ids: tuple[str, ...],
         recursive: bool = True,
     ) -> None:
-        """Delete dynamic form field configurations, groups, and fields."""
+        """Delete custom field configurations, groups, and fields."""
         if not config_ids and not group_ids and not field_ids:
             click.echo("✗ Must provide at least one of: --id, --group-id, or --field-id", err=True)
             sys.exit(ExitCodes.INVALID_INPUT)
@@ -751,7 +751,7 @@ def register_dff_commands(cli: Any) -> None:
     )
     @click.option("--output", "-o", help="Output JSON file (default: <config-name>.json)")
     def export_configuration(config_id: str, output: Optional[str] = None) -> None:
-        """Export a dynamic form field configuration to a JSON file."""
+        """Export a custom field configuration to a JSON file."""
         url = f"{get_base_url()}/nidynamicformfields/v1/resolved-configuration"
 
         try:
@@ -802,7 +802,7 @@ def register_dff_commands(cli: Any) -> None:
         resource_type: Optional[str] = None,
         output: Optional[str] = None,
     ) -> None:
-        """Create a template configuration file for dynamic form fields."""
+        """Create a template configuration file for custom fields."""
         try:
             # Prompt for required fields if not provided
             if not name:
@@ -925,9 +925,9 @@ def register_dff_commands(cli: Any) -> None:
         port: int = 8080,
         no_browser: bool = False,
     ) -> None:
-        """Launch a local web editor for dynamic form field configurations.
+        """Launch a local web editor for custom field configurations.
 
-        This command starts a web editor for editing dynamic form field configurations.
+        This command starts a web editor for editing custom field configurations.
         You can provide a JSON file to edit, or load a configuration by ID from the server.
         """
         try:

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -305,9 +305,9 @@ def _query_all_configurations(
 
 
 def register_dff_commands(cli: Any) -> None:
-    """Register the 'customfields' command group and its subcommands."""
+    """Register the 'customfield' command group and its subcommands."""
 
-    @cli.group(name="customfields")
+    @cli.group(name="customfield")
     @click.pass_context
     def dff(ctx: click.Context) -> None:
         """Manage custom field (DFF) configurations."""

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -39,12 +39,12 @@ class DFFWebEditor:
         """
         try:
             import tempfile
-            
+
             # Create a per-session temp directory for runtime files (config, uploaded files)
             # Keep it alive for the server lifetime
             self._temp_dir = tempfile.TemporaryDirectory(prefix="slcli-dff-")
             self._temp_path = Path(self._temp_dir.name)
-            
+
             # Generate per-session secret for proxy auth
             self._secret = secrets.token_urlsafe(24)
             self._write_editor_config(file)

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -3,7 +3,6 @@
 import http.server
 import json
 import secrets
-import shutil
 import socketserver
 import sys
 import threading
@@ -15,21 +14,20 @@ from typing import Optional, Any
 import click
 import requests
 
-from .utils import ExitCodes, get_base_url, get_headers, get_ssl_verify, load_json_file
+from .utils import ExitCodes, get_base_url, get_headers, get_ssl_verify
 
 
 class DFFWebEditor:
     """Web-based editor for Dynamic Form Fields configurations."""
 
-    def __init__(self, port: int = 8080, output_dir: str = "dff-editor"):
+    def __init__(self, port: int = 8080):
         """Initialize the DFF web editor.
 
         Args:
             port: Port number for the HTTP server
-            output_dir: Directory name for editor files
         """
         self.port = port
-        self.output_dir = Path(output_dir)
+        self._editor_dir = self._resolve_editor_directory()
 
     def launch(self, file: Optional[str] = None, open_browser: bool = True) -> None:
         """Launch the web editor with optional file loading.
@@ -39,367 +37,74 @@ class DFFWebEditor:
             open_browser: Whether to automatically open browser
         """
         try:
-            self._create_editor_directory()
-            initial_content = self._load_initial_content(file)
             # Generate per-session secret for proxy auth
             self._secret = secrets.token_urlsafe(24)
-            self._create_editor_files(initial_content, file)
-            self._write_editor_config()
+            self._write_editor_config(file)
             self._start_server(open_browser)
         except Exception as exc:
             click.echo(f"✗ Error starting editor: {exc}", err=True)
             sys.exit(ExitCodes.GENERAL_ERROR)
 
-    def _create_editor_directory(self) -> None:
-        """Create the editor directory structure."""
-        self.output_dir.mkdir(exist_ok=True)
+    def _resolve_editor_directory(self) -> Path:
+        """Resolve the editor directory from the install location.
 
-    def _load_initial_content(self, file: Optional[str]) -> str:
-        """Load initial content from file or use default template.
-
-        Args:
-            file: Optional file path to load
+        Priority:
+        1) PyInstaller MEIPASS (onefile extraction dir)
+        2) Frozen onedir next to the executable
+        3) Site-packages root containing dff-editor (pip/Poetry install)
+        4) Source tree relative to this file (development)
 
         Returns:
-            JSON string for initial editor content
+            Path to the dff-editor directory
+
+        Raises:
+            FileNotFoundError: If dff-editor directory cannot be found
         """
-        if file and Path(file).exists():
-            try:
-                existing_data = load_json_file(file)
-                return json.dumps(existing_data, indent=2)
-            except Exception:
-                return self._get_default_template()
-        else:
-            return self._get_default_template()
+        candidates = []
 
-    def _get_default_template(self) -> str:
-        """Get the default DFF configuration template."""
-        return """{
-  "configurations": [
-    {
-      "name": "Example Configuration",
-      "workspace": "your-workspace-id",
-      "resourceType": "workorder:workorder",
-      "groupKeys": ["group1"],
-      "properties": {}
-    }
-  ],
-  "groups": [
-    {
-      "key": "group1",
-      "workspace": "your-workspace-id",
-      "name": "Example Group",
-      "displayText": "Example Group",
-      "fieldKeys": ["field1"],
-      "properties": {}
-    }
-  ],
-  "fields": [
-    {
-      "key": "field1",
-      "workspace": "your-workspace-id",
-      "name": "Example Field",
-      "displayText": "Example Field",
-      "fieldType": "STRING",
-      "required": false,
-      "validation": {},
-      "properties": {}
-    }
-  ]
-}"""
-
-    def _create_editor_files(self, initial_content: str, file: Optional[str]) -> None:
-        """Create or copy the editor assets into the output directory.
-
-        Prefers copying the packaged `dff-editor` assets (Monaco-based editor).
-        Falls back to the legacy generated HTML/JS if the assets are missing.
-
-        Args:
-            initial_content: Initial JSON content for the editor (used for legacy fallback)
-            file: Optional source file name for display (used for legacy fallback)
-        """
-        # Resolve source directory for bundled assets across dev, pip, and frozen builds
-        # Priority:
-        # 1) PyInstaller MEIPASS (onefile extraction dir)
-        # 2) Frozen onedir next to the executable
-        # 3) Site-packages root containing dff-editor (pip/Poetry install)
-        # 4) Source tree relative to this file (development)
-        source_dir_candidates = []
+        # PyInstaller onefile mode
         meipass = getattr(sys, "_MEIPASS", None)
         if meipass:
-            source_dir_candidates.append(Path(meipass) / "dff-editor")
+            candidates.append(Path(meipass) / "dff-editor")
+
+        # Frozen onedir layout
         if getattr(sys, "frozen", False):
-            # Onedir layout keeps data beside the executable
-            source_dir_candidates.append(Path(sys.executable).resolve().parent / "dff-editor")
+            candidates.append(Path(sys.executable).resolve().parent / "dff-editor")
 
-        # pip/Poetry install: dff-editor sits alongside the slcli package in site-packages
+        # pip/Poetry install: dff-editor alongside slcli package
         site_packages_dir = Path(__file__).resolve().parent.parent
-        source_dir_candidates.append(site_packages_dir / "dff-editor")
+        candidates.append(site_packages_dir / "dff-editor")
 
-        source_dir_candidates.append(Path(__file__).resolve().parent.parent / "dff-editor")
+        # Development/source tree
+        candidates.append(Path(__file__).resolve().parent.parent / "dff-editor")
 
-        source_dir: Path = next(
-            (p for p in source_dir_candidates if p.exists()),
-            Path(__file__).resolve().parent.parent / "dff-editor",
+        for candidate in candidates:
+            if candidate.exists() and (candidate / "index.html").exists():
+                return candidate
+
+        # No editor directory found
+        raise FileNotFoundError(
+            "DFF editor assets not found. Please ensure the installation is complete. "
+            "Try reinstalling: pip install --force-reinstall slcli"
         )
-        target_dir = self.output_dir.resolve()
 
-        # If source and target are the same, assets are already in place (development mode)
-        if source_dir.exists() and source_dir != target_dir:
-            # Only copy the essential editor files
-            essential_files = ["index.html", "editor.js", "README.md"]
-            for filename in essential_files:
-                source_file = source_dir / filename
-                if source_file.exists():
-                    target_file = target_dir / filename
-                    shutil.copy2(source_file, target_file)
-            return
-        elif source_dir.exists() and source_dir == target_dir:
-            # Development mode: ensure essential files are present before assuming assets
-            essential_files = ["index.html", "editor.js", "README.md"]
-            if all((target_dir / f).exists() for f in essential_files):
-                return
-            # else fall through to legacy fallback generation
+    def _write_editor_config(self, file: Optional[str]) -> None:
+        """Write the editor configuration consumed by the frontend.
 
-        # Fallback to legacy generated assets if packaged files are unavailable.
-        html_content = self._generate_html_content(initial_content, file)
-        (self.output_dir / "index.html").write_text(html_content)
-        readme_content = self._generate_readme_content()
-        (self.output_dir / "README.md").write_text(readme_content)
-
-    def _write_editor_config(self) -> None:
-        """Write the editor configuration consumed by the frontend."""
-        server_url = get_base_url().rstrip("/")
-        config_path = self.output_dir / "slcli-config.json"
-        # Include per-session secret for proxy authentication
-        config = {"serverUrl": server_url, "secret": getattr(self, "_secret", None)}
-        config_path.write_text(json.dumps(config, indent=2))
-
-    def _generate_html_content(self, initial_content: str, file: Optional[str]) -> str:
-        """Generate minimal error HTML when editor assets are not properly installed."""
-        return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Editor Installation Error</title>
-    <style>
-        body {{
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            max-width: 800px;
-            margin: 50px auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }}
-        .container {{
-            background: white;
-            padding: 40px;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }}
-        h1 {{
-            color: #d32f2f;
-            border-bottom: 2px solid #d32f2f;
-            padding-bottom: 10px;
-        }}
-        .error-box {{
-            background: #ffebee;
-            border: 2px solid #d32f2f;
-            padding: 20px;
-            border-radius: 4px;
-            margin: 20px 0;
-        }}
-        .error-box h2 {{
-            color: #d32f2f;
-            margin-top: 0;
-        }}
-        .code {{
-            background: #f5f5f5;
-            padding: 10px;
-            border-radius: 4px;
-            font-family: monospace;
-            margin: 10px 0;
-        }}
-        ul {{
-            line-height: 1.8;
-        }}
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>✗ Editor Installation Error</h1>
-        
-        <div class="error-box">
-            <h2>DFF Web Editor Not Properly Installed</h2>
-            <p>The Dynamic Form Fields web editor assets (Monaco-based editor) could not be found. 
-            This usually indicates an incomplete or corrupted installation.</p>
-        </div>
-        
-        <h3>How to Fix:</h3>
-        <ul>
-            <li><strong>If installed via pip/pipx:</strong>
-                <div class="code">pip install --force-reinstall slcli</div>
-            </li>
-            <li><strong>If installed via Homebrew:</strong>
-                <div class="code">brew reinstall slcli</div>
-            </li>
-            <li><strong>If installed via Scoop:</strong>
-                <div class="code">scoop uninstall slcli<br>scoop install slcli</div>
-            </li>
-            <li><strong>If running from source:</strong>
-                <div class="code">git pull<br>poetry install</div>
-                Ensure the <code>dff-editor/</code> directory exists in the repository root.
-            </li>
-        </ul>
-        
-        <h3>Need Help?</h3>
-        <p>Visit the project repository: <a href="https://github.com/ni-kismet/systemlink-cli">github.com/ni-kismet/systemlink-cli</a></p>
-        <p>Or file an issue if the problem persists after reinstalling.</p>
-    </div>
-</body>
-</html>"""
-
-    def _get_javascript_content(self) -> str:
-        """Get the JavaScript content for the editor."""
-        return """
-        function validateJson() {
-            const textarea = document.getElementById('jsonEditor');
-            const status = document.getElementById('status');
-            try {
-                JSON.parse(textarea.value);
-                showStatus('✓ JSON is valid', 'success');
-            } catch (e) {
-                showStatus('✗ Invalid JSON: ' + e.message, 'error');
-            }
-        }
-        
-        function formatJson() {
-            const textarea = document.getElementById('jsonEditor');
-            const status = document.getElementById('status');
-            try {
-                const config = JSON.parse(textarea.value);
-                textarea.value = JSON.stringify(config, null, 2);
-                showStatus('✓ JSON formatted', 'success');
-            } catch (e) {
-                showStatus('✗ Cannot format: Invalid JSON', 'error');
-            }
-        }
-        
-        function downloadConfiguration() {
-            const textarea = document.getElementById('jsonEditor');
-            try {
-                const config = JSON.parse(textarea.value);
-                const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = 'dff-configuration.json';
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-                showStatus('✓ Configuration downloaded', 'success');
-            } catch (e) {
-                showStatus('✗ Cannot download: Invalid JSON', 'error');
-            }
-        }
-        
-        function loadExample() {
-            const exampleConfig = {
-                "configurations": [
-                    {
-                        "name": "Sample Configuration",
-                        "workspace": "your-workspace-id",
-                        "resourceType": "TestResult",
-                        "groupKeys": ["basicInfo", "measurements"],
-                        "properties": {}
-                    }
-                ],
-                "groups": [
-                    {
-                        "key": "basicInfo",
-                        "workspace": "your-workspace-id",
-                        "name": "Basic Information",
-                        "displayText": "Basic Information",
-                        "fieldKeys": ["deviceId", "operator"],
-                        "properties": {}
-                    }
-                ],
-                "fields": [
-                    {
-                        "key": "deviceId",
-                        "workspace": "your-workspace-id",
-                        "name": "Device ID",
-                        "displayText": "Device Identifier",
-                        "fieldType": "STRING",
-                        "required": true,
-                        "validation": {
-                            "maxLength": 50
-                        },
-                        "properties": {}
-                    }
-                ]
-            };
-            
-            document.getElementById('jsonEditor').value = JSON.stringify(exampleConfig, null, 2);
-            showStatus('✓ Example configuration loaded', 'success');
-        }
-        
-        function showStatus(message, type) {
-            const status = document.getElementById('status');
-            status.className = 'status ' + type;
-            status.textContent = message;
-            setTimeout(() => {
-                status.className = 'status';
-                status.textContent = '';
-            }, 5000);
-        }
+        Args:
+            file: Optional initial file to load
         """
+        config: dict[str, Any] = {
+            "serverUrl": get_base_url().rstrip("/"),
+            "secret": getattr(self, "_secret", None),
+        }
 
-    def _generate_readme_content(self) -> str:
-        """Generate README content for the editor directory."""
-        return f"""# Dynamic Form Fields Editor
+        # Include initial file path if provided
+        if file:
+            config["initialFile"] = str(Path(file).absolute())
 
-This directory contains a standalone web editor for SystemLink Dynamic Form Fields configurations.
-
-## Files
-
-- `index.html` - The main editor interface
-- `README.md` - This file
-
-## Usage
-
-1. Start the editor server:
-   ```
-   slcli dff edit --output-dir {self.output_dir.name} --port {self.port}
-   ```
-
-2. Open your browser to: http://localhost:{self.port}
-
-3. Edit your configuration in the JSON editor
-
-4. Use the tools to validate, format, and download your configuration
-
-## Configuration Structure
-
-Dynamic Form Fields configurations consist of:
-
-- **Configurations**: Top-level configuration objects that define how forms are structured
-- **Groups**: Logical groupings of fields within a configuration
-- **Fields**: Individual form fields with types, validation rules, and properties
-
-### Resource Types
-
-The `resourceType` field in configurations must be one of these valid values:
-
-- `workorder:workorder`
-- `workitem:workitem`
-- `asset:asset`
-- `system:system`
-- `testmonitor:product`
-
-See the example configuration in the editor for a sample structure.
-"""
+        config_path = self._editor_dir / "slcli-config.json"
+        config_path.write_text(json.dumps(config, indent=2))
 
     def _start_server(self, open_browser: bool) -> None:
         """Start the HTTP server and optionally open browser.
@@ -407,7 +112,7 @@ See the example configuration in the editor for a sample structure.
         Args:
             open_browser: Whether to automatically open browser
         """
-        output_dir = self.output_dir  # Capture for closure
+        editor_dir = self._editor_dir  # Capture for closure
         api_base = get_base_url().rstrip("/")
         default_headers = get_headers()
         ssl_verify = get_ssl_verify()
@@ -417,8 +122,8 @@ See the example configuration in the editor for a sample structure.
             allow_reuse_address = True
 
         class Handler(http.server.SimpleHTTPRequestHandler):
-            def __init__(self, *args, **kwargs) -> None:  # type: ignore
-                super().__init__(*args, directory=str(output_dir), **kwargs)
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                super().__init__(*args, directory=str(editor_dir), **kwargs)
 
             def log_message(self, format: str, *args: Any) -> None:
                 # Suppress server logs
@@ -426,10 +131,6 @@ See the example configuration in the editor for a sample structure.
 
             def _proxy_request(self, method: str) -> bool:
                 parsed = urllib.parse.urlparse(self.path)
-
-                # Handle metadata saving (local file operation)
-                if parsed.path == "/api/dff/save-metadata" and method == "POST":
-                    return self._handle_save_metadata()
 
                 # Handle API proxying
                 path_map = {
@@ -470,7 +171,7 @@ See the example configuration in the editor for a sample structure.
                         data=data,
                         verify=ssl_verify,
                     )
-                except requests.RequestException as exc:  # pragma: no cover - network failure path
+                except requests.RequestException as exc:  # pragma: no cover
                     self.send_error(502, f"Proxy error: {exc}")
                     return True
 
@@ -481,37 +182,6 @@ See the example configuration in the editor for a sample structure.
                 self.end_headers()
                 self.wfile.write(resp.content)
                 return True
-
-            def _handle_save_metadata(self) -> bool:
-                """Save metadata to .editor-metadata.json file."""
-                try:
-                    # Require per-session secret for local save
-                    req_secret = self.headers.get("X-Editor-Secret")
-                    if not secret or req_secret != secret:
-                        self.send_error(403, "Forbidden: Missing or invalid editor secret")
-                        return True
-
-                    content_length = int(self.headers.get("Content-Length", "0"))
-                    if content_length == 0:
-                        self.send_error(400, "No metadata provided")
-                        return True
-
-                    data = self.rfile.read(content_length)
-                    metadata = json.loads(data)
-
-                    # Save to .editor-metadata.json in the output directory
-                    metadata_path = output_dir / ".editor-metadata.json"
-                    with open(metadata_path, "w") as f:
-                        json.dump(metadata, f, indent=2)
-
-                    self.send_response(200)
-                    self.send_header("Content-Type", "application/json")
-                    self.end_headers()
-                    self.wfile.write(json.dumps({"status": "success"}).encode())
-                    return True
-                except Exception as e:  # pragma: no cover
-                    self.send_error(500, f"Failed to save metadata: {e}")
-                    return True
 
             def do_GET(self) -> None:  # noqa: N802
                 if self._proxy_request("GET"):
@@ -533,16 +203,13 @@ See the example configuration in the editor for a sample structure.
                 server_thread.daemon = True
                 server_thread.start()
 
-                click.echo(f"✓ Created editor files in: {self.output_dir.absolute()}")
                 click.echo(f"✓ Starting Dynamic Form Fields editor at {server_url}")
+                click.echo(f"✓ Loading editor from: {editor_dir}")
 
                 if open_browser:
                     click.echo("✓ Opening in your default browser...")
                     webbrowser.open(server_url)
 
-                click.echo(f"\nEditor files created in: {self.output_dir.absolute()}")
-                click.echo("- index.html (main editor)")
-                click.echo("- README.md (documentation)")
                 click.echo("\nPress Ctrl+C to stop the editor server")
 
                 try:
@@ -551,7 +218,6 @@ See the example configuration in the editor for a sample structure.
                         threading.Event().wait(1)
                 except KeyboardInterrupt:
                     click.echo("\n✓ Editor server stopped")
-                    click.echo(f"✓ Editor files remain in: {self.output_dir.absolute()}")
                     httpd.shutdown()
                     httpd.server_close()
                     server_thread.join(timeout=2)
@@ -570,7 +236,6 @@ See the example configuration in the editor for a sample structure.
 def launch_dff_editor(
     file: Optional[str] = None,
     port: int = 8080,
-    output_dir: str = "dff-editor",
     open_browser: bool = True,
 ) -> None:
     """Launch the DFF web editor with specified configuration.
@@ -578,8 +243,7 @@ def launch_dff_editor(
     Args:
         file: Optional JSON file to edit
         port: Port for local HTTP server
-        output_dir: Directory to create editor files in
         open_browser: Whether to auto-open browser
     """
-    editor = DFFWebEditor(port=port, output_dir=output_dir)
+    editor = DFFWebEditor(port=port)
     editor.launch(file=file, open_browser=open_browser)

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -1,4 +1,4 @@
-"""Web editor utilities for DFF configuration editing."""
+"""Web editor utilities for custom fields configuration editing."""
 
 import http.server
 import json
@@ -18,7 +18,7 @@ from .utils import ExitCodes, get_base_url, get_headers, get_ssl_verify
 
 
 class DFFWebEditor:
-    """Web-based editor for Dynamic Form Fields configurations."""
+    """Web-based editor for custom fields configurations."""
 
     def __init__(self, port: int = 8080):
         """Initialize the DFF web editor.
@@ -103,12 +103,23 @@ class DFFWebEditor:
         """Write the editor configuration consumed by the frontend.
 
         Args:
-            file: Optional initial file to load (currently unused by frontend)
+            file: Optional initial file to load
         """
         config: dict[str, Any] = {
             "serverUrl": get_base_url().rstrip("/"),
             "secret": getattr(self, "_secret", None),
         }
+
+        # If a file was provided, copy it to the temp directory for the editor to load
+        if file:
+            import shutil
+            from pathlib import Path
+
+            source_path = Path(file)
+            if source_path.exists():
+                dest_path = self._temp_path / "config.json"
+                shutil.copy(source_path, dest_path)
+                config["configFile"] = "config.json"
 
         config_path = self._temp_path / "slcli-config.json"
         config_path.write_text(json.dumps(config, indent=2))
@@ -151,6 +162,19 @@ class DFFWebEditor:
                         return True
                     else:
                         self.send_error(404, "Config not found")
+                        return True
+
+                # Serve config.json (the DFF configuration) from temp directory
+                if parsed.path == "/config.json" and method == "GET":
+                    config_file = temp_path / "config.json"
+                    if config_file.exists():
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(config_file.read_bytes())
+                        return True
+                    else:
+                        self.send_error(404, "Config file not found")
                         return True
 
                 # Handle API proxying
@@ -224,7 +248,7 @@ class DFFWebEditor:
                 server_thread.daemon = True
                 server_thread.start()
 
-                click.echo(f"✓ Starting Dynamic Form Fields editor at {server_url}")
+                click.echo(f"✓ Starting Custom Fields editor at {server_url}")
                 click.echo(f"✓ Loading editor from: {editor_dir}")
 
                 if open_browser:

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -2,7 +2,6 @@
 
 import http.server
 import json
-import os
 import secrets
 import socketserver
 import sys

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -113,7 +113,6 @@ class DFFWebEditor:
         # If a file was provided, copy it to the temp directory for the editor to load
         if file:
             import shutil
-            from pathlib import Path
 
             source_path = Path(file)
             if source_path.exists():

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,7 +13,7 @@ tests/e2e/
 ├── conftest.py                 # Shared fixtures and configuration
 ├── test_notebook_e2e.py        # Notebook command tests
 ├── test_user_e2e.py           # User command tests
-├── test_dff_e2e.py            # Dynamic Form Fields tests
+├── test_dff_e2e.py            # Custom Fields tests
 ├── test_workspace_e2e.py      # Workspace command tests
 ├── test_tag_e2e.py            # Tag command tests
 ├── run_e2e.py                 # E2E test runner
@@ -65,7 +65,7 @@ The API key should have:
 - Permissions to create/read/update/delete notebooks
 - Access to user management APIs
 - Access to workspace management APIs
-- Access to Dynamic Form Fields (if testing DFF functionality)
+- Access to Custom Fields (if testing custom fields functionality)
 
 ## Running E2E Tests
 
@@ -91,7 +91,7 @@ poetry run pytest tests/e2e/test_user_e2e.py -m e2e -v
 # Workspace tests only
 poetry run pytest tests/e2e/test_workspace_e2e.py -m e2e -v
 
-# DFF tests only
+# Custom fields tests only
 poetry run pytest tests/e2e/test_dff_e2e.py -m e2e -v
 
 # Tag tests only
@@ -177,7 +177,7 @@ If tests fail only in parallel mode, they likely have:
 - Workspace filtering
 - Name vs ID-based operations
 
-### 🔧 Dynamic Form Fields Tests
+### 🔧 Custom Fields Tests
 
 - Configuration CRUD operations
 - Groups and fields listing
@@ -197,7 +197,7 @@ The framework uses pytest markers to categorize tests:
 - `@pytest.mark.e2e` - All E2E tests
 - `@pytest.mark.slow` - Long-running tests
 - `@pytest.mark.notebook` - Notebook-related tests
-- `@pytest.mark.dff` - Dynamic Form Fields tests
+- `@pytest.mark.dff` - Custom Fields tests
 - `@pytest.mark.workspace` - Workspace-related tests
 - `@pytest.mark.user` - User management tests
 
@@ -292,7 +292,7 @@ def test_notebook_create_and_delete_cycle(self, cli_runner, cli_helper):
 ### Test Data Fixtures
 
 - `sample_notebook_content` - Valid notebook JSON
-- `sample_dff_config` - DFF configuration template
+- `sample_dff_config` - Custom Fields configuration template
 
 ### Helper Classes
 
@@ -333,14 +333,14 @@ def test_notebook_create_and_delete_cycle(self, cli_runner, cli_helper):
    - Set `SLCLI_NON_INTERACTIVE=true` to force non-interactive mode
    - Use `--format json` to avoid pagination entirely
 
-6. **DFF Configuration Creation Failures**
+6. **Custom Fields Configuration Creation Failures**
 
-   - DFF API requires workspace IDs, not workspace names
+   - Custom Fields API requires workspace IDs, not workspace names
    - Use `slcli workspace list --format json` to get workspace IDs
    - Verify all required fields are present in configuration JSON
-   - Check that `resourceType` values are valid (use `slcli dff init --help`)
+   - Check that `resourceType` values are valid (use `slcli customfields init --help`)
 
-7. **DFF Export/Import Structure Issues**
+7. **Custom Fields Export/Import Structure Issues**
    - Export commands return data with `configurations` (plural) key
    - Import commands expect same structure with `configurations` array
    - Single configuration get commands also return `configurations` array
@@ -361,23 +361,23 @@ poetry run pytest tests/e2e/ -x
 poetry run pytest tests/e2e/test_notebook_e2e.py::TestNotebookE2E::test_notebook_create_and_delete_cycle -v -s
 ```
 
-### DFF-Specific Debugging
+### Custom Fields Debugging
 
-For Dynamic Form Fields tests, common issues and solutions:
+For Custom Fields tests, common issues and solutions:
 
 ```bash
-# Test DFF configuration creation manually
-poetry run slcli dff create --file /path/to/config.json
+# Test custom fields configuration creation manually
+poetry run slcli customfields create --file /path/to/config.json
 
-# Check workspace ID (DFF requires IDs, not names)
+# Check workspace ID (custom fields require IDs, not names)
 poetry run slcli workspace list --format json | jq '.[] | select(.name=="Default") | .id'
 
-# Verify DFF export structure
-poetry run slcli dff export --id <config-id> --output /tmp/export.json
+# Verify custom fields export structure
+poetry run slcli customfields export --id <config-id> --output /tmp/export.json
 cat /tmp/export.json | jq keys  # Should show "configurations", "groups", "fields"
 
 # Test resource type validation
-poetry run slcli dff init --help  # Shows valid resource types
+poetry run slcli customfields init --help  # Shows valid resource types
 ```
 
 ## Best Practices

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -303,42 +303,36 @@ def test_notebook_create_and_delete_cycle(self, cli_runner, cli_helper):
 ### Common Issues
 
 1. **Authentication Failures**
-
    - Verify credentials are correct
    - Check if test user account is active
    - Ensure user has required permissions
 
 2. **Network/Connectivity Issues**
-
    - Verify dev environment URL is accessible
    - Check firewall/VPN requirements
    - Increase timeout values if needed
 
 3. **Permission Errors**
-
    - Verify test user has workspace access
    - Check API permissions for user role
    - Ensure workspace exists and is accessible
 
 4. **Test Data Conflicts**
-
    - Enable cleanup to remove test artifacts
    - Use unique names with UUID suffixes
    - Check for leftover data from previous runs
 
 5. **Interactive Pagination Issues**
-
    - E2E tests automatically disable interactive pagination
    - CLI detects non-interactive environments (pytest, automated testing, piped output)
    - Set `SLCLI_NON_INTERACTIVE=true` to force non-interactive mode
    - Use `--format json` to avoid pagination entirely
 
 6. **Custom Fields Configuration Creation Failures**
-
    - Custom Fields API requires workspace IDs, not workspace names
    - Use `slcli workspace list --format json` to get workspace IDs
    - Verify all required fields are present in configuration JSON
-   - Check that `resourceType` values are valid (use `slcli customfields init --help`)
+   - Check that `resourceType` values are valid (use `slcli customfield init --help`)
 
 7. **Custom Fields Export/Import Structure Issues**
    - Export commands return data with `configurations` (plural) key

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -361,17 +361,17 @@ For Custom Fields tests, common issues and solutions:
 
 ```bash
 # Test custom fields configuration creation manually
-poetry run slcli customfields create --file /path/to/config.json
+poetry run slcli customfield create --file /path/to/config.json
 
 # Check workspace ID (custom fields require IDs, not names)
 poetry run slcli workspace list --format json | jq '.[] | select(.name=="Default") | .id'
 
 # Verify custom fields export structure
-poetry run slcli customfields export --id <config-id> --output /tmp/export.json
+poetry run slcli customfield export --id <config-id> --output /tmp/export.json
 cat /tmp/export.json | jq keys  # Should show "configurations", "groups", "fields"
 
 # Test resource type validation
-poetry run slcli customfields init --help  # Shows valid resource types
+poetry run slcli customfield init --help  # Shows valid resource types
 ```
 
 ## Best Practices

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -94,7 +94,7 @@ def test_dff_config_list_success(monkeypatch: Any, runner: CliRunner) -> None:
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "list"])
+    result = runner.invoke(cli, ["customfield", "list"])
 
     assert result.exit_code == 0
     assert "Test Configuration" in result.output
@@ -129,7 +129,7 @@ def test_dff_config_list_json_format(monkeypatch: Any, runner: CliRunner) -> Non
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "list", "--format", "json"])
+    result = runner.invoke(cli, ["customfield", "list", "--format", "json"])
 
     assert result.exit_code == 0
     output_json = json.loads(result.output)
@@ -167,7 +167,7 @@ def test_dff_config_get_success(monkeypatch: Any, runner: CliRunner) -> None:
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "get", "--id", "config1"])
+    result = runner.invoke(cli, ["customfield", "get", "--id", "config1"])
 
     assert result.exit_code == 0
     output_json = json.loads(result.output)
@@ -188,7 +188,7 @@ def test_dff_config_init_success(runner: CliRunner, monkeypatch: Any) -> None:
         result = runner.invoke(
             cli,
             [
-                "customfields",
+                "customfield",
                 "init",
                 "--name",
                 "Test Config",
@@ -279,7 +279,7 @@ def test_dff_config_create_success(monkeypatch: Any, runner: CliRunner) -> None:
         input_file = f.name
 
     try:
-        result = runner.invoke(cli, ["customfields", "create", "--file", input_file])
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
         assert result.exit_code == 0
         assert "configurations created successfully" in result.output
     finally:
@@ -349,7 +349,7 @@ def test_dff_config_create_validation_error(monkeypatch: Any, runner: CliRunner)
         json.dump(invalid_config, f)
 
     try:
-        result = runner.invoke(cli, ["customfields", "create", "--file", input_file])
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
         assert result.exit_code == 2  # ExitCodes.INVALID_INPUT
         assert "Validation errors occurred" in result.output
         assert "request: The request field is required" in result.output
@@ -388,7 +388,7 @@ def test_dff_config_export_success(monkeypatch: Any, runner: CliRunner) -> None:
         output_file = Path(temp_dir) / "exported-config.json"
 
         result = runner.invoke(
-            cli, ["customfields", "export", "--id", "config1", "--output", str(output_file)]
+            cli, ["customfield", "export", "--id", "config1", "--output", str(output_file)]
         )
 
         assert result.exit_code == 0
@@ -409,7 +409,7 @@ def test_dff_config_delete_confirmation_abort(monkeypatch: Any, runner: CliRunne
     cli = make_cli()
 
     # Simulate user saying 'no' to confirmation
-    result = runner.invoke(cli, ["customfields", "delete", "--id", "config1"], input="n\n")
+    result = runner.invoke(cli, ["customfield", "delete", "--id", "config1"], input="n\n")
 
     assert result.exit_code == 1  # Aborted
     assert "Aborted" in result.output
@@ -459,7 +459,7 @@ def test_dff_config_workspace_filtering(monkeypatch: Any, runner: CliRunner) -> 
     cli = make_cli()
 
     # Test filtering by workspace name
-    result = runner.invoke(cli, ["customfields", "list", "--workspace", "Workspace1"])
+    result = runner.invoke(cli, ["customfield", "list", "--workspace", "Workspace1"])
     assert result.exit_code == 0
     assert "Config 1" in result.output
     assert "Config 2" not in result.output
@@ -470,8 +470,8 @@ def test_dff_help_commands(runner: CliRunner, monkeypatch: Any) -> None:
     patch_keyring(monkeypatch)
     cli = make_cli()
 
-    # Test main customfields help
-    result = runner.invoke(cli, ["customfields", "--help"])
+    # Test main customfield help
+    result = runner.invoke(cli, ["customfield", "--help"])
     assert result.exit_code == 0
     assert "Manage custom field" in result.output
 
@@ -481,7 +481,7 @@ def test_dff_edit_command_help(runner: CliRunner, monkeypatch: Any) -> None:
     patch_keyring(monkeypatch)
     cli = make_cli()
 
-    result = runner.invoke(cli, ["customfields", "edit", "--help"])
+    result = runner.invoke(cli, ["customfield", "edit", "--help"])
     assert result.exit_code == 0
     assert "Launch a local web editor" in result.output
     assert "--port" in result.output
@@ -525,7 +525,7 @@ def test_dff_edit_with_config_id_loads_config(monkeypatch: Any, runner: CliRunne
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "edit", "--id", "test-config-123", "--no-browser"])
+    result = runner.invoke(cli, ["customfield", "edit", "--id", "test-config-123", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -570,7 +570,7 @@ def test_dff_edit_with_config_id_fetches_resolved_configuration(
     monkeypatch.setattr("slcli.dff_click.save_json_file", mock_save_json_file)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "edit", "--id", "cfg-123", "--no-browser"])
+    result = runner.invoke(cli, ["customfield", "edit", "--id", "cfg-123", "--no-browser"])
 
     assert result.exit_code == 0
     assert requested_url is not None
@@ -594,7 +594,7 @@ def test_dff_edit_without_id_no_metadata_saved(monkeypatch: Any, runner: CliRunn
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "edit", "--no-browser"])
+    result = runner.invoke(cli, ["customfield", "edit", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -640,7 +640,7 @@ def test_dff_edit_with_id_generates_filename_from_config_name(
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "edit", "--id", "cfg-xyz", "--no-browser"])
+    result = runner.invoke(cli, ["customfield", "edit", "--id", "cfg-xyz", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -682,7 +682,9 @@ def test_dff_delete_with_recursive_flag(monkeypatch: Any, runner: CliRunner) -> 
     monkeypatch.setattr("slcli.dff_click.make_api_request", mock_make_api_request)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["customfields", "delete", "--id", "config1", "--no-recursive"], input="y\n")
+    result = runner.invoke(
+        cli, ["customfield", "delete", "--id", "config1", "--no-recursive"], input="y\n"
+    )
 
     assert result.exit_code == 0
     assert payload_data["recursive"] is False

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -94,7 +94,7 @@ def test_dff_config_list_success(monkeypatch: Any, runner: CliRunner) -> None:
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "list"])
+    result = runner.invoke(cli, ["customfields", "list"])
 
     assert result.exit_code == 0
     assert "Test Configuration" in result.output
@@ -129,7 +129,7 @@ def test_dff_config_list_json_format(monkeypatch: Any, runner: CliRunner) -> Non
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "list", "--format", "json"])
+    result = runner.invoke(cli, ["customfields", "list", "--format", "json"])
 
     assert result.exit_code == 0
     output_json = json.loads(result.output)
@@ -167,7 +167,7 @@ def test_dff_config_get_success(monkeypatch: Any, runner: CliRunner) -> None:
     )
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "get", "--id", "config1"])
+    result = runner.invoke(cli, ["customfields", "get", "--id", "config1"])
 
     assert result.exit_code == 0
     output_json = json.loads(result.output)
@@ -188,7 +188,7 @@ def test_dff_config_init_success(runner: CliRunner, monkeypatch: Any) -> None:
         result = runner.invoke(
             cli,
             [
-                "dff",
+                "customfields",
                 "init",
                 "--name",
                 "Test Config",
@@ -279,7 +279,7 @@ def test_dff_config_create_success(monkeypatch: Any, runner: CliRunner) -> None:
         input_file = f.name
 
     try:
-        result = runner.invoke(cli, ["dff", "create", "--file", input_file])
+        result = runner.invoke(cli, ["customfields", "create", "--file", input_file])
         assert result.exit_code == 0
         assert "configurations created successfully" in result.output
     finally:
@@ -349,7 +349,7 @@ def test_dff_config_create_validation_error(monkeypatch: Any, runner: CliRunner)
         json.dump(invalid_config, f)
 
     try:
-        result = runner.invoke(cli, ["dff", "create", "--file", input_file])
+        result = runner.invoke(cli, ["customfields", "create", "--file", input_file])
         assert result.exit_code == 2  # ExitCodes.INVALID_INPUT
         assert "Validation errors occurred" in result.output
         assert "request: The request field is required" in result.output
@@ -388,7 +388,7 @@ def test_dff_config_export_success(monkeypatch: Any, runner: CliRunner) -> None:
         output_file = Path(temp_dir) / "exported-config.json"
 
         result = runner.invoke(
-            cli, ["dff", "export", "--id", "config1", "--output", str(output_file)]
+            cli, ["customfields", "export", "--id", "config1", "--output", str(output_file)]
         )
 
         assert result.exit_code == 0
@@ -409,7 +409,7 @@ def test_dff_config_delete_confirmation_abort(monkeypatch: Any, runner: CliRunne
     cli = make_cli()
 
     # Simulate user saying 'no' to confirmation
-    result = runner.invoke(cli, ["dff", "delete", "--id", "config1"], input="n\n")
+    result = runner.invoke(cli, ["customfields", "delete", "--id", "config1"], input="n\n")
 
     assert result.exit_code == 1  # Aborted
     assert "Aborted" in result.output
@@ -459,7 +459,7 @@ def test_dff_config_workspace_filtering(monkeypatch: Any, runner: CliRunner) -> 
     cli = make_cli()
 
     # Test filtering by workspace name
-    result = runner.invoke(cli, ["dff", "list", "--workspace", "Workspace1"])
+    result = runner.invoke(cli, ["customfields", "list", "--workspace", "Workspace1"])
     assert result.exit_code == 0
     assert "Config 1" in result.output
     assert "Config 2" not in result.output
@@ -470,10 +470,10 @@ def test_dff_help_commands(runner: CliRunner, monkeypatch: Any) -> None:
     patch_keyring(monkeypatch)
     cli = make_cli()
 
-    # Test main dff help
-    result = runner.invoke(cli, ["dff", "--help"])
+    # Test main customfields help
+    result = runner.invoke(cli, ["customfields", "--help"])
     assert result.exit_code == 0
-    assert "Manage dynamic form field configurations" in result.output
+    assert "Manage custom field" in result.output
 
 
 def test_dff_edit_command_help(runner: CliRunner, monkeypatch: Any) -> None:
@@ -481,7 +481,7 @@ def test_dff_edit_command_help(runner: CliRunner, monkeypatch: Any) -> None:
     patch_keyring(monkeypatch)
     cli = make_cli()
 
-    result = runner.invoke(cli, ["dff", "edit", "--help"])
+    result = runner.invoke(cli, ["customfields", "edit", "--help"])
     assert result.exit_code == 0
     assert "Launch a local web editor" in result.output
     assert "--port" in result.output
@@ -525,7 +525,7 @@ def test_dff_edit_with_config_id_loads_config(monkeypatch: Any, runner: CliRunne
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "edit", "--id", "test-config-123", "--no-browser"])
+    result = runner.invoke(cli, ["customfields", "edit", "--id", "test-config-123", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -570,7 +570,7 @@ def test_dff_edit_with_config_id_fetches_resolved_configuration(
     monkeypatch.setattr("slcli.dff_click.save_json_file", mock_save_json_file)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "edit", "--id", "cfg-123", "--no-browser"])
+    result = runner.invoke(cli, ["customfields", "edit", "--id", "cfg-123", "--no-browser"])
 
     assert result.exit_code == 0
     assert requested_url is not None
@@ -594,7 +594,7 @@ def test_dff_edit_without_id_no_metadata_saved(monkeypatch: Any, runner: CliRunn
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "edit", "--no-browser"])
+    result = runner.invoke(cli, ["customfields", "edit", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -640,7 +640,7 @@ def test_dff_edit_with_id_generates_filename_from_config_name(
     monkeypatch.setattr("slcli.dff_click.launch_dff_editor", mock_launch_editor)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "edit", "--id", "cfg-xyz", "--no-browser"])
+    result = runner.invoke(cli, ["customfields", "edit", "--id", "cfg-xyz", "--no-browser"])
 
     assert result.exit_code == 0
 
@@ -682,7 +682,7 @@ def test_dff_delete_with_recursive_flag(monkeypatch: Any, runner: CliRunner) -> 
     monkeypatch.setattr("slcli.dff_click.make_api_request", mock_make_api_request)
 
     cli = make_cli()
-    result = runner.invoke(cli, ["dff", "delete", "--id", "config1", "--no-recursive"], input="y\n")
+    result = runner.invoke(cli, ["customfields", "delete", "--id", "config1", "--no-recursive"], input="y\n")
 
     assert result.exit_code == 0
     assert payload_data["recursive"] is False

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -485,11 +485,11 @@ def test_dff_edit_command_help(runner: CliRunner, monkeypatch: Any) -> None:
     assert result.exit_code == 0
     assert "Launch a local web editor" in result.output
     assert "--port" in result.output
-    assert "--output-dir" in result.output
+    assert "--no-browser" in result.output
 
 
-def test_dff_edit_with_config_id_saves_metadata(monkeypatch: Any, runner: CliRunner) -> None:
-    """Test that dff edit --id saves metadata file."""
+def test_dff_edit_with_config_id_loads_config(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test that dff edit --id loads configuration from server."""
     patch_keyring(monkeypatch)
 
     # Track calls to save_json_file
@@ -529,14 +529,9 @@ def test_dff_edit_with_config_id_saves_metadata(monkeypatch: Any, runner: CliRun
 
     assert result.exit_code == 0
 
-    # Check that metadata file was saved
-    metadata_files = [path for path in saved_files.keys() if ".editor-metadata.json" in path]
-    assert len(metadata_files) == 1
-
-    metadata = saved_files[metadata_files[0]]
-    assert metadata["configId"] == "test-config-123"
-    assert "configFile" in metadata
-    assert ".json" in metadata["configFile"]
+    # Check that configuration file was saved (not metadata file)
+    config_files = [path for path in saved_files.keys() if ".json" in path]
+    assert len(config_files) >= 1
 
 
 def test_dff_edit_with_config_id_fetches_resolved_configuration(

--- a/tests/unit/test_feature_gating.py
+++ b/tests/unit/test_feature_gating.py
@@ -35,7 +35,7 @@ class TestFeatureGatingDFF:
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["customfields", "list"])
+        result = runner.invoke(cli, ["customfield", "list"])
 
         assert result.exit_code == 2  # INVALID_INPUT
         assert "Dynamic Form Fields is not available on SystemLink Server" in result.output
@@ -57,7 +57,7 @@ class TestFeatureGatingDFF:
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["customfields", "--help"])
+        result = runner.invoke(cli, ["customfield", "--help"])
 
         assert result.exit_code == 0
         assert "Manage custom field" in result.output
@@ -170,7 +170,7 @@ class TestFeatureGatingSLE:
         monkeypatch.setattr("slcli.utils.make_api_request", mock_make_api_request)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["customfields", "config", "list", "--format", "json"])
+        result = runner.invoke(cli, ["customfield", "config", "list", "--format", "json"])
 
         # Should not be blocked by feature gating (exit code 2)
         # It may fail for other reasons, but not due to platform gating

--- a/tests/unit/test_feature_gating.py
+++ b/tests/unit/test_feature_gating.py
@@ -60,7 +60,7 @@ class TestFeatureGatingDFF:
         result = runner.invoke(cli, ["customfield", "--help"])
 
         assert result.exit_code == 0
-        assert "Manage custom field" in result.output
+        assert "Manage custom field (DFF) configurations" in result.output
 
 
 class TestFeatureGatingTemplates:

--- a/tests/unit/test_feature_gating.py
+++ b/tests/unit/test_feature_gating.py
@@ -35,7 +35,7 @@ class TestFeatureGatingDFF:
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["dff", "list"])
+        result = runner.invoke(cli, ["customfields", "list"])
 
         assert result.exit_code == 2  # INVALID_INPUT
         assert "Dynamic Form Fields is not available on SystemLink Server" in result.output
@@ -57,10 +57,10 @@ class TestFeatureGatingDFF:
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["dff", "--help"])
+        result = runner.invoke(cli, ["customfields", "--help"])
 
         assert result.exit_code == 0
-        assert "Manage dynamic form field configurations" in result.output
+        assert "Manage custom field" in result.output
 
 
 class TestFeatureGatingTemplates:
@@ -170,7 +170,7 @@ class TestFeatureGatingSLE:
         monkeypatch.setattr("slcli.utils.make_api_request", mock_make_api_request)
 
         runner = CliRunner()
-        result = runner.invoke(cli, ["dff", "config", "list", "--format", "json"])
+        result = runner.invoke(cli, ["customfields", "config", "list", "--format", "json"])
 
         # Should not be blocked by feature gating (exit code 2)
         # It may fail for other reasons, but not due to platform gating


### PR DESCRIPTION
## Summary

This PR renames the `dff` command to `customfield` (singular) and adds several enhancements to the custom fields web editor.

## Changes

### 1. Command Renamed: `dff` → `customfield`
- Updated command registration from `customfields` to `customfield` (singular)
- Updated all user-facing documentation (README, dff-editor README, DFF_WEB_EDITOR.md, e2e README)
- Updated all unit and E2E tests to use new command name
- Updated web editor page title from "Dynamic Form Fields Editor" to "Custom Fields Editor"

### 2. Fixed `customfield edit -i <id>` Command
**Problem:** The edit command ignored the `--id` parameter and always loaded the last successful config  
**Solution:**
- Modified `slcli/web_editor.py` to copy config files to temp directory and serve via HTTP
- Updated `dff-editor/editor.js` to load from `configFile\- Updated `dff-editor/editor.js` to load from `configFile\- Updated `dff-editor/editor.js` to load from `configFile\- Updated `dff-editor/editor.js` to load dde- Updated `dff-editor/editor.js` to load from `configFile\- Updated `dff-editor/editor.js` to load from `configFile\- Updnte- Updated8n UI into all create/edit dialogs (configurations, gro- Updated `dff-editor/editor.js` to load from `configFile\- Updated `dff-edit) for field labels, descriptions, etc.

### 3. DFF editor changes
- Added Enum Value Editing for SELECT/MULTISELECT Fields
- L8n string editing

## Files Modified

### Core Implementation
- `slcli/dff_click.py` - Command name changed to `customfield`
- `slcli/web_editor.py` - Config file serving for edit command
- `dff-editor/editor.js` - i18n support, enum editing, config loading
- `dff-editor/index.html` - Page title updated

### Documentation
- `README.md` - All command examples updated
- `dff-editor/README.md` - Usage examples updated
- `docs/DFF_WEB_EDITOR.md\