### PR TITLE
feat: add legacy mac support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
         include:
           - os: ubuntu-latest
             platform: linux
@@ -23,6 +23,9 @@ jobs:
           - os: macos-latest
             platform: macos
             artifact_name: slcli-macos
+          - os: macos-13
+            platform: macos
+            artifact_name: slcli-macos-13
           - os: windows-latest
             platform: windows
             artifact_name: slcli-windows
@@ -55,13 +58,13 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           cd dist
-          tar -czf slcli-linux.tar.gz slcli/
+          tar -czf "${{ matrix.artifact_name }}.tar.gz" slcli/
 
       - name: Create platform-specific tarball (macOS)
         if: matrix.platform == 'macos'
         run: |
           cd dist
-          tar -czf slcli-macos.tar.gz slcli/
+          tar -czf "${{ matrix.artifact_name }}.tar.gz" slcli/
 
       - name: Create Windows ZIP for Scoop
         if: matrix.platform == 'windows'
@@ -166,6 +169,7 @@ jobs:
             scoop-artifacts/scoop-slcli.json
             slcli-linux/slcli-linux.tar.gz
             slcli-macos/slcli-macos.tar.gz
+            slcli-macos-13/slcli-macos-13.tar.gz
             slcli-windows/slcli.zip
           generate_release_notes: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,12 @@ jobs:
           name: slcli-macos
           path: dist/
 
+      - name: Download macOS 13 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: slcli-macos-13
+          path: dist/
+
       - name: Build Homebrew formula
         run: poetry run python scripts/build_homebrew.py
 

--- a/scripts/build_homebrew.py
+++ b/scripts/build_homebrew.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).parent.parent.resolve()
 DIST = ROOT / "dist"
 LINUX_TARBALL = DIST / "slcli-linux.tar.gz"
 MACOS_TARBALL = DIST / "slcli-macos.tar.gz"
+MACOS_13_TARBALL = DIST / "slcli-macos-13.tar.gz"
 FORMULA_TEMPLATE = ROOT / "scripts" / "homebrew-slcli.rb.j2"
 DIST_FORMULA = DIST / "homebrew-slcli.rb"
 PYPROJECT = ROOT / "pyproject.toml"
@@ -34,7 +35,7 @@ def compute_sha256(tarball_path):
     return sha256
 
 
-def render_formula(sha256_linux, sha256_macos, version):
+def render_formula(sha256_linux, sha256_macos, sha256_macos_13, version):
     """Render the Homebrew formula from the template and write to dist/homebrew-slcli.rb."""
     if not FORMULA_TEMPLATE.exists():
         print(f"Error: {FORMULA_TEMPLATE} not found.")
@@ -43,6 +44,7 @@ def render_formula(sha256_linux, sha256_macos, version):
     rendered = (
         template.replace("{{ sha256_linux }}", sha256_linux)
         .replace("{{ sha256_macos }}", sha256_macos)
+        .replace("{{ sha256_macos_13 }}", sha256_macos_13)
         .replace("{{ version }}", version)
     )
     DIST_FORMULA.write_text(rendered)
@@ -56,9 +58,10 @@ def main():
     # Compute SHA256 for both platform tarballs
     sha256_linux = compute_sha256(LINUX_TARBALL)
     sha256_macos = compute_sha256(MACOS_TARBALL)
+    sha256_macos_13 = compute_sha256(MACOS_13_TARBALL)
 
     # Render the formula
-    render_formula(sha256_linux, sha256_macos, version)
+    render_formula(sha256_linux, sha256_macos, sha256_macos_13, version)
     print("Homebrew formula build complete.")
 
 

--- a/scripts/homebrew-slcli.rb.j2
+++ b/scripts/homebrew-slcli.rb.j2
@@ -5,8 +5,15 @@ class Slcli < Formula
   license "MIT"
 
   on_macos do
-    url "https://github.com/ni-kismet/systemlink-cli/releases/download/v{{ version }}/slcli-macos.tar.gz"
-    sha256 "{{ sha256_macos }}"
+    on_intel do
+      url "https://github.com/ni-kismet/systemlink-cli/releases/download/v{{ version }}/slcli-macos-13.tar.gz"
+      sha256 "{{ sha256_macos_13 }}"
+    end
+
+    on_arm do
+      url "https://github.com/ni-kismet/systemlink-cli/releases/download/v{{ version }}/slcli-macos.tar.gz"
+      sha256 "{{ sha256_macos }}"
+    end
   end
 
   on_linux do


### PR DESCRIPTION
## Summary
- Add macos-13 build to release matrix for legacy Intel support.
- Serve macos-13 binaries to Intel Macs via Homebrew; Apple Silicon keeps macos-latest.
- Generate and inject macos-13 checksum in Homebrew formula.

## Testing
- Not run