### PR TITLE
Test Monitor Phase 2 + summary/grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,6 +1262,12 @@ slcli testmonitor product list \
   --substitution "cRIO" \
   --substitution "9030"
 
+# Show summary statistics (total count and by family)
+slcli testmonitor product list --summary
+
+# Show summary in JSON format
+slcli testmonitor product list --format json --summary
+
 # JSON output (no interactive pagination)
 slcli testmonitor product list --format json
 ```
@@ -1288,6 +1294,15 @@ slcli testmonitor result list \
   --substitution 30 \
   --product-filter '(family == @0)' \
   --product-substitution "cRIO"
+
+# Show summary statistics grouped by status
+slcli testmonitor result list --summary
+
+# Show results grouped by program name with counts
+slcli testmonitor result list --group-by programName
+
+# Show grouped summary in JSON format
+slcli testmonitor result list --format json --group-by status
 
 # JSON output (no interactive pagination)
 slcli testmonitor result list --format json

--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,32 @@ slcli testmonitor result list \
 slcli testmonitor result list --format json
 ```
 
+### Get product details
+
+```bash
+# Get a specific product by ID in table format
+slcli testmonitor product get 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+
+# Get product details in JSON format
+slcli testmonitor product get 02600cf8-c2bb-4ff9-a139-031e943fb0c0 --format json
+```
+
+### Get result details with steps and measurements
+
+```bash
+# Get a specific test result by ID
+slcli testmonitor result get abc123def456
+
+# Include step information
+slcli testmonitor result get abc123def456 --include-steps
+
+# Include step measurements (outputs)
+slcli testmonitor result get abc123def456 --include-steps --include-measurements
+
+# Get result details in JSON format
+slcli testmonitor result get abc123def456 --include-steps --format json
+```
+
 ## Notebook Management
 
 The `notebook` command group is organized into logical subgroups to mirror function command structure:

--- a/README.md
+++ b/README.md
@@ -1262,10 +1262,10 @@ slcli testmonitor product list \
   --substitution "cRIO" \
   --substitution "9030"
 
-# Show summary statistics (total count and by family)
+# Show summary statistics (total count and number of distinct families)
 slcli testmonitor product list --summary
 
-# Show summary in JSON format
+# Show summary in JSON format (number of distinct families)
 slcli testmonitor product list --format json --summary
 
 # JSON output (no interactive pagination)

--- a/tests/unit/test_testmonitor_click.py
+++ b/tests/unit/test_testmonitor_click.py
@@ -877,6 +877,8 @@ def test_list_products_with_summary_flag_json(monkeypatch: Any, runner: CliRunne
     assert "total" in data
     assert data["total"] == 3
     assert "families" in data
+    # Verify we have 2 distinct families (cRIO and myRIO)
+    assert data["families"] == 2
 
 
 def test_list_products_with_summary_flag_table(monkeypatch: Any, runner: CliRunner) -> None:
@@ -984,6 +986,11 @@ def test_list_results_with_summary_flag_json(monkeypatch: Any, runner: CliRunner
     assert "total" in data
     assert data["total"] == 3
     assert "groups" in data
+    # Verify grouping by status is correct (PASSED: 2, FAILED: 1)
+    assert "PASSED" in data["groups"]
+    assert data["groups"]["PASSED"] == 2
+    assert "FAILED" in data["groups"]
+    assert data["groups"]["FAILED"] == 1
 
 
 def test_list_results_with_groupby_flag_json(monkeypatch: Any, runner: CliRunner) -> None:
@@ -1038,6 +1045,11 @@ def test_list_results_with_groupby_flag_json(monkeypatch: Any, runner: CliRunner
     assert "total" in data
     assert data["total"] == 3
     assert "groups" in data
+    # Verify grouping by programName is correct (Calibration: 2, Diagnostics: 1)
+    assert "Calibration" in data["groups"]
+    assert data["groups"]["Calibration"] == 2
+    assert "Diagnostics" in data["groups"]
+    assert data["groups"]["Diagnostics"] == 1
 
 
 def test_list_results_with_summary_flag_table(monkeypatch: Any, runner: CliRunner) -> None:
@@ -1093,44 +1105,6 @@ def test_list_results_with_summary_flag_table(monkeypatch: Any, runner: CliRunne
     assert result.exit_code == 0
     assert "Test Results Summary" in result.output
     assert "Total Results: 3" in result.output
-
-
-def test_parse_natural_date_yesterday() -> None:
-    """Test natural date parsing for 'yesterday'."""
-    from slcli.testmonitor_click import _parse_natural_date
-
-    result = _parse_natural_date("yesterday")
-    # Result should be a date string, just verify it's not the input
-    assert result != "yesterday"
-    # Should be in ISO format (YYYY-MM-DD or similar)
-    assert "T" in result or "-" in result
-
-
-def test_parse_natural_date_weeks_ago() -> None:
-    """Test natural date parsing for 'X weeks ago'."""
-    from slcli.testmonitor_click import _parse_natural_date
-
-    result = _parse_natural_date("2 weeks ago")
-    assert result != "2 weeks ago"
-    assert "T" in result or "-" in result
-
-
-def test_parse_natural_date_quarters_ago() -> None:
-    """Test natural date parsing for 'X quarters ago'."""
-    from slcli.testmonitor_click import _parse_natural_date
-
-    result = _parse_natural_date("3 quarters ago")
-    assert result != "3 quarters ago"
-    assert "T" in result or "-" in result
-
-
-def test_parse_natural_date_invalid() -> None:
-    """Test natural date parsing with invalid input."""
-    from slcli.testmonitor_click import _parse_natural_date
-
-    # Should return original on invalid input
-    result = _parse_natural_date("invalid-date")
-    assert result == "invalid-date"
 
 
 def test_summarize_results_empty_list() -> None:


### PR DESCRIPTION
## Summary
- add Test Monitor Phase 2 commands: product get and result get with step/measurement expansion
- add result/product summaries with grouping support
- expand unit tests and README examples for new flags

## Details
- Product list: --summary outputs total and family counts
- Result list: --summary and --group-by (status/programName/serialNumber/operator/hostName/systemId)
- Group-by mapping preserves camelCase field names
- Table output prints summary header and counts; JSON output returns summary payloads
- Added helper utilities for summary and natural-date parsing (parsing not yet wired to filters)

## Testing
- poetry run ni-python-styleguide lint
- poetry run mypy slcli tests
- poetry run pytest tests/unit -q
- poetry run pytest tests/e2e/ -n auto --timeout=300
