### PR TITLE
feat: Add Asset Management commands (Phases 1-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,118 @@ slcli user create --type user \
   --workspace-policies "DevWorkspace:template-dev,ProdWorkspace:template-prod"
 ```
 
+## Asset Management
+
+Manage hardware assets tracked by the Asset Management service. Query, inspect,
+and manage assets with rich filtering, calibration tracking, and location history.
+
+### List Assets
+
+```bash
+# List all assets (paginated table, 25 per page)
+slcli asset list
+
+# Filter by model name (contains match)
+slcli asset list --model "PXI-4071"
+
+# Filter by serial number (exact match)
+slcli asset list --serial-number "01BB877A"
+
+# Filter by bus type
+slcli asset list --bus-type PCI_PXI
+
+# Show only connected & present assets
+slcli asset list --connected
+
+# Show only calibratable assets
+slcli asset list --calibratable
+
+# Advanced filter with API filter syntax
+slcli asset list --filter 'ModelName.Contains("PXI") and BusType = "PCI_PXI"'
+
+# Filter by workspace
+slcli asset list --workspace "Production"
+
+# JSON output (all results, no pagination)
+slcli asset list --model "DMM" --format json
+
+# Order by last updated, ascending
+slcli asset list --order-by LAST_UPDATED_TIMESTAMP --ascending
+
+# Show inline summary statistics
+slcli asset list --summary
+```
+
+### Get Asset Details
+
+```bash
+# Detailed view in table format
+slcli asset get <asset-id>
+
+# JSON output
+slcli asset get <asset-id> --format json
+
+# Include calibration history
+slcli asset get <asset-id> --include-calibration
+```
+
+### Fleet Summary
+
+```bash
+# Fleet-wide statistics (total, active, calibration breakdown)
+slcli asset summary
+
+# JSON output
+slcli asset summary --format json
+```
+
+### Calibration History
+
+```bash
+# Show calibration history for an asset
+slcli asset calibration <asset-id>
+
+# JSON output
+slcli asset calibration <asset-id> --format json
+
+# Limit results
+slcli asset calibration <asset-id> --take 10
+```
+
+### Location History
+
+```bash
+# Show location/connection history
+slcli asset location-history <asset-id>
+
+# Filter by date range (for temporal correlation)
+slcli asset location-history <asset-id> \
+  --from "2025-12-01T00:00:00Z" \
+  --to "2025-12-02T00:00:00Z"
+
+# JSON output
+slcli asset location-history <asset-id> --format json
+```
+
+### Create, Update, Delete
+
+```bash
+# Create a new asset
+slcli asset create --model-name "PXI-4071" --serial-number "SN-123" --bus-type PCI_PXI
+
+# Create with keywords and properties
+slcli asset create --model-name "DMM" --keyword "lab-a" --property "owner=Team1"
+
+# Update asset properties
+slcli asset update <asset-id> --name "Updated Name" --serial-number "SN-456"
+
+# Delete an asset (with confirmation)
+slcli asset delete <asset-id>
+
+# Delete without confirmation
+slcli asset delete <asset-id> --force
+```
+
 ## Feed Management
 
 Manage NI Package Manager feeds for both SystemLink Enterprise (SLE) and SystemLink Server (SLS). Platform detection is automatic, and platform values are case-insensitive.

--- a/docs/asset-command-proposal.md
+++ b/docs/asset-command-proposal.md
@@ -126,13 +126,15 @@ slcli asset
 └── location-history  # Get location/connection history for an asset
 ```
 
-**NOT creating:**
+**NOT creating (Phase 1 scope):**
 
 - ❌ `asset query` separate from `list` (consolidated into `list --filter`)
 - ❌ `asset find-systems` (AI agent can correlate `asset list` results)
-- ❌ `asset create` / `asset update` / `asset delete` (Phase 2, when needed)
 - ❌ `asset utilization` (Phase 2, lower priority)
 - ❌ `asset move-location` / `asset send-for-calibration` (Phase 2, mutation operations)
+
+> Note: In the current implementation, `asset create`, `asset update`, and `asset delete` are implemented
+> and documented in the README. They were originally proposed as Phase 2 work and are no longer excluded.
 
 ---
 

--- a/docs/asset-command-proposal.md
+++ b/docs/asset-command-proposal.md
@@ -1,0 +1,860 @@
+# Asset Command Proposal: Analysis & Recommendations
+
+**Date:** February 10, 2026  
+**Context:** Review of slcli-workflow-analysis.md against the Asset Management API (niapm v1)
+
+---
+
+## Executive Summary
+
+The workflow analysis identifies two high-priority workflows requiring asset data (Workflows 2 and 4), plus general asset management needs. The Asset Management API (`/niapm/v1/`) provides comprehensive endpoints for querying, filtering, and managing assets — including location history, calibration tracking, and utilization.
+
+**Recommendation:** Create a single `slcli asset` command group with `list`, `get`, `summary`, and `calibration` subcommands. Keep the command structure flat (no nested groups), consistent with `slcli file`, `slcli tag`, etc. The `testmonitor` nested-group pattern is not needed here because assets are a single entity type, unlike testmonitor's product/result split.
+
+---
+
+## Current Implementation Assessment
+
+### What We Have
+
+No asset commands exist in slcli today. The workflow analysis proposes several asset-related commands across Workflows 2 and 4:
+
+- **Workflow 2:** "What was the SN of the PXI-4071 used to measure DUT SN 1234567?" — requires cross-service correlation (Test Monitor → Systems → Assets)
+- **Workflow 4:** "Find me a system that has a DMM and a scope" — requires querying assets by model and correlating by system location
+
+---
+
+## Workflow Analysis Proposals vs. Recommended Implementation
+
+### Workflow 2: "What was the SN of the PXI-4071 used to measure DUT SN 1234567?"
+
+**Workflow Analysis Proposes:**
+
+```bash
+# Multiple specialized commands
+slcli asset query \
+  --filter 'location.minionId = "<minion-id>" and model contains "PXI-4071"'
+slcli asset location-history <asset-id> \
+  --from "<date>" --to "<date>"
+slcli testresult get-assets <result-id> \
+  --filter 'model contains "PXI-4071"'
+slcli testresult correlate \
+  --serial-number "1234567" \
+  --show assets,system,conditions
+```
+
+**Recommended Implementation:**
+
+```bash
+# Step 1: Get result to find systemId (existing testmonitor command)
+slcli testmonitor result list \
+  --serial-number "1234567" \
+  --format json
+
+# Step 2: Find assets on that system matching the model
+slcli asset list \
+  --filter 'Location.MinionId = "<minion-id>" and ModelName.Contains("PXI-4071")' \
+  --format json
+
+# Step 3: Check location history if temporal correlation needed
+slcli asset location-history <asset-id> \
+  --from "2025-12-01T00:00:00Z" \
+  --to "2025-12-02T00:00:00Z"
+```
+
+**Assessment:** ✅ Recommended approach is BETTER
+
+- Uses existing `testmonitor result list` for step 1
+- Standard `asset list` with filter handles step 2
+- `location-history` is a focused, composable subcommand
+- No need for specialized cross-service correlation commands — AI agents (Copilot) can chain these steps naturally
+
+---
+
+### Workflow 4: "Find me a system that has a DMM and a scope"
+
+**Workflow Analysis Proposes:**
+
+```bash
+slcli system find \
+  --has-asset "DMM" \
+  --has-asset "scope" \
+  --state connected
+slcli system query-by-assets \
+  --requires "DMM,scope"
+slcli asset find-systems \
+  --with-capabilities "voltage-measurement,waveform-acquisition"
+```
+
+**Recommended Implementation:**
+
+```bash
+# Step 1: Find DMMs and note their minionIds
+slcli asset list \
+  --model "DMM" \
+  --connected \
+  --format json
+
+# Step 2: Find scopes and note their minionIds
+slcli asset list \
+  --model "scope" \
+  --connected \
+  --format json
+
+# Copilot computes intersection of minionIds client-side
+```
+
+**Assessment:** ✅ Recommended approach is BETTER
+
+- Uses a single, general-purpose `asset list` command with convenience filters
+- AI agents can easily correlate minionIds across two queries
+- No need for `system find --has-asset` or `asset find-systems` — these would be single-use commands
+- The API doesn't support cross-entity joins, so these would just be client-side wrappers anyway
+
+---
+
+## Concrete Command Proposal
+
+### Command Structure
+
+```
+slcli asset
+├── list              # Query/list assets with filters
+├── get <id>          # Get detailed asset information
+├── summary           # Get fleet summary statistics
+├── calibration       # Get calibration history for an asset
+└── location-history  # Get location/connection history for an asset
+```
+
+**NOT creating:**
+
+- ❌ `asset query` separate from `list` (consolidated into `list --filter`)
+- ❌ `asset find-systems` (AI agent can correlate `asset list` results)
+- ❌ `asset create` / `asset update` / `asset delete` (Phase 2, when needed)
+- ❌ `asset utilization` (Phase 2, lower priority)
+- ❌ `asset move-location` / `asset send-for-calibration` (Phase 2, mutation operations)
+
+---
+
+### 1. `slcli asset list`
+
+**Purpose:** Query and list assets with comprehensive filtering
+
+**API Endpoint:** POST `/niapm/v1/query-assets`  
+**Pagination:** Skip/Take (server-side offset pagination, max Take=1000)
+
+```bash
+# List all assets (paginated, 25 per page)
+slcli asset list
+
+# Filter by model name (convenience option)
+slcli asset list --model "PXI-4071"
+
+# Filter by serial number
+slcli asset list --serial-number "01BB877A"
+
+# Filter by bus type
+slcli asset list --bus-type PCI_PXI
+
+# Filter by asset type
+slcli asset list --asset-type DEVICE_UNDER_TEST
+
+# Filter by calibration status
+slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE
+
+# Show only connected/present assets
+slcli asset list --connected
+
+# Show only calibratable assets
+slcli asset list --calibratable
+
+# Advanced filter with API filter syntax
+slcli asset list \
+  --filter 'ModelName.Contains("PXI") and BusType = "PCI_PXI"'
+
+# Filter by workspace
+slcli asset list --workspace "Production"
+
+# JSON output (all results, no pagination)
+slcli asset list --model "DMM" --format json
+
+# Order by last updated
+slcli asset list --order-by LAST_UPDATED_TIMESTAMP --descending
+```
+
+**Options:**
+
+| Option                     | Type                | Default | Description                           |
+| -------------------------- | ------------------- | ------- | ------------------------------------- |
+| `--format/-f`              | Choice[table, json] | table   | Output format                         |
+| `--take/-t`                | int                 | 25      | Items per page (table)                |
+| `--model`                  | str                 | None    | Filter by model name (contains match) |
+| `--serial-number`          | str                 | None    | Filter by serial number (exact match) |
+| `--bus-type`               | Choice              | None    | Filter by bus type                    |
+| `--asset-type`             | Choice              | None    | Filter by asset type                  |
+| `--calibration-status`     | Choice              | None    | Filter by calibration status          |
+| `--connected`              | flag                | False   | Show only assets in connected systems |
+| `--calibratable`           | flag                | False   | Show only calibratable assets         |
+| `--workspace/-w`           | str                 | None    | Filter by workspace (name or ID)      |
+| `--filter`                 | str                 | None    | Advanced API filter expression        |
+| `--order-by`               | Choice              | None    | Sort field                            |
+| `--descending/--ascending` | flag                | True    | Sort direction                        |
+| `--summary`                | flag                | False   | Show summary statistics               |
+
+**Table Output Columns:**
+
+| Column        | Width | Source Field                                                   |
+| ------------- | ----- | -------------------------------------------------------------- |
+| Name          | 24    | `name`                                                         |
+| Model         | 20    | `modelName`                                                    |
+| Serial Number | 16    | `serialNumber`                                                 |
+| Bus Type      | 12    | `busType`                                                      |
+| Calibration   | 16    | `calibrationStatus`                                            |
+| Location      | 16    | `location.minionId` (truncated) or `location.physicalLocation` |
+| Workspace     | 16    | workspace name via `get_workspace_map()`                       |
+| ID            | 36    | `id`                                                           |
+
+**Implementation Notes:**
+
+- The Asset API uses **skip/take pagination** (not continuation tokens). Table output paginates interactively (25 per page, Y/n). JSON fetches all pages.
+- Convenience options (`--model`, `--serial-number`, etc.) are translated into the API's filter expression syntax: `ModelName.Contains("value")`, `SerialNumber = "value"`, etc.
+- The filter syntax uses `=`, `!=`, `.Contains()`, `!.Contains()`, `and`, `or` — different from Test Monitor's Dynamic LINQ `@0` substitutions. Document this clearly in `--help`.
+- `--connected` maps to filter: `Location.AssetState.SystemConnection = "CONNECTED" and Location.AssetState.AssetPresence = "PRESENT"`
+
+---
+
+### 2. `slcli asset get <id>`
+
+**Purpose:** Get detailed information about a specific asset
+
+**API Endpoint:** GET `/niapm/v1/assets/{assetId}`
+
+```bash
+# Get asset details in table format
+slcli asset get 69e95bf9-8b52-4e46-924b-abbd5ee19bbf
+
+# Get asset details in JSON format
+slcli asset get 69e95bf9-8b52-4e46-924b-abbd5ee19bbf --format json
+
+# Include calibration details
+slcli asset get 69e95bf9-8b52-4e46-924b-abbd5ee19bbf --include-calibration
+```
+
+**Options:**
+
+| Option                  | Type                | Default | Description                 |
+| ----------------------- | ------------------- | ------- | --------------------------- |
+| `--format/-f`           | Choice[table, json] | table   | Output format               |
+| `--include-calibration` | flag                | False   | Include calibration details |
+
+**Table Output (detailed view):**
+
+```
+Asset: NI PXIe-6368 (69e95bf9-8b52-4e46-924b-abbd5ee19bbf)
+Model: NI PXIe-6368
+Serial Number: 01BB877A
+Part Number: A1234 B5
+Vendor: NI
+Bus Type: PCI_PXI
+Asset Type: GENERIC
+Firmware: A1
+Hardware: 12A
+Workspace: Production (846e294a-a007-47ac-9fc2-fac07eab240e)
+Location: NI_PXIe-8135_Embedded_Controller (Slot 2)
+Presence: PRESENT
+System Connection: CONNECTED
+Calibration Status: OK
+Last Calibrated: 2025-06-15
+Next Due: 2026-06-15
+Keywords: Keyword1, Keyword2
+Properties:
+  Key1: Value1
+```
+
+**Implementation Notes:**
+
+- `--include-calibration`: Fetches GET `/niapm/v1/assets/{assetId}/history/calibration` and appends history entries
+- Location display: Show `minionId` or `physicalLocation`, whichever is populated, plus `slotNumber` if present
+- Calibration display: Show `calibrationStatus`, last calibration date, next due date
+- Use `isinstance()` checks for nested objects (location, calibration) — they may be null
+
+---
+
+### 3. `slcli asset summary`
+
+**Purpose:** Get fleet-wide asset summary statistics
+
+**API Endpoint:** GET `/niapm/v1/asset-summary`
+
+```bash
+# Show asset summary in table format
+slcli asset summary
+
+# Show summary in JSON format
+slcli asset summary --format json
+```
+
+**Options:**
+
+| Option        | Type                | Default | Description   |
+| ------------- | ------------------- | ------- | ------------- |
+| `--format/-f` | Choice[table, json] | table   | Output format |
+
+**Table Output:**
+
+```
+Asset Fleet Summary:
+  Total Assets: 17
+  Active (in connected system): 12
+  Not Active: 5
+  In Use: 10
+  Not In Use: 7
+  With Alarms: 3
+
+Calibration Status:
+  Approaching Due Date: 3
+  Past Due Date: 4
+  Out for Calibration: 2
+  Total Calibratable: 7
+```
+
+**Implementation Notes:**
+
+- This is a simple single-endpoint command — no pagination needed
+- The `AssetSummaryResponse` returns all fields in one call
+- Useful for AI agents to quickly assess fleet health
+
+---
+
+### 4. `slcli asset calibration <asset-id>`
+
+**Purpose:** Get calibration history for a specific asset
+
+**API Endpoint:** GET `/niapm/v1/assets/{assetId}/history/calibration`
+
+```bash
+# Show calibration history
+slcli asset calibration 69e95bf9-8b52-4e46-924b-abbd5ee19bbf
+
+# JSON output
+slcli asset calibration 69e95bf9-8b52-4e46-924b-abbd5ee19bbf --format json
+
+# Limit results
+slcli asset calibration 69e95bf9-8b52-4e46-924b-abbd5ee19bbf --take 10
+```
+
+**Options:**
+
+| Option        | Type                | Default | Description               |
+| ------------- | ------------------- | ------- | ------------------------- |
+| `--format/-f` | Choice[table, json] | table   | Output format             |
+| `--take/-t`   | int                 | 25      | Number of history entries |
+
+**Table Output Columns:**
+
+| Column        | Width | Source Field                   |
+| ------------- | ----- | ------------------------------ |
+| Date          | 20    | `date`                         |
+| Type          | 12    | `entryType` (AUTOMATIC/MANUAL) |
+| Limited       | 8     | `isLimited`                    |
+| Next Due      | 20    | `resolvedDueDate`              |
+| Interval (mo) | 14    | `recommendedInterval`          |
+| Comments      | 30    | `comments`                     |
+
+**Implementation Notes:**
+
+- Uses skip/take pagination on the calibration history endpoint
+- `CalibrationHistoryResponse` returns an array of `CalibrationHistoryModel` entries
+- Temperature sensor data available but not shown in table by default (included in JSON)
+
+---
+
+### 5. `slcli asset location-history <asset-id>`
+
+**Purpose:** Get location/connection history for a specific asset (supports temporal correlation for Workflow 2)
+
+**API Endpoint:** POST `/niapm/v1/assets/{assetId}/history/query-location`
+
+```bash
+# Show location history
+slcli asset location-history 69e95bf9-8b52-4e46-924b-abbd5ee19bbf
+
+# Filter by date range (for temporal correlation)
+slcli asset location-history 69e95bf9-8b52-4e46-924b-abbd5ee19bbf \
+  --from "2025-12-01T00:00:00Z" \
+  --to "2025-12-02T00:00:00Z"
+
+# JSON output
+slcli asset location-history 69e95bf9-8b52-4e46-924b-abbd5ee19bbf --format json
+```
+
+**Options:**
+
+| Option        | Type                | Default | Description               |
+| ------------- | ------------------- | ------- | ------------------------- |
+| `--format/-f` | Choice[table, json] | table   | Output format             |
+| `--take/-t`   | int                 | 25      | Number of history entries |
+| `--from`      | str (ISO-8601)      | None    | Start of date range       |
+| `--to`        | str (ISO-8601)      | None    | End of date range         |
+
+**Table Output Columns:**
+
+| Column     | Width | Source Field                 |
+| ---------- | ----- | ---------------------------- |
+| Timestamp  | 24    | timestamp from history entry |
+| Minion ID  | 30    | `minionId`                   |
+| Slot       | 6     | `slotNumber`                 |
+| Connection | 14    | `systemConnection`           |
+| Presence   | 12    | `assetPresence`              |
+
+**Implementation Notes:**
+
+- This is a POST endpoint with `QueryLocationHistoryRequest` body
+- Returns `ConnectionHistoryResponse` with a list of `ConnectionHistoryModel` entries
+- Critical for Workflow 2: confirming an asset was present in a system at the time of a test
+- Date filtering is handled server-side in the request body
+
+---
+
+## Rationale for Simplified Structure
+
+### 1. Aligns with API Structure
+
+The Asset Management API v1 is organized around a **single primary entity** (assets) with related sub-resources:
+
+- **Assets** — core entity with rich properties (model, serial, location, calibration)
+- **Calibration History** — sub-resource of an asset
+- **Location History** — sub-resource of an asset
+- **Utilization History** — sub-resource of an asset (Phase 2)
+
+This supports a flat command group (like `file`, `tag`) rather than nested groups (like `testmonitor`).
+
+### 2. Matches User Mental Model
+
+Users think in terms of:
+
+- "What assets do I have?" → `asset list`
+- "Show me details of this asset" → `asset get`
+- "What's the calibration status?" → `asset summary` or `asset calibration <id>`
+- "Was this DMM in that system during testing?" → `asset location-history <id> --from --to`
+
+They don't think:
+
+- "Query asset location moves" (too API-specific)
+- "Search materialized assets" (implementation detail)
+- "Start/end utilization" (API operation, not user workflow)
+
+### 3. Reduces Command Explosion
+
+Workflow analysis proposes:
+
+- `asset query` (generic query)
+- `asset find-systems` (cross-service)
+- `asset query-for-test` (cross-service)
+- `asset location-history` (history)
+- `system find --has-asset` (cross-service)
+- `system query-by-assets` (cross-service)
+  = **6+ new commands across groups**
+
+Our proposal:
+
+- `asset list` (with rich filtering)
+- `asset get` (detailed view)
+- `asset summary` (fleet overview)
+- `asset calibration` (calibration history)
+- `asset location-history` (location tracking)
+  = **5 focused commands in one group**
+
+### 4. Follows Established slcli Patterns
+
+Similar commands in slcli:
+
+```bash
+# File service — single group, simple verbs
+slcli file list
+slcli file get <id>
+slcli file upload
+
+# Tag service — single group
+slcli tag list
+slcli tag get <path>
+slcli tag create
+
+# Workspace service — single group
+slcli workspace list
+slcli workspace get --workspace <name-or-id>
+```
+
+We follow this pattern:
+
+```bash
+slcli asset list
+slcli asset get <id>
+slcli asset summary
+slcli asset calibration <id>
+slcli asset location-history <id>
+```
+
+---
+
+## Addressing Specific Workflow Requirements
+
+### Workflow 2: "What was the SN of the PXI-4071 used to measure DUT SN 1234567?"
+
+**Using proposed commands (AI agent orchestration):**
+
+```bash
+# Step 1: Find the test result to get systemId
+slcli testmonitor result list \
+  --serial-number "1234567" \
+  --format json
+# → Extract systemId from result
+
+# Step 2: Find PXI-4071 assets on that system
+slcli asset list \
+  --filter 'Location.MinionId = "<minion-id>" and ModelName.Contains("PXI-4071")' \
+  --format json
+# → Get asset serial number
+
+# Step 3 (optional): Verify asset was present during test
+slcli asset location-history <asset-id> \
+  --from "2025-12-01T10:00:00Z" \
+  --to "2025-12-01T11:00:00Z" \
+  --format json
+# → Confirm PRESENT + CONNECTED at test time
+```
+
+**Why this works:** Copilot can chain these three commands and correlate the results. No specialized cross-service command needed.
+
+---
+
+### Workflow 4: "Find me a system that has a DMM and a scope"
+
+**Using proposed commands (AI agent orchestration):**
+
+```bash
+# Step 1: Find DMMs in connected systems
+slcli asset list \
+  --model "DMM" \
+  --connected \
+  --format json
+# → Collect minionIds: ["minion-A", "minion-B", "minion-C"]
+
+# Step 2: Find scopes in connected systems
+slcli asset list \
+  --model "scope" \
+  --connected \
+  --format json
+# → Collect minionIds: ["minion-B", "minion-D"]
+
+# Step 3: Intersection → minion-B has both
+# Copilot computes this client-side and presents the result
+```
+
+**Why this works:** The `--model` convenience filter with `--connected` flag makes each query simple. Copilot excels at set intersection logic.
+
+---
+
+## API Requirements
+
+### Existing APIs (Available Now)
+
+**Asset CRUD:**
+
+- ✅ GET `/niapm/v1/assets` — Get assets (query params: Skip, Take, CalibratableOnly, ReturnCount)
+- ✅ POST `/niapm/v1/query-assets` — Query assets with filter expression
+- ✅ GET `/niapm/v1/assets/{assetId}` — Get single asset by ID
+- ✅ POST `/niapm/v1/assets` — Create assets (Phase 2)
+- ✅ POST `/niapm/v1/update-assets` — Update assets (Phase 2)
+- ✅ POST `/niapm/v1/delete-assets` — Delete assets (Phase 2)
+
+**Summary:**
+
+- ✅ GET `/niapm/v1/asset-summary` — Get fleet summary statistics
+
+**Calibration:**
+
+- ✅ GET `/niapm/v1/assets/{assetId}/history/calibration` — Get calibration history
+- ✅ POST `/niapm/v1/assets/{assetId}/history/delete-calibrations` — Delete calibration entries (Phase 2)
+- ✅ POST `/niapm/v1/assets/send-for-calibration` — Send for calibration (Phase 2)
+- ✅ POST `/niapm/v1/assets/receive-from-calibration` — Receive from calibration (Phase 2)
+
+**Location:**
+
+- ✅ POST `/niapm/v1/assets/{assetId}/history/query-location` — Query location history
+- ✅ POST `/niapm/v1/assets/move-location` — Move asset location (Phase 2)
+- ✅ POST `/niapm/v1/assets/query-location-moves` — Query pending moves (Phase 2)
+
+**Search (Materialized):**
+
+- ✅ POST `/niapm/v1/materialized/search-assets` — Advanced search with projection support
+
+**Utilization:**
+
+- ✅ POST `/niapm/v1/query-asset-utilization-history` — Query utilization history
+- ✅ POST `/niapm/v1/assets/start-utilization` — Start utilization (Phase 2)
+- ✅ POST `/niapm/v1/assets/end-utilization` — End utilization (Phase 2)
+
+### Implementation Notes
+
+**For `asset list` (query-assets):**
+
+- POST `/niapm/v1/query-assets` with `QueryAssetsRequest` body
+- Supports rich filter expressions: `ModelName.Contains("PXI")`, `SerialNumber = "01BB"`, etc.
+- Pagination via `skip`/`take` (max take=1000)
+- Order by `LAST_UPDATED_TIMESTAMP` or `ID`
+- `returnCount=true` to get total matching assets
+- **Filter syntax** differs from Test Monitor (no `@0` substitutions) — uses `.Contains()`, `=`, `!=`, `and`, `or`
+
+**For `asset list --connected`:**
+
+- Translates to filter: `Location.AssetState.SystemConnection = "CONNECTED" and Location.AssetState.AssetPresence = "PRESENT"`
+- Merged with any user `--filter` using `and`
+
+**For `asset list --model`:**
+
+- Translates to filter: `ModelName.Contains("<value>")`
+- Uses `.Contains()` for partial matching (users may search "DMM", "4071", "PXI-4071")
+
+**For `asset summary`:**
+
+- GET `/niapm/v1/asset-summary` — single endpoint, no pagination
+- Returns: total, active, notActive, inUse, notInUse, withAlarms, calibration breakdown
+
+**For `asset calibration`:**
+
+- GET `/niapm/v1/assets/{assetId}/history/calibration` with Skip/Take params
+- Returns `CalibrationHistoryResponse` with entries and totalCount
+
+**For `asset location-history`:**
+
+- POST `/niapm/v1/assets/{assetId}/history/query-location` with date range in body
+- Returns `ConnectionHistoryResponse` with location/connection events
+
+### No New APIs Required
+
+All proposed commands can be implemented using existing Asset Management v1 APIs.
+
+---
+
+## Implementation Priority
+
+### Phase 1: Core Commands (Initial PR)
+
+- 🔨 `slcli asset list` — with filter, model, serial-number, bus-type, connected, calibratable, workspace, order-by, summary
+- 🔨 `slcli asset get <id>` — detailed view with optional calibration include
+- 🔨 `slcli asset summary` — fleet statistics
+
+### Phase 2: History Commands
+
+- 🔨 `slcli asset calibration <id>` — calibration history with pagination
+- 🔨 `slcli asset location-history <id>` — location history with date range filtering
+
+### Phase 3: Mutation Commands
+
+- 🔨 `slcli asset create` — create assets (with `check_readonly_mode()`)
+- 🔨 `slcli asset update` — update asset properties
+- 🔨 `slcli asset delete` — delete assets (with confirmation, `--force`)
+
+### Phase 4: Advanced Features
+
+- 🔨 `slcli asset utilization <id>` — utilization history
+- 🔨 `slcli asset move-location` — move assets between systems/locations
+- 🔨 `slcli asset send-for-calibration` — calibration workflow
+- 🔨 `slcli asset receive-from-calibration` — calibration workflow
+- 🔨 `slcli asset export` — export to CSV/file service
+
+---
+
+## Implementation Checklist
+
+### Module Structure
+
+```
+slcli/
+├── asset_click.py          # Command module (register_asset_commands)
+└── ...
+
+tests/unit/
+├── test_asset_click.py     # Unit tests
+└── ...
+```
+
+### Requirements (per copilot-instructions.md)
+
+- [ ] Create `slcli/asset_click.py` with `register_asset_commands(cli: Any) -> None`
+- [ ] Register in `slcli/main.py`
+- [ ] All functions have complete type annotations
+- [ ] Use `UniversalResponseHandler` for list/get responses
+- [ ] Use `handle_api_error()` for error handling
+- [ ] Use `format_success()` for success messages
+- [ ] Use `check_readonly_mode()` for mutation commands (Phase 3)
+- [ ] All list commands support `--format/-f` (table/json)
+- [ ] All list commands support `--take/-t` with default 25
+- [ ] Table output with interactive pagination (Y/n)
+- [ ] JSON output fetches all results (no pagination)
+- [ ] Exit codes use `ExitCodes` enum
+- [ ] Unit tests in `tests/unit/test_asset_click.py`
+- [ ] Coverage ≥ 80% for new code
+- [ ] Linting passes: `poetry run ni-python-styleguide lint`
+- [ ] Type checking passes: `poetry run mypy slcli tests`
+- [ ] README.md updated with usage examples
+
+### Pagination Strategy
+
+The Asset API uses **skip/take** pagination (not continuation tokens like Test Monitor). Implementation approach:
+
+```python
+def _query_all_assets(
+    filter_expr: Optional[str],
+    order_by: Optional[str],
+    descending: bool,
+    take: Optional[int] = 10000,
+    calibratable_only: bool = False,
+) -> List[Dict[str, Any]]:
+    """Query assets using skip/take pagination."""
+    url = f"{_get_asset_base_url()}/query-assets"
+    all_assets: List[Dict[str, Any]] = []
+    page_size = 1000  # API max per request
+    skip = 0
+
+    while True:
+        if take is not None:
+            remaining = take - len(all_assets)
+            if remaining <= 0:
+                break
+            batch_size = min(page_size, remaining)
+        else:
+            batch_size = page_size
+
+        payload: Dict[str, Any] = {
+            "skip": skip,
+            "take": batch_size,
+            "descending": descending,
+            "returnCount": True,
+        }
+
+        if filter_expr:
+            payload["filter"] = filter_expr
+        if order_by:
+            payload["orderBy"] = order_by
+        if calibratable_only:
+            payload["calibratableOnly"] = True
+
+        resp = make_api_request("POST", url, payload=payload)
+        data = resp.json()
+        assets = data.get("assets", []) if isinstance(data, dict) else []
+
+        all_assets.extend(assets)
+        skip += len(assets)
+
+        # Stop if we got fewer than requested (last page)
+        if len(assets) < batch_size:
+            break
+        if take is not None and len(all_assets) >= take:
+            break
+
+    return all_assets[:take] if take is not None else all_assets
+```
+
+For interactive table pagination, use `_fetch_assets_page()` with skip/take:
+
+```python
+def _fetch_assets_page(
+    filter_expr: Optional[str],
+    order_by: Optional[str],
+    descending: bool,
+    take: int,
+    skip: int,
+    calibratable_only: bool = False,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Fetch a single page of assets. Returns (assets, total_count)."""
+    # ... similar to above but single page
+```
+
+### Filter Expression Builder
+
+Convenience options are translated to API filter syntax:
+
+```python
+def _build_asset_filter(
+    model: Optional[str] = None,
+    serial_number: Optional[str] = None,
+    bus_type: Optional[str] = None,
+    asset_type: Optional[str] = None,
+    calibration_status: Optional[str] = None,
+    connected: bool = False,
+    custom_filter: Optional[str] = None,
+) -> Optional[str]:
+    """Build API filter expression from convenience options."""
+    parts: List[str] = []
+
+    if model:
+        parts.append(f'ModelName.Contains("{model}")')
+    if serial_number:
+        parts.append(f'SerialNumber = "{serial_number}"')
+    if bus_type:
+        parts.append(f'BusType = "{bus_type}"')
+    if asset_type:
+        parts.append(f'AssetType = "{asset_type}"')
+    if calibration_status:
+        parts.append(f'CalibrationStatus = "{calibration_status}"')
+    if connected:
+        parts.append(
+            'Location.AssetState.SystemConnection = "CONNECTED"'
+            ' and Location.AssetState.AssetPresence = "PRESENT"'
+        )
+    if custom_filter:
+        parts.append(custom_filter)
+
+    return " and ".join(parts) if parts else None
+```
+
+**Note:** Unlike Test Monitor's Dynamic LINQ with `@0` substitutions, the Asset API uses direct string values in the filter. Input validation should sanitize user values to prevent filter injection (escape quotes in user-provided strings).
+
+---
+
+## Comparison Table
+
+| Capability                | Workflow Analysis               | This Proposal                                   | Assessment             |
+| ------------------------- | ------------------------------- | ----------------------------------------------- | ---------------------- |
+| List/query assets         | `asset query`                   | `asset list`                                    | ✅ Consistent naming   |
+| Get asset details         | `asset get <id>`                | `asset get <id>`                                | ✅ Equivalent          |
+| Find assets by model      | custom commands                 | `asset list --model`                            | ✅ Simpler             |
+| Find assets by system     | `asset query --filter minionId` | `asset list --filter 'Location.MinionId = ...'` | ✅ Equivalent          |
+| Connected assets          | custom flag                     | `asset list --connected`                        | ✅ Cleaner             |
+| Fleet summary             | not proposed                    | `asset summary`                                 | ✅ Added value         |
+| Calibration history       | not proposed                    | `asset calibration <id>`                        | ✅ Added value         |
+| Location history          | `asset location-history`        | `asset location-history <id>`                   | ✅ Equivalent          |
+| Cross-service correlation | specialized commands            | AI agent orchestration                          | ✅ More composable     |
+| Find systems by assets    | `system find --has-asset`       | two `asset list` queries                        | ✅ No new abstractions |
+| Total commands            | 6+ across groups                | 5 in one group                                  | ✅ Fewer commands      |
+
+---
+
+## Key Design Decisions
+
+### 1. Filter Syntax Documentation
+
+The Asset API uses a **different filter syntax** than Test Monitor:
+
+- **Asset API:** `ModelName.Contains("PXI") and BusType = "PCI_PXI"`
+- **Test Monitor:** `name == @0` with substitutions
+
+This should be clearly documented in `--help` text and README. Consider adding a `--help-filter` flag or documenting common filter examples.
+
+### 2. No Parameterized Queries
+
+The Asset API does not support `@0`-style substitutions. User-provided filter values are embedded directly in the filter string. **Input sanitization is required** — escape double quotes in user-provided values for `--model`, `--serial-number`, etc. to prevent filter injection.
+
+### 3. Skip/Take vs Continuation Tokens
+
+The Asset API uses skip/take, which is simpler but has known issues with large datasets (skip-based pagination can miss or duplicate items if data changes during pagination). For interactive table output, this is acceptable. For JSON "fetch all" mode, it's good enough given the 10k safety cap.
+
+### 4. Summary Command
+
+The `asset summary` command is a lightweight addition that provides significant value for AI agents assessing fleet health without needing to paginate through all assets.
+
+### 5. Materialized Search API
+
+The API also offers POST `/niapm/v1/materialized/search-assets` with projection support. This could be used as an optimization for `asset list` when only specific fields are needed, but the standard `query-assets` endpoint is sufficient for Phase 1.

--- a/slcli/asset_click.py
+++ b/slcli/asset_click.py
@@ -1,0 +1,1241 @@
+"""CLI commands for managing SystemLink assets.
+
+Provides CLI commands for listing, querying, and managing assets in the
+Asset Management service (niapm v1). Supports filtering by model, serial
+number, bus type, asset type, calibration status, and connection state.
+"""
+
+import json
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+import click
+
+from .cli_utils import validate_output_format
+from .universal_handlers import FilteredResponse, UniversalResponseHandler
+from .utils import (
+    ExitCodes,
+    check_readonly_mode,
+    format_success,
+    get_base_url,
+    get_workspace_map,
+    handle_api_error,
+    make_api_request,
+)
+from .workspace_utils import get_workspace_display_name, resolve_workspace_filter
+
+
+def _get_asset_base_url() -> str:
+    """Get the base URL for the Asset Management API."""
+    return f"{get_base_url()}/niapm/v1"
+
+
+def _escape_filter_value(value: str) -> str:
+    """Escape double quotes in filter values to prevent injection.
+
+    Args:
+        value: Raw filter value from user input.
+
+    Returns:
+        Escaped value safe for embedding in filter expressions.
+    """
+    return value.replace('"', '\\"')
+
+
+def _parse_properties(properties: Tuple[str, ...]) -> Dict[str, str]:
+    """Parse key=value property strings into a dictionary.
+
+    Args:
+        properties: Tuple of strings in "key=value" format.
+
+    Returns:
+        Dictionary mapping property keys to values.
+
+    Raises:
+        SystemExit: If any property string is not in key=value format.
+    """
+    props_dict: Dict[str, str] = {}
+    for prop in properties:
+        if "=" not in prop:
+            click.echo(
+                f"✗ Invalid property format: {prop}. Use key=value",
+                err=True,
+            )
+            sys.exit(ExitCodes.INVALID_INPUT)
+        key, val = prop.split("=", 1)
+        props_dict[key.strip()] = val.strip()
+    return props_dict
+
+
+def _build_asset_filter(
+    model: Optional[str] = None,
+    serial_number: Optional[str] = None,
+    bus_type: Optional[str] = None,
+    asset_type: Optional[str] = None,
+    calibration_status: Optional[str] = None,
+    connected: bool = False,
+    workspace_id: Optional[str] = None,
+    custom_filter: Optional[str] = None,
+) -> Optional[str]:
+    """Build API filter expression from convenience options.
+
+    Args:
+        model: Filter by model name (contains match).
+        serial_number: Filter by serial number (exact match).
+        bus_type: Filter by bus type.
+        asset_type: Filter by asset type.
+        calibration_status: Filter by calibration status.
+        connected: Show only connected/present assets.
+        workspace_id: Filter by workspace ID.
+        custom_filter: Advanced user-provided filter expression.
+
+    Returns:
+        Combined filter expression string, or None if no filters.
+    """
+    parts: List[str] = []
+
+    if model:
+        escaped = _escape_filter_value(model)
+        parts.append(f'ModelName.Contains("{escaped}")')
+    if serial_number:
+        escaped = _escape_filter_value(serial_number)
+        parts.append(f'SerialNumber = "{escaped}"')
+    if bus_type:
+        parts.append(f'BusType = "{bus_type}"')
+    if asset_type:
+        parts.append(f'AssetType = "{asset_type}"')
+    if calibration_status:
+        parts.append(f'CalibrationStatus = "{calibration_status}"')
+    if connected:
+        parts.append(
+            'Location.AssetState.SystemConnection = "CONNECTED"'
+            ' and Location.AssetState.AssetPresence = "PRESENT"'
+        )
+    if workspace_id:
+        escaped = _escape_filter_value(workspace_id)
+        parts.append(f'Workspace = "{escaped}"')
+    if custom_filter:
+        parts.append(custom_filter)
+
+    return " and ".join(parts) if parts else None
+
+
+def _query_all_assets(
+    filter_expr: Optional[str],
+    order_by: Optional[str],
+    descending: bool,
+    take: Optional[int] = 10000,
+    calibratable_only: bool = False,
+) -> List[Dict[str, Any]]:
+    """Query assets using skip/take pagination.
+
+    Fetches up to ``take`` items (default 10,000 for performance).
+
+    Args:
+        filter_expr: Optional API filter expression.
+        order_by: Field to order by.
+        descending: Whether to return results in descending order.
+        take: Maximum number of items to fetch.
+        calibratable_only: Only return calibratable assets.
+
+    Returns:
+        List of asset objects (up to ``take`` count).
+    """
+    url = f"{_get_asset_base_url()}/query-assets"
+    all_assets: List[Dict[str, Any]] = []
+    page_size = 1000  # API max per request
+    skip = 0
+
+    while True:
+        if take is not None:
+            remaining = take - len(all_assets)
+            if remaining <= 0:
+                break
+            batch_size = min(page_size, remaining)
+        else:
+            batch_size = page_size
+
+        payload: Dict[str, Any] = {
+            "skip": skip,
+            "take": batch_size,
+            "descending": descending,
+            "returnCount": True,
+        }
+
+        if filter_expr:
+            payload["filter"] = filter_expr
+        if order_by:
+            payload["orderBy"] = order_by
+        if calibratable_only:
+            payload["calibratableOnly"] = True
+
+        resp = make_api_request("POST", url, payload=payload)
+        data = resp.json()
+        assets = data.get("assets", []) if isinstance(data, dict) else []
+
+        all_assets.extend(assets)
+        skip += len(assets)
+
+        # Stop if we got fewer than requested (last page)
+        if len(assets) < batch_size:
+            break
+        if take is not None and len(all_assets) >= take:
+            break
+
+    return all_assets[:take] if take is not None else all_assets
+
+
+def _fetch_assets_page(
+    filter_expr: Optional[str],
+    order_by: Optional[str],
+    descending: bool,
+    take: int,
+    skip: int,
+    calibratable_only: bool = False,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Fetch a single page of assets.
+
+    Args:
+        filter_expr: Optional API filter expression.
+        order_by: Field to order by.
+        descending: Whether to return results in descending order.
+        take: Number of items to fetch.
+        skip: Number of items to skip.
+        calibratable_only: Only return calibratable assets.
+
+    Returns:
+        Tuple of (assets list, total count from server).
+    """
+    url = f"{_get_asset_base_url()}/query-assets"
+    payload: Dict[str, Any] = {
+        "skip": skip,
+        "take": take,
+        "descending": descending,
+        "returnCount": True,
+    }
+
+    if filter_expr:
+        payload["filter"] = filter_expr
+    if order_by:
+        payload["orderBy"] = order_by
+    if calibratable_only:
+        payload["calibratableOnly"] = True
+
+    resp = make_api_request("POST", url, payload=payload)
+    data = resp.json()
+
+    assets = data.get("assets", []) if isinstance(data, dict) else []
+    total_count = data.get("totalCount", 0) if isinstance(data, dict) else 0
+
+    return assets, total_count
+
+
+def _handle_asset_interactive_pagination(
+    filter_expr: Optional[str],
+    order_by: Optional[str],
+    descending: bool,
+    take: int,
+    calibratable_only: bool,
+    formatter_func: Any,
+    headers: List[str],
+    column_widths: List[int],
+    empty_message: str,
+) -> None:
+    """Handle interactive skip/take pagination for table output.
+
+    Args:
+        filter_expr: Optional API filter expression.
+        order_by: Field to order by.
+        descending: Whether to return results in descending order.
+        take: Number of items per page.
+        calibratable_only: Only return calibratable assets.
+        formatter_func: Function to format each item for display.
+        headers: Column headers for the table.
+        column_widths: Column widths for the table.
+        empty_message: Message to display when no items are found.
+    """
+    skip = 0
+    shown_count = 0
+
+    while True:
+        page_items, total_count = _fetch_assets_page(
+            filter_expr, order_by, descending, take, skip, calibratable_only
+        )
+
+        if not page_items:
+            if shown_count == 0:
+                click.echo(empty_message)
+            break
+
+        shown_count += len(page_items)
+        skip += len(page_items)
+
+        mock_resp: Any = FilteredResponse({"assets": page_items})
+        UniversalResponseHandler.handle_list_response(
+            resp=mock_resp,
+            data_key="assets",
+            item_name="asset",
+            format_output="table",
+            formatter_func=formatter_func,
+            headers=headers,
+            column_widths=column_widths,
+            empty_message=empty_message,
+            enable_pagination=False,
+            page_size=take,
+            total_count=total_count,
+            shown_count=shown_count,
+        )
+
+        # Flush stdout so the table is visible before prompting
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+
+        # Check if there are more results
+        if shown_count >= total_count:
+            break
+
+        if not click.confirm("Show next set of results?", default=True):
+            break
+
+
+def _warn_if_large_dataset(
+    filter_expr: Optional[str],
+    calibratable_only: bool = False,
+) -> None:
+    """Check dataset size and warn user if fetching large number of items.
+
+    Args:
+        filter_expr: Optional API filter expression.
+        calibratable_only: Only count calibratable assets.
+    """
+    url = f"{_get_asset_base_url()}/query-assets"
+    payload: Dict[str, Any] = {
+        "skip": 0,
+        "take": 1,
+        "returnCount": True,
+    }
+
+    if filter_expr:
+        payload["filter"] = filter_expr
+    if calibratable_only:
+        payload["calibratableOnly"] = True
+
+    try:
+        resp = make_api_request("POST", url, payload=payload)
+        data = resp.json()
+        total_count = data.get("totalCount", 0) if isinstance(data, dict) else 0
+
+        if total_count > 10000:
+            click.echo(
+                f"⚠️  Warning: {total_count} items found. Fetching up to 10,000...",
+                err=True,
+            )
+        elif total_count > 1000:
+            click.echo(
+                f"ℹ️  Fetching {total_count} items...",
+                err=True,
+            )
+    except Exception:
+        pass
+
+
+def _get_asset_location_display(asset: Dict[str, Any]) -> str:
+    """Get a display string for an asset's location.
+
+    Args:
+        asset: Asset dictionary.
+
+    Returns:
+        Location display string.
+    """
+    location = asset.get("location")
+    if not isinstance(location, dict):
+        return ""
+
+    minion_id = location.get("minionId", "")
+    physical = location.get("physicalLocation", "")
+    slot = location.get("slotNumber")
+
+    display = minion_id or physical
+    if slot is not None:
+        display = f"{display} (Slot {slot})" if display else f"Slot {slot}"
+
+    return display
+
+
+def _format_asset_detail(asset: Dict[str, Any], workspace_map: Dict[str, str]) -> None:
+    """Format and display detailed asset information.
+
+    Args:
+        asset: Asset dictionary.
+        workspace_map: Workspace ID to name mapping.
+    """
+    name = asset.get("name", "Unknown")
+    asset_id = asset.get("id", "")
+    click.echo(f"Asset: {name} ({asset_id})")
+    click.echo(f"  Model: {asset.get('modelName', 'N/A')}")
+    click.echo(f"  Serial Number: {asset.get('serialNumber', 'N/A')}")
+    click.echo(f"  Part Number: {asset.get('partNumber', 'N/A')}")
+    click.echo(f"  Vendor: {asset.get('vendorName', 'N/A')}")
+    click.echo(f"  Bus Type: {asset.get('busType', 'N/A')}")
+    click.echo(f"  Asset Type: {asset.get('assetType', 'N/A')}")
+    click.echo(f"  Firmware: {asset.get('firmwareVersion', 'N/A')}")
+    click.echo(f"  Hardware: {asset.get('hardwareVersion', 'N/A')}")
+
+    # Workspace
+    ws_id = asset.get("workspace", "")
+    ws_name = get_workspace_display_name(ws_id, workspace_map)
+    click.echo(f"  Workspace: {ws_name} ({ws_id})")
+
+    # Location
+    location = asset.get("location")
+    if isinstance(location, dict):
+        loc_display = _get_asset_location_display(asset)
+        click.echo(f"  Location: {loc_display}")
+
+        state = location.get("state")
+        if isinstance(state, dict):
+            click.echo(f"  Presence: {state.get('assetPresence', 'N/A')}")
+            click.echo(f"  System Connection: {state.get('systemConnection', 'N/A')}")
+
+    # Calibration
+    click.echo(f"  Calibration Status: {asset.get('calibrationStatus', 'N/A')}")
+
+    ext_cal = asset.get("externalCalibration")
+    if isinstance(ext_cal, dict):
+        click.echo(f"  Last Calibrated: {ext_cal.get('date', 'N/A')}")
+        click.echo(f"  Next Due: {ext_cal.get('nextRecommendedDate', 'N/A')}")
+
+    # Keywords
+    keywords = asset.get("keywords")
+    if keywords and isinstance(keywords, list):
+        click.echo(f"  Keywords: {', '.join(str(k) for k in keywords)}")
+
+    # Properties
+    properties = asset.get("properties")
+    if properties and isinstance(properties, dict):
+        click.echo("  Properties:")
+        for key, value in properties.items():
+            click.echo(f"    {key}: {value}")
+
+
+def register_asset_commands(cli: Any) -> None:
+    """Register the 'asset' command group and its subcommands.
+
+    Args:
+        cli: Click CLI group to register commands on.
+    """
+
+    @cli.group()
+    def asset() -> None:
+        """Manage SystemLink assets.
+
+        Query, inspect, and manage hardware assets tracked by the Asset
+        Management service.  Supports filtering by model, serial number, bus
+        type, calibration status, and connection state.
+
+        Filter syntax uses the Asset API expression language:
+          ModelName.Contains("PXI"), SerialNumber = "01BB877A",
+          BusType = "PCI_PXI", and/or operators.
+        """
+
+    # ------------------------------------------------------------------
+    # Phase 1: list, get, summary
+    # ------------------------------------------------------------------
+
+    @asset.command(name="list")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--take",
+        "-t",
+        type=int,
+        default=25,
+        show_default=True,
+        help="Items per page (table output only)",
+    )
+    @click.option("--model", help="Filter by model name (contains match)")
+    @click.option("--serial-number", help="Filter by serial number (exact match)")
+    @click.option(
+        "--bus-type",
+        type=click.Choice(
+            ["BUILT_IN_SYSTEM", "PCI_PXI", "USB", "GPIB", "VXI", "SERIAL", "TCP_IP", "CRIO"],
+            case_sensitive=True,
+        ),
+        help="Filter by bus type",
+    )
+    @click.option(
+        "--asset-type",
+        type=click.Choice(
+            ["GENERIC", "DEVICE_UNDER_TEST", "FIXTURE", "SYSTEM"],
+            case_sensitive=True,
+        ),
+        help="Filter by asset type",
+    )
+    @click.option(
+        "--calibration-status",
+        type=click.Choice(
+            [
+                "OK",
+                "APPROACHING_RECOMMENDED_DUE_DATE",
+                "PAST_RECOMMENDED_DUE_DATE",
+                "OUT_FOR_CALIBRATION",
+            ],
+            case_sensitive=True,
+        ),
+        help="Filter by calibration status",
+    )
+    @click.option(
+        "--connected",
+        is_flag=True,
+        help="Show only assets in connected systems (CONNECTED + PRESENT)",
+    )
+    @click.option(
+        "--calibratable",
+        is_flag=True,
+        help="Show only calibratable assets",
+    )
+    @click.option("--workspace", "-w", help="Filter by workspace name or ID")
+    @click.option(
+        "--filter",
+        "filter_query",
+        help=(
+            "Advanced API filter expression "
+            '(e.g., \'ModelName.Contains("PXI") and BusType = "PCI_PXI"\')'
+        ),
+    )
+    @click.option(
+        "--order-by",
+        type=click.Choice(["LAST_UPDATED_TIMESTAMP", "ID"], case_sensitive=False),
+        help="Order by field",
+    )
+    @click.option(
+        "--descending/--ascending",
+        default=True,
+        help="Sort order (default: descending)",
+    )
+    @click.option(
+        "--summary",
+        is_flag=True,
+        help="Show summary statistics instead of listing assets",
+    )
+    def list_assets(
+        format: str,
+        take: int,
+        model: Optional[str],
+        serial_number: Optional[str],
+        bus_type: Optional[str],
+        asset_type: Optional[str],
+        calibration_status: Optional[str],
+        connected: bool,
+        calibratable: bool,
+        workspace: Optional[str],
+        filter_query: Optional[str],
+        order_by: Optional[str],
+        descending: bool,
+        summary: bool,
+    ) -> None:
+        """List and query assets with optional filtering.
+
+        Supports convenience filters (--model, --serial-number, --bus-type,
+        etc.) that are translated to API filter expressions.  Combine multiple
+        options — they are joined with 'and'.
+
+        For advanced queries use --filter with the Asset API filter syntax:
+        ModelName.Contains("PXI") and BusType = "PCI_PXI"
+        """
+        format_output = validate_output_format(format)
+
+        try:
+            # Resolve workspace if provided
+            workspace_id: Optional[str] = None
+            try:
+                workspace_map = get_workspace_map()
+            except Exception:
+                workspace_map = {}
+
+            if workspace:
+                workspace_id = resolve_workspace_filter(workspace, workspace_map)
+
+            filter_expr = _build_asset_filter(
+                model=model,
+                serial_number=serial_number,
+                bus_type=bus_type,
+                asset_type=asset_type,
+                calibration_status=calibration_status,
+                connected=connected,
+                workspace_id=workspace_id,
+                custom_filter=filter_query,
+            )
+
+            if order_by:
+                order_by = order_by.upper()
+
+            def asset_formatter(item: Dict[str, Any]) -> List[str]:
+                ws_id = item.get("workspace", "")
+                ws_name = get_workspace_display_name(ws_id, workspace_map)
+                return [
+                    item.get("name", ""),
+                    item.get("modelName", ""),
+                    item.get("serialNumber", ""),
+                    item.get("busType", ""),
+                    item.get("calibrationStatus", ""),
+                    _get_asset_location_display(item),
+                    ws_name,
+                    item.get("id", ""),
+                ]
+
+            headers = [
+                "Name",
+                "Model",
+                "Serial Number",
+                "Bus Type",
+                "Calibration",
+                "Location",
+                "Workspace",
+                "ID",
+            ]
+            column_widths = [24, 20, 16, 12, 16, 16, 16, 36]
+
+            if format_output.lower() == "json":
+                _warn_if_large_dataset(filter_expr, calibratable)
+                assets = _query_all_assets(
+                    filter_expr, order_by, descending, calibratable_only=calibratable
+                )
+
+                if summary:
+                    summary_stats = _summarize_assets(assets)
+                    click.echo(json.dumps(summary_stats, indent=2))
+                else:
+                    mock_resp: Any = FilteredResponse({"assets": assets})
+                    UniversalResponseHandler.handle_list_response(
+                        resp=mock_resp,
+                        data_key="assets",
+                        item_name="asset",
+                        format_output=format_output,
+                        formatter_func=asset_formatter,
+                        headers=headers,
+                        column_widths=column_widths,
+                        empty_message="No assets found.",
+                        enable_pagination=False,
+                        page_size=take,
+                    )
+            else:
+                if summary:
+                    _warn_if_large_dataset(filter_expr, calibratable)
+                    all_assets = _query_all_assets(
+                        filter_expr, order_by, descending, calibratable_only=calibratable
+                    )
+                    summary_stats = _summarize_assets(all_assets)
+                    click.echo("\nAsset Summary Statistics:")
+                    click.echo(f"  Total Assets: {summary_stats['total']}")
+                    click.echo(
+                        f"  Bus Types: {', '.join(summary_stats.get('busTypes', {}).keys()) or 'N/A'}"
+                    )
+                    if summary_stats.get("truncated"):
+                        click.echo(f"  Note: {summary_stats['note']}", err=True)
+                    click.echo()
+                else:
+                    _handle_asset_interactive_pagination(
+                        filter_expr=filter_expr,
+                        order_by=order_by,
+                        descending=descending,
+                        take=take,
+                        calibratable_only=calibratable,
+                        formatter_func=asset_formatter,
+                        headers=headers,
+                        column_widths=column_widths,
+                        empty_message="No assets found.",
+                    )
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @asset.command(name="get")
+    @click.argument("asset_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--include-calibration",
+        is_flag=True,
+        help="Include calibration history in output",
+    )
+    def get_asset(
+        asset_id: str,
+        format: str,
+        include_calibration: bool,
+    ) -> None:
+        """Get detailed information about a specific asset.
+
+        ASSET_ID is the unique identifier of the asset.
+        """
+        format_output = validate_output_format(format)
+
+        try:
+            url = f"{_get_asset_base_url()}/assets/{asset_id}"
+            resp = make_api_request("GET", url)
+            asset_data = resp.json()
+
+            # Optionally fetch calibration history
+            if include_calibration:
+                try:
+                    cal_url = f"{_get_asset_base_url()}/assets/{asset_id}/history/calibration"
+                    cal_resp = make_api_request("GET", cal_url)
+                    cal_data = cal_resp.json()
+                    cal_entries = (
+                        cal_data.get("calibrationHistory", []) if isinstance(cal_data, dict) else []
+                    )
+                    asset_data["calibrationHistory"] = cal_entries
+                except Exception:
+                    asset_data["calibrationHistory"] = []
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(asset_data, indent=2))
+            else:
+                try:
+                    workspace_map = get_workspace_map()
+                except Exception:
+                    workspace_map = {}
+                _format_asset_detail(asset_data, workspace_map)
+
+                if include_calibration and asset_data.get("calibrationHistory"):
+                    click.echo("\nCalibration History:")
+                    for entry in asset_data["calibrationHistory"]:
+                        date = entry.get("date", "N/A")
+                        entry_type = entry.get("entryType", "N/A")
+                        click.echo(f"  {date} — {entry_type}")
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @asset.command(name="summary")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def asset_summary(format: str) -> None:
+        """Show fleet-wide asset summary statistics.
+
+        Displays counts for total, active, in-use assets and calibration
+        status breakdown.
+        """
+        format_output = validate_output_format(format)
+
+        try:
+            url = f"{_get_asset_base_url()}/asset-summary"
+            resp = make_api_request("GET", url)
+            data = resp.json()
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(data, indent=2))
+            else:
+                click.echo("\nAsset Fleet Summary:")
+                click.echo(f"  Total Assets: {data.get('total', 0)}")
+                click.echo(f"  Active (in connected system): {data.get('active', 0)}")
+                click.echo(f"  Not Active: {data.get('notActive', 0)}")
+                click.echo(f"  In Use: {data.get('inUse', 0)}")
+                click.echo(f"  Not In Use: {data.get('notInUse', 0)}")
+                click.echo(f"  With Alarms: {data.get('withAlarms', 0)}")
+                click.echo("\nCalibration Status:")
+                click.echo(
+                    f"  Approaching Due Date: " f"{data.get('approachingRecommendedDueDate', 0)}"
+                )
+                click.echo(f"  Past Due Date: {data.get('pastRecommendedDueDate', 0)}")
+                click.echo(f"  Out for Calibration: {data.get('outForCalibration', 0)}")
+                click.echo(f"  Total Calibratable: {data.get('totalCalibrated', 0)}")
+                click.echo()
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    # ------------------------------------------------------------------
+    # Phase 2: calibration, location-history
+    # ------------------------------------------------------------------
+
+    @asset.command(name="calibration")
+    @click.argument("asset_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--take",
+        "-t",
+        type=int,
+        default=25,
+        show_default=True,
+        help="Number of history entries to return",
+    )
+    def asset_calibration(
+        asset_id: str,
+        format: str,
+        take: int,
+    ) -> None:
+        """Get calibration history for a specific asset.
+
+        ASSET_ID is the unique identifier of the asset.
+        """
+        format_output = validate_output_format(format)
+
+        try:
+            url = (
+                f"{_get_asset_base_url()}/assets/{asset_id}/history/calibration"
+                f"?Skip=0&Take={take}"
+            )
+            resp = make_api_request("GET", url)
+            data = resp.json()
+
+            entries = data.get("calibrationHistory", []) if isinstance(data, dict) else []
+
+            def calibration_formatter(item: Dict[str, Any]) -> List[str]:
+                return [
+                    item.get("date", ""),
+                    item.get("entryType", ""),
+                    str(item.get("isLimited", "")),
+                    item.get("resolvedDueDate", ""),
+                    str(item.get("recommendedInterval", "")),
+                    item.get("comments", ""),
+                ]
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(entries, indent=2))
+            else:
+                mock_resp: Any = FilteredResponse({"calibrationHistory": entries})
+                UniversalResponseHandler.handle_list_response(
+                    resp=mock_resp,
+                    data_key="calibrationHistory",
+                    item_name="calibration entry",
+                    format_output=format_output,
+                    formatter_func=calibration_formatter,
+                    headers=[
+                        "Date",
+                        "Type",
+                        "Limited",
+                        "Next Due",
+                        "Interval (mo)",
+                        "Comments",
+                    ],
+                    column_widths=[20, 12, 8, 20, 14, 30],
+                    empty_message="No calibration history found.",
+                    enable_pagination=True,
+                    page_size=take,
+                )
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @asset.command(name="location-history")
+    @click.argument("asset_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--take",
+        "-t",
+        type=int,
+        default=25,
+        show_default=True,
+        help="Number of history entries to return",
+    )
+    @click.option(
+        "--from",
+        "date_from",
+        type=str,
+        default=None,
+        help="Start of date range (ISO-8601, e.g., 2025-12-01T00:00:00Z)",
+    )
+    @click.option(
+        "--to",
+        "date_to",
+        type=str,
+        default=None,
+        help="End of date range (ISO-8601, e.g., 2025-12-02T00:00:00Z)",
+    )
+    def asset_location_history(
+        asset_id: str,
+        format: str,
+        take: int,
+        date_from: Optional[str],
+        date_to: Optional[str],
+    ) -> None:
+        """Get location/connection history for a specific asset.
+
+        ASSET_ID is the unique identifier of the asset.
+
+        Use --from and --to for temporal correlation (e.g., confirming an
+        asset was present in a system at the time of a test).
+        """
+        format_output = validate_output_format(format)
+
+        try:
+            url = f"{_get_asset_base_url()}/assets/{asset_id}/history/query-location"
+            payload: Dict[str, Any] = {
+                "skip": 0,
+                "take": take,
+            }
+            if date_from:
+                payload["startTimestamp"] = date_from
+            if date_to:
+                payload["endTimestamp"] = date_to
+
+            resp = make_api_request("POST", url, payload=payload)
+            data = resp.json()
+
+            entries = data.get("connectionHistory", []) if isinstance(data, dict) else []
+
+            def location_formatter(item: Dict[str, Any]) -> List[str]:
+                return [
+                    item.get("timestamp", ""),
+                    item.get("minionId", ""),
+                    str(item.get("slotNumber", "")),
+                    item.get("systemConnection", ""),
+                    item.get("assetPresence", ""),
+                ]
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(entries, indent=2))
+            else:
+                mock_resp: Any = FilteredResponse({"connectionHistory": entries})
+                UniversalResponseHandler.handle_list_response(
+                    resp=mock_resp,
+                    data_key="connectionHistory",
+                    item_name="location entry",
+                    format_output=format_output,
+                    formatter_func=location_formatter,
+                    headers=["Timestamp", "Minion ID", "Slot", "Connection", "Presence"],
+                    column_widths=[24, 30, 6, 14, 12],
+                    empty_message="No location history found.",
+                    enable_pagination=True,
+                    page_size=take,
+                )
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    # ------------------------------------------------------------------
+    # Phase 3: create, update, delete (mutations)
+    # ------------------------------------------------------------------
+
+    @asset.command(name="create")
+    @click.option("--model-name", required=True, help="Model name of the asset")
+    @click.option("--model-number", default=None, help="Model number")
+    @click.option("--serial-number", default=None, help="Serial number")
+    @click.option("--vendor-name", default=None, help="Vendor name")
+    @click.option("--vendor-number", default=None, help="Vendor number")
+    @click.option("--part-number", default=None, help="Part number")
+    @click.option("--name", "asset_name", default=None, help="Display name for the asset")
+    @click.option(
+        "--bus-type",
+        type=click.Choice(
+            ["BUILT_IN_SYSTEM", "PCI_PXI", "USB", "GPIB", "VXI", "SERIAL", "TCP_IP", "CRIO"],
+            case_sensitive=True,
+        ),
+        default=None,
+        help="Bus type",
+    )
+    @click.option(
+        "--asset-type",
+        type=click.Choice(
+            ["GENERIC", "DEVICE_UNDER_TEST", "FIXTURE", "SYSTEM"],
+            case_sensitive=True,
+        ),
+        default=None,
+        help="Asset type",
+    )
+    @click.option("--firmware-version", default=None, help="Firmware version")
+    @click.option("--hardware-version", default=None, help="Hardware version")
+    @click.option("--workspace", "-w", default=None, help="Workspace name or ID")
+    @click.option(
+        "--keyword",
+        "keywords",
+        multiple=True,
+        help="Keyword to associate (repeatable)",
+    )
+    @click.option(
+        "--property",
+        "properties",
+        multiple=True,
+        help="Property in key=value format (repeatable)",
+    )
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def create_asset(
+        model_name: str,
+        model_number: Optional[str],
+        serial_number: Optional[str],
+        vendor_name: Optional[str],
+        vendor_number: Optional[str],
+        part_number: Optional[str],
+        asset_name: Optional[str],
+        bus_type: Optional[str],
+        asset_type: Optional[str],
+        firmware_version: Optional[str],
+        hardware_version: Optional[str],
+        workspace: Optional[str],
+        keywords: Tuple[str, ...],
+        properties: Tuple[str, ...],
+        format: str,
+    ) -> None:
+        """Create a new asset.
+
+        Requires at minimum a --model-name.  Additional fields can be set
+        via options.
+        """
+        check_readonly_mode("create an asset")
+        format_output = validate_output_format(format)
+
+        try:
+            asset_data: Dict[str, Any] = {
+                "modelName": model_name,
+            }
+
+            if model_number:
+                asset_data["modelNumber"] = model_number
+            if serial_number:
+                asset_data["serialNumber"] = serial_number
+            if vendor_name:
+                asset_data["vendorName"] = vendor_name
+            if vendor_number:
+                asset_data["vendorNumber"] = vendor_number
+            if part_number:
+                asset_data["partNumber"] = part_number
+            if asset_name:
+                asset_data["name"] = asset_name
+            if bus_type:
+                asset_data["busType"] = bus_type
+            if asset_type:
+                asset_data["assetType"] = asset_type
+            if firmware_version:
+                asset_data["firmwareVersion"] = firmware_version
+            if hardware_version:
+                asset_data["hardwareVersion"] = hardware_version
+
+            # Resolve workspace
+            if workspace:
+                try:
+                    ws_map = get_workspace_map()
+                    ws_id = resolve_workspace_filter(workspace, ws_map)
+                    asset_data["workspace"] = ws_id
+                except Exception:
+                    asset_data["workspace"] = workspace
+
+            if keywords:
+                asset_data["keywords"] = list(keywords)
+
+            if properties:
+                asset_data["properties"] = _parse_properties(properties)
+
+            url = f"{_get_asset_base_url()}/assets"
+            payload: Dict[str, Any] = {"assets": [asset_data]}
+            resp = make_api_request("POST", url, payload=payload)
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(resp.json(), indent=2))
+            else:
+                format_success(
+                    "Asset created",
+                    {"Model": model_name, "Serial": serial_number or "N/A"},
+                )
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @asset.command(name="update")
+    @click.argument("asset_id")
+    @click.option("--name", "asset_name", default=None, help="Update display name")
+    @click.option("--model-name", default=None, help="Update model name")
+    @click.option("--model-number", default=None, help="Update model number")
+    @click.option("--serial-number", default=None, help="Update serial number")
+    @click.option("--vendor-name", default=None, help="Update vendor name")
+    @click.option("--part-number", default=None, help="Update part number")
+    @click.option("--firmware-version", default=None, help="Update firmware version")
+    @click.option("--hardware-version", default=None, help="Update hardware version")
+    @click.option(
+        "--keyword",
+        "keywords",
+        multiple=True,
+        help="Replace keywords (repeatable)",
+    )
+    @click.option(
+        "--property",
+        "properties",
+        multiple=True,
+        help="Replace properties in key=value format (repeatable)",
+    )
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def update_asset(
+        asset_id: str,
+        asset_name: Optional[str],
+        model_name: Optional[str],
+        model_number: Optional[str],
+        serial_number: Optional[str],
+        vendor_name: Optional[str],
+        part_number: Optional[str],
+        firmware_version: Optional[str],
+        hardware_version: Optional[str],
+        keywords: Tuple[str, ...],
+        properties: Tuple[str, ...],
+        format: str,
+    ) -> None:
+        """Update an existing asset's properties.
+
+        ASSET_ID is the unique identifier of the asset to update.
+        Only the specified fields are changed; others remain unchanged.
+        """
+        check_readonly_mode("update an asset")
+        format_output = validate_output_format(format)
+
+        try:
+            # Build update payload — include ID and only changed fields
+            update_data: Dict[str, Any] = {"id": asset_id}
+
+            if asset_name is not None:
+                update_data["name"] = asset_name
+            if model_name is not None:
+                update_data["modelName"] = model_name
+            if model_number is not None:
+                update_data["modelNumber"] = model_number
+            if serial_number is not None:
+                update_data["serialNumber"] = serial_number
+            if vendor_name is not None:
+                update_data["vendorName"] = vendor_name
+            if part_number is not None:
+                update_data["partNumber"] = part_number
+            if firmware_version is not None:
+                update_data["firmwareVersion"] = firmware_version
+            if hardware_version is not None:
+                update_data["hardwareVersion"] = hardware_version
+
+            if keywords:
+                update_data["keywords"] = list(keywords)
+
+            if properties:
+                update_data["properties"] = _parse_properties(properties)
+
+            url = f"{_get_asset_base_url()}/update-assets"
+            payload: Dict[str, Any] = {"assets": [update_data]}
+            resp = make_api_request("POST", url, payload=payload)
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(resp.json(), indent=2))
+            else:
+                format_success("Asset updated", {"ID": asset_id})
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @asset.command(name="delete")
+    @click.argument("asset_id")
+    @click.option(
+        "--force",
+        is_flag=True,
+        help="Delete without confirmation",
+    )
+    def delete_asset(
+        asset_id: str,
+        force: bool,
+    ) -> None:
+        """Delete an asset.
+
+        ASSET_ID is the unique identifier of the asset to delete.
+        """
+        check_readonly_mode("delete an asset")
+
+        try:
+            # Fetch asset info for confirmation display
+            try:
+                info_url = f"{_get_asset_base_url()}/assets/{asset_id}"
+                info_resp = make_api_request("GET", info_url)
+                info = info_resp.json()
+                display_name = info.get("name") or info.get("modelName") or asset_id
+            except Exception:
+                display_name = asset_id
+
+            if not force:
+                if not click.confirm(f"Are you sure you want to delete asset '{display_name}'?"):
+                    click.echo("Delete cancelled.")
+                    sys.exit(ExitCodes.SUCCESS)
+
+            url = f"{_get_asset_base_url()}/delete-assets"
+            payload: Dict[str, Any] = {"ids": [asset_id]}
+            make_api_request("POST", url, payload=payload)
+
+            format_success("Asset deleted", {"Name": display_name, "ID": asset_id})
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+
+def _summarize_assets(
+    assets: List[Dict[str, Any]],
+    max_items: Optional[int] = 10000,
+) -> Dict[str, Any]:
+    """Summarize asset data by aggregating bus types and calibration status.
+
+    Args:
+        assets: List of asset objects.
+        max_items: Maximum items that were fetched.
+
+    Returns:
+        Dictionary with summary statistics.
+    """
+    summary: Dict[str, Any] = {"total": len(assets)}
+
+    if max_items is not None and len(assets) >= max_items:
+        summary["truncated"] = True
+        summary["note"] = f"Results limited to {max_items} items"
+
+    # Group by bus type
+    bus_types: Dict[str, int] = {}
+    for a in assets:
+        bt = str(a.get("busType", "N/A"))
+        bus_types[bt] = bus_types.get(bt, 0) + 1
+    summary["busTypes"] = bus_types
+
+    # Group by calibration status
+    cal_statuses: Dict[str, int] = {}
+    for a in assets:
+        cs = str(a.get("calibrationStatus", "N/A"))
+        cal_statuses[cs] = cal_statuses.get(cs, 0) + 1
+    summary["calibrationStatuses"] = cal_statuses
+
+    return summary

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -8,6 +8,7 @@ import click
 import keyring
 import tomllib
 
+from .asset_click import register_asset_commands
 from .completion_click import register_completion_command
 from .config_click import register_config_commands
 from .dff_click import register_dff_commands
@@ -367,6 +368,7 @@ def info(format: str) -> None:
 
 
 register_completion_command(cli)
+register_asset_commands(cli)
 register_dff_commands(cli)
 register_config_commands(cli)
 register_example_commands(cli)

--- a/slcli/universal_handlers.py
+++ b/slcli/universal_handlers.py
@@ -104,15 +104,22 @@ class UniversalResponseHandler:
                 click.echo(json.dumps(items, indent=2))
             elif formatter_func and headers and column_widths:
                 # Use traditional output (no pagination)
-                output_formatted_list(
-                    items,
-                    format_output,
-                    headers,
-                    column_widths,
-                    formatter_func,
-                    empty_message,
-                    f"{item_name}(s)",
-                )
+                # When total_count is provided (server-side pagination), use _output_formatted_page
+                # to suppress the per-page footer, since we'll show a custom summary below.
+                if total_count is not None:
+                    from .cli_utils import _output_formatted_page
+
+                    _output_formatted_page(items, headers, column_widths, formatter_func)
+                else:
+                    output_formatted_list(
+                        items,
+                        format_output,
+                        headers,
+                        column_widths,
+                        formatter_func,
+                        empty_message,
+                        f"{item_name}(s)",
+                    )
                 # If the caller provided a server-side total, display a
                 # concise summary like the notebook listing after rendering
                 # the formatted table for the current page.

--- a/tests/unit/test_asset_click.py
+++ b/tests/unit/test_asset_click.py
@@ -1,0 +1,1478 @@
+"""Unit tests for asset CLI commands."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from slcli.asset_click import (
+    _build_asset_filter,
+    _escape_filter_value,
+    _get_asset_location_display,
+    _parse_properties,
+    _query_all_assets,
+    _summarize_assets,
+    register_asset_commands,
+)
+
+
+def patch_keyring(monkeypatch: Any) -> None:
+    """Patch keyring to return test values."""
+    monkeypatch.setattr(
+        "slcli.utils.keyring.get_password",
+        lambda service, key: ("test-key" if key == "SYSTEMLINK_API_KEY" else "https://test.com"),
+    )
+
+
+def make_cli() -> click.Group:
+    """Create CLI instance with asset commands for testing."""
+
+    @click.group()
+    def test_cli() -> None:
+        pass
+
+    register_asset_commands(test_cli)
+    return test_cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CliRunner for tests."""
+    return CliRunner()
+
+
+class MockResponse:
+    """Mock response class for requests."""
+
+    def __init__(self, json_data: Any, status_code: int = 200) -> None:
+        """Initialize a mock response.
+
+        Args:
+            json_data: JSON payload to return from json().
+            status_code: HTTP status code to simulate.
+        """
+        self._json_data = json_data
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        """Return the JSON data."""
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        """Raise on HTTP error status."""
+        if self.status_code >= 400:
+            raise Exception(f"HTTP error {self.status_code}")
+
+
+SAMPLE_ASSET: Dict[str, Any] = {
+    "id": "asset-1",
+    "name": "NI PXIe-6368",
+    "modelName": "PXIe-6368",
+    "modelNumber": "PXIe-6368",
+    "serialNumber": "01BB877A",
+    "vendorName": "NI",
+    "vendorNumber": "V001",
+    "partNumber": "A1234",
+    "busType": "PCI_PXI",
+    "assetType": "GENERIC",
+    "firmwareVersion": "A1",
+    "hardwareVersion": "12A",
+    "calibrationStatus": "OK",
+    "workspace": "ws-1",
+    "location": {
+        "minionId": "minion-A",
+        "physicalLocation": "",
+        "slotNumber": 2,
+        "state": {
+            "assetPresence": "PRESENT",
+            "systemConnection": "CONNECTED",
+        },
+    },
+    "keywords": ["Keyword1", "Keyword2"],
+    "properties": {"Key1": "Value1"},
+}
+
+SAMPLE_ASSET_2: Dict[str, Any] = {
+    "id": "asset-2",
+    "name": "NI PXI-4071",
+    "modelName": "PXI-4071",
+    "serialNumber": "02CC999B",
+    "busType": "PCI_PXI",
+    "assetType": "GENERIC",
+    "calibrationStatus": "PAST_RECOMMENDED_DUE_DATE",
+    "workspace": "ws-2",
+    "location": {
+        "minionId": "minion-B",
+        "slotNumber": 5,
+        "state": {
+            "assetPresence": "PRESENT",
+            "systemConnection": "CONNECTED",
+        },
+    },
+}
+
+
+# =============================================================================
+# Helper function tests
+# =============================================================================
+
+
+class TestEscapeFilterValue:
+    """Tests for _escape_filter_value."""
+
+    def test_escapes_double_quotes(self) -> None:
+        """Test that double quotes are escaped."""
+        assert _escape_filter_value('value"with"quotes') == 'value\\"with\\"quotes'
+
+    def test_no_quotes(self) -> None:
+        """Test that plain strings pass through unchanged."""
+        assert _escape_filter_value("simple") == "simple"
+
+    def test_empty_string(self) -> None:
+        """Test that empty strings pass through."""
+        assert _escape_filter_value("") == ""
+
+
+class TestBuildAssetFilter:
+    """Tests for _build_asset_filter."""
+
+    def test_no_filters_returns_none(self) -> None:
+        """Test that no filters returns None."""
+        assert _build_asset_filter() is None
+
+    def test_model_filter(self) -> None:
+        """Test model name filter uses Contains."""
+        result = _build_asset_filter(model="PXI-4071")
+        assert result == 'ModelName.Contains("PXI-4071")'
+
+    def test_serial_number_filter(self) -> None:
+        """Test serial number filter uses exact match."""
+        result = _build_asset_filter(serial_number="01BB877A")
+        assert result == 'SerialNumber = "01BB877A"'
+
+    def test_bus_type_filter(self) -> None:
+        """Test bus type filter."""
+        result = _build_asset_filter(bus_type="PCI_PXI")
+        assert result == 'BusType = "PCI_PXI"'
+
+    def test_asset_type_filter(self) -> None:
+        """Test asset type filter."""
+        result = _build_asset_filter(asset_type="DEVICE_UNDER_TEST")
+        assert result == 'AssetType = "DEVICE_UNDER_TEST"'
+
+    def test_calibration_status_filter(self) -> None:
+        """Test calibration status filter."""
+        result = _build_asset_filter(calibration_status="OK")
+        assert result == 'CalibrationStatus = "OK"'
+
+    def test_connected_filter(self) -> None:
+        """Test connected flag adds SystemConnection and AssetPresence."""
+        result = _build_asset_filter(connected=True)
+        assert result is not None
+        assert 'SystemConnection = "CONNECTED"' in result
+        assert 'AssetPresence = "PRESENT"' in result
+
+    def test_workspace_filter(self) -> None:
+        """Test workspace filter."""
+        result = _build_asset_filter(workspace_id="ws-123")
+        assert result == 'Workspace = "ws-123"'
+
+    def test_custom_filter(self) -> None:
+        """Test custom filter passthrough."""
+        result = _build_asset_filter(custom_filter='VendorName = "NI"')
+        assert result == 'VendorName = "NI"'
+
+    def test_combined_filters(self) -> None:
+        """Test multiple filters are joined with 'and'."""
+        result = _build_asset_filter(model="PXI", bus_type="USB")
+        assert result is not None
+        assert 'ModelName.Contains("PXI")' in result
+        assert 'BusType = "USB"' in result
+        assert " and " in result
+
+    def test_escapes_model_injection(self) -> None:
+        """Test that injection in model values is escaped."""
+        result = _build_asset_filter(model='PXI") or (1=1) and ("')
+        assert result is not None
+        assert '\\"' in result
+
+
+class TestGetAssetLocationDisplay:
+    """Tests for _get_asset_location_display."""
+
+    def test_no_location(self) -> None:
+        """Test asset with no location returns empty string."""
+        assert _get_asset_location_display({}) == ""
+
+    def test_location_none(self) -> None:
+        """Test asset with None location returns empty string."""
+        assert _get_asset_location_display({"location": None}) == ""
+
+    def test_minion_id_with_slot(self) -> None:
+        """Test location with minionId and slot."""
+        asset: Dict[str, Any] = {"location": {"minionId": "controller-1", "slotNumber": 3}}
+        assert _get_asset_location_display(asset) == "controller-1 (Slot 3)"
+
+    def test_physical_location_only(self) -> None:
+        """Test physical location without minionId."""
+        asset: Dict[str, Any] = {"location": {"minionId": "", "physicalLocation": "Lab A"}}
+        assert _get_asset_location_display(asset) == "Lab A"
+
+    def test_slot_only(self) -> None:
+        """Test location with slot but no minionId or physical."""
+        asset: Dict[str, Any] = {
+            "location": {"minionId": "", "physicalLocation": "", "slotNumber": 7}
+        }
+        assert _get_asset_location_display(asset) == "Slot 7"
+
+
+class TestSummarizeAssets:
+    """Tests for _summarize_assets."""
+
+    def test_empty_list(self) -> None:
+        """Test summary of empty list."""
+        result = _summarize_assets([])
+        assert result["total"] == 0
+
+    def test_counts_bus_types(self) -> None:
+        """Test that bus types are counted."""
+        result = _summarize_assets([SAMPLE_ASSET, SAMPLE_ASSET_2])
+        assert result["busTypes"]["PCI_PXI"] == 2
+
+    def test_counts_calibration_statuses(self) -> None:
+        """Test that calibration statuses are counted."""
+        result = _summarize_assets([SAMPLE_ASSET, SAMPLE_ASSET_2])
+        assert result["calibrationStatuses"]["OK"] == 1
+        assert result["calibrationStatuses"]["PAST_RECOMMENDED_DUE_DATE"] == 1
+
+    def test_truncation_indicator(self) -> None:
+        """Test truncation indicator when hitting max."""
+        assets = [SAMPLE_ASSET] * 10
+        result = _summarize_assets(assets, max_items=10)
+        assert result["truncated"] is True
+
+
+class TestParseProperties:
+    """Tests for _parse_properties."""
+
+    def test_parse_single_property(self) -> None:
+        """Test parsing a single key=value property."""
+        result = _parse_properties(("location=Lab A",))
+        assert result == {"location": "Lab A"}
+
+    def test_parse_multiple_properties(self) -> None:
+        """Test parsing multiple properties."""
+        result = _parse_properties(("key1=val1", "key2=val2"))
+        assert result == {"key1": "val1", "key2": "val2"}
+
+    def test_parse_property_with_equals_in_value(self) -> None:
+        """Test that only the first = is used as delimiter."""
+        result = _parse_properties(("expr=a=b",))
+        assert result == {"expr": "a=b"}
+
+    def test_parse_property_strips_whitespace(self) -> None:
+        """Test that keys and values are stripped."""
+        result = _parse_properties((" key = value ",))
+        assert result == {"key": "value"}
+
+    def test_parse_invalid_property_exits(self) -> None:
+        """Test that invalid format exits with INVALID_INPUT."""
+        with pytest.raises(SystemExit) as exc_info:
+            _parse_properties(("badformat",))
+        assert exc_info.value.code == 2  # ExitCodes.INVALID_INPUT
+
+    def test_parse_empty_tuple(self) -> None:
+        """Test parsing an empty tuple."""
+        result = _parse_properties(())
+        assert result == {}
+
+
+class TestQueryAllAssets:
+    """Tests for _query_all_assets pagination logic."""
+
+    def test_single_page(self, monkeypatch: Any) -> None:
+        """Test fetching when all assets fit in a single page."""
+        patch_keyring(monkeypatch)
+        assets = [SAMPLE_ASSET, SAMPLE_ASSET_2]
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": assets, "totalCount": 2})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        result = _query_all_assets(None, None, False, take=100)
+        assert len(result) == 2
+        assert result[0]["id"] == "asset-1"
+        assert result[1]["id"] == "asset-2"
+
+    def test_multi_page_accumulation(self, monkeypatch: Any) -> None:
+        """Test that multiple pages are accumulated correctly."""
+        patch_keyring(monkeypatch)
+        page1 = [{"id": f"asset-{i}"} for i in range(1000)]
+        page2 = [{"id": f"asset-{i}"} for i in range(1000, 1500)]
+
+        call_count = 0
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return MockResponse({"assets": page1, "totalCount": 1500})
+            return MockResponse({"assets": page2, "totalCount": 1500})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        result = _query_all_assets(None, None, False, take=10000)
+        assert len(result) == 1500
+        assert call_count == 2
+
+    def test_take_cap_truncates_results(self, monkeypatch: Any) -> None:
+        """Test that results are truncated at the take limit."""
+        patch_keyring(monkeypatch)
+        all_items = [{"id": f"asset-{i}"} for i in range(1000)]
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            take = payload.get("take", 1000) if payload else 1000
+            return MockResponse({"assets": all_items[:take], "totalCount": 1000})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        result = _query_all_assets(None, None, False, take=50)
+        assert len(result) == 50
+
+    def test_early_exit_on_short_page(self, monkeypatch: Any) -> None:
+        """Test that pagination stops when a page returns fewer items than requested."""
+        patch_keyring(monkeypatch)
+
+        call_count = 0
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            nonlocal call_count
+            call_count += 1
+            # Return only 3 items — less than batch_size, signals last page
+            return MockResponse({"assets": [{"id": f"a-{i}"} for i in range(3)], "totalCount": 3})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        result = _query_all_assets(None, None, False, take=10000)
+        assert len(result) == 3
+        assert call_count == 1  # Should not make a second request
+
+    def test_empty_result(self, monkeypatch: Any) -> None:
+        """Test handling of empty results."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        result = _query_all_assets(None, None, False)
+        assert result == []
+
+    def test_filter_and_order_passed_to_api(self, monkeypatch: Any) -> None:
+        """Test that filter, orderBy, and calibratableOnly are sent in payload."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        _query_all_assets(
+            filter_expr='BusType = "USB"',
+            order_by="ID",
+            descending=True,
+            calibratable_only=True,
+        )
+        assert len(captured_payloads) == 1
+        p = captured_payloads[0]
+        assert p["filter"] == 'BusType = "USB"'
+        assert p["orderBy"] == "ID"
+        assert p["descending"] is True
+        assert p["calibratableOnly"] is True
+
+
+# =============================================================================
+# asset list command tests
+# =============================================================================
+
+
+class TestListAssets:
+    """Tests for the asset list command."""
+
+    def test_list_assets_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test listing assets in table format."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": [SAMPLE_ASSET], "totalCount": 1})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list"])
+        assert result.exit_code == 0
+        assert "PXIe-6368" in result.output
+
+    def test_list_assets_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test listing assets in JSON format."""
+        patch_keyring(monkeypatch)
+
+        call_count = 0
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            nonlocal call_count
+            call_count += 1
+            # First call is _warn_if_large_dataset (take=1)
+            if payload and payload.get("take") == 1:
+                return MockResponse({"assets": [], "totalCount": 1})
+            return MockResponse({"assets": [SAMPLE_ASSET, SAMPLE_ASSET_2], "totalCount": 2})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["id"] == "asset-1"
+
+    def test_list_assets_with_model_filter(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that --model option builds correct filter."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [SAMPLE_ASSET], "totalCount": 1})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--model", "PXI-4071"])
+        assert result.exit_code == 0
+        assert any(
+            'ModelName.Contains("PXI-4071")' in p.get("filter", "") for p in captured_payloads
+        )
+
+    def test_list_assets_with_connected_flag(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that --connected option builds correct filter."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--connected"])
+        assert result.exit_code == 0
+        assert any(
+            "CONNECTED" in p.get("filter", "") and "PRESENT" in p.get("filter", "")
+            for p in captured_payloads
+        )
+
+    def test_list_assets_with_bus_type(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --bus-type option."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--bus-type", "USB"])
+        assert result.exit_code == 0
+        assert any('BusType = "USB"' in p.get("filter", "") for p in captured_payloads)
+
+    def test_list_assets_with_workspace_filter(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --workspace resolves name to ID."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr(
+            "slcli.asset_click.get_workspace_map",
+            lambda: {"ws-1": "Production"},
+        )
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--workspace", "Production"])
+        assert result.exit_code == 0
+        assert any('Workspace = "ws-1"' in p.get("filter", "") for p in captured_payloads)
+
+    def test_list_assets_with_custom_filter(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --filter option passes through custom expression."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        custom = 'VendorName = "NI"'
+        result = runner.invoke(cli, ["asset", "list", "--filter", custom])
+        assert result.exit_code == 0
+        assert any(custom in p.get("filter", "") for p in captured_payloads)
+
+    def test_list_assets_summary_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --summary flag with JSON output."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": [SAMPLE_ASSET, SAMPLE_ASSET_2], "totalCount": 2})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--summary", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total"] == 2
+        assert "busTypes" in data
+
+    def test_list_assets_summary_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --summary flag with table output."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": [SAMPLE_ASSET], "totalCount": 1})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--summary"])
+        assert result.exit_code == 0
+        assert "Asset Summary Statistics:" in result.output
+        assert "Total Assets: 1" in result.output
+
+    def test_list_assets_order_by(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --order-by and --ascending options."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            ["asset", "list", "--order-by", "ID", "--ascending"],
+        )
+        assert result.exit_code == 0
+        assert any(
+            p.get("orderBy") == "ID" and p.get("descending") is False for p in captured_payloads
+        )
+
+    def test_list_assets_calibratable_flag(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --calibratable flag sets calibratableOnly."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list", "--calibratable"])
+        assert result.exit_code == 0
+        assert any(p.get("calibratableOnly") is True for p in captured_payloads)
+
+    def test_list_assets_empty(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test listing assets when none exist."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"assets": [], "totalCount": 0})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list"])
+        assert result.exit_code == 0
+        assert "No assets found" in result.output
+
+    def test_list_assets_api_error(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that API errors are handled gracefully."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            raise Exception("Network connection failed")
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "list"])
+        assert result.exit_code != 0
+
+
+# =============================================================================
+# asset get command tests
+# =============================================================================
+
+
+class TestGetAsset:
+    """Tests for the asset get command."""
+
+    def test_get_asset_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test getting asset details in table format."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(SAMPLE_ASSET)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "get", "asset-1"])
+        assert result.exit_code == 0
+        assert "NI PXIe-6368" in result.output
+        assert "01BB877A" in result.output
+        assert "PCI_PXI" in result.output
+        assert "Keyword1" in result.output
+        assert "Key1: Value1" in result.output
+
+    def test_get_asset_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test getting asset details in JSON format."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(SAMPLE_ASSET)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "get", "asset-1", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["id"] == "asset-1"
+
+    def test_get_asset_with_calibration(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --include-calibration fetches calibration history."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if "calibration" in url:
+                return MockResponse(
+                    {
+                        "calibrationHistory": [
+                            {"date": "2025-06-15", "entryType": "AUTOMATIC"},
+                        ]
+                    }
+                )
+            return MockResponse(SAMPLE_ASSET)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "get", "asset-1", "--include-calibration"])
+        assert result.exit_code == 0
+        assert "Calibration History:" in result.output
+        assert "2025-06-15" in result.output
+
+    def test_get_asset_not_found(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test error handling for non-existent asset."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            raise Exception("Resource not found: asset-999")
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "get", "asset-999"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+# =============================================================================
+# asset summary command tests
+# =============================================================================
+
+
+class TestAssetSummary:
+    """Tests for the asset summary command."""
+
+    def test_summary_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test summary in table format."""
+        patch_keyring(monkeypatch)
+
+        summary_data: Dict[str, Any] = {
+            "total": 17,
+            "active": 12,
+            "notActive": 5,
+            "inUse": 10,
+            "notInUse": 7,
+            "withAlarms": 3,
+            "approachingRecommendedDueDate": 3,
+            "pastRecommendedDueDate": 4,
+            "outForCalibration": 2,
+            "totalCalibrated": 7,
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(summary_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "summary"])
+        assert result.exit_code == 0
+        assert "Total Assets: 17" in result.output
+        assert "Active (in connected system): 12" in result.output
+        assert "Not Active: 5" in result.output
+        assert "In Use: 10" in result.output
+        assert "With Alarms: 3" in result.output
+        assert "Approaching Due Date: 3" in result.output
+        assert "Past Due Date: 4" in result.output
+        assert "Out for Calibration: 2" in result.output
+
+    def test_summary_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test summary in JSON format."""
+        patch_keyring(monkeypatch)
+
+        summary_data: Dict[str, Any] = {
+            "total": 17,
+            "active": 12,
+            "notActive": 5,
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(summary_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "summary", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["total"] == 17
+
+    def test_summary_api_error(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test error handling for summary endpoint."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            raise Exception("Permission denied")
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "summary"])
+        assert result.exit_code != 0
+
+
+# =============================================================================
+# asset calibration command tests
+# =============================================================================
+
+
+class TestAssetCalibration:
+    """Tests for the asset calibration command."""
+
+    def test_calibration_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test calibration history in table format."""
+        patch_keyring(monkeypatch)
+
+        cal_data: Dict[str, Any] = {
+            "calibrationHistory": [
+                {
+                    "date": "2025-06-15T10:00:00Z",
+                    "entryType": "AUTOMATIC",
+                    "isLimited": False,
+                    "resolvedDueDate": "2026-06-15T00:00:00Z",
+                    "recommendedInterval": 12,
+                    "comments": "Passed all checks",
+                },
+            ],
+            "totalCount": 1,
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(cal_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "calibration", "asset-1"])
+        assert result.exit_code == 0
+        assert "AUTOMATIC" in result.output
+
+    def test_calibration_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test calibration history in JSON format."""
+        patch_keyring(monkeypatch)
+
+        cal_data: Dict[str, Any] = {
+            "calibrationHistory": [
+                {
+                    "date": "2025-06-15",
+                    "entryType": "MANUAL",
+                    "isLimited": True,
+                },
+            ],
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(cal_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "calibration", "asset-1", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["entryType"] == "MANUAL"
+
+    def test_calibration_empty(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test empty calibration history."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"calibrationHistory": []})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "calibration", "asset-1"])
+        assert result.exit_code == 0
+        assert "No calibration history found" in result.output
+
+
+# =============================================================================
+# asset location-history command tests
+# =============================================================================
+
+
+class TestAssetLocationHistory:
+    """Tests for the asset location-history command."""
+
+    def test_location_history_table(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test location history in table format."""
+        patch_keyring(monkeypatch)
+
+        loc_data: Dict[str, Any] = {
+            "connectionHistory": [
+                {
+                    "timestamp": "2025-12-01T10:30:00Z",
+                    "minionId": "controller-1",
+                    "slotNumber": 2,
+                    "systemConnection": "CONNECTED",
+                    "assetPresence": "PRESENT",
+                },
+            ],
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(loc_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "location-history", "asset-1"])
+        assert result.exit_code == 0
+        assert "controller-1" in result.output
+        assert "CONNECTED" in result.output
+
+    def test_location_history_json(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test location history in JSON format."""
+        patch_keyring(monkeypatch)
+
+        loc_data: Dict[str, Any] = {
+            "connectionHistory": [
+                {
+                    "timestamp": "2025-12-01T10:30:00Z",
+                    "minionId": "ctrl-1",
+                    "slotNumber": 3,
+                    "systemConnection": "CONNECTED",
+                    "assetPresence": "PRESENT",
+                },
+            ],
+        }
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(loc_data)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "location-history", "asset-1", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["minionId"] == "ctrl-1"
+
+    def test_location_history_with_date_range(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test --from and --to date range options."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Dict[str, Any]] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({"connectionHistory": []})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "location-history",
+                "asset-1",
+                "--from",
+                "2025-12-01T00:00:00Z",
+                "--to",
+                "2025-12-02T00:00:00Z",
+            ],
+        )
+        assert result.exit_code == 0
+        assert any(
+            p.get("startTimestamp") == "2025-12-01T00:00:00Z"
+            and p.get("endTimestamp") == "2025-12-02T00:00:00Z"
+            for p in captured_payloads
+        )
+
+    def test_location_history_empty(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test empty location history."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Optional[Dict[str, Any]] = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"connectionHistory": []})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "location-history", "asset-1"])
+        assert result.exit_code == 0
+        assert "No location history found" in result.output
+
+
+# =============================================================================
+# asset create command tests
+# =============================================================================
+
+
+class TestCreateAsset:
+    """Tests for the asset create command."""
+
+    def test_create_asset_success(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test creating an asset successfully."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Any] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse([{"id": "new-asset-1", "modelName": "PXI-4071"}])
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "create",
+                "--model-name",
+                "PXI-4071",
+                "--serial-number",
+                "SN-123",
+                "--bus-type",
+                "PCI_PXI",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert captured_payloads
+        created = captured_payloads[0]
+        assert isinstance(created, dict)
+        assert created["assets"][0]["modelName"] == "PXI-4071"
+        assert created["assets"][0]["serialNumber"] == "SN-123"
+        assert created["assets"][0]["busType"] == "PCI_PXI"
+
+    def test_create_asset_json_output(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test create with JSON output."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse([{"id": "new-1", "modelName": "DMM"}])
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            ["asset", "create", "--model-name", "DMM", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["id"] == "new-1"
+
+    def test_create_asset_with_keywords_and_properties(
+        self, monkeypatch: Any, runner: CliRunner
+    ) -> None:
+        """Test creating asset with keywords and properties."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Any] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse([{"id": "new-2"}])
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "create",
+                "--model-name",
+                "Test",
+                "--keyword",
+                "tag1",
+                "--keyword",
+                "tag2",
+                "--property",
+                "location=Lab A",
+                "--property",
+                "owner=Team1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured_payloads
+        created = captured_payloads[0]["assets"][0]
+        assert created["keywords"] == ["tag1", "tag2"]
+        assert created["properties"]["location"] == "Lab A"
+
+    def test_create_asset_invalid_property(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test creating asset with invalid property format."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "create",
+                "--model-name",
+                "Test",
+                "--property",
+                "badformat",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid property format" in result.output
+
+    def test_create_asset_readonly_blocked(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that create is blocked in readonly mode."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: True)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "create", "--model-name", "Test"])
+        assert result.exit_code != 0
+        assert "readonly" in result.output.lower()
+
+
+# =============================================================================
+# asset update command tests
+# =============================================================================
+
+
+class TestUpdateAsset:
+    """Tests for the asset update command."""
+
+    def test_update_asset_success(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test updating an asset successfully."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Any] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            return MockResponse({})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "update",
+                "asset-1",
+                "--name",
+                "New Name",
+                "--serial-number",
+                "SN-999",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert captured_payloads
+        updated = captured_payloads[0]["assets"][0]
+        assert updated["id"] == "asset-1"
+        assert updated["name"] == "New Name"
+        assert updated["serialNumber"] == "SN-999"
+
+    def test_update_asset_json_output(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test update with JSON output."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse({"updated": True})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "asset",
+                "update",
+                "asset-1",
+                "--name",
+                "Updated",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["updated"] is True
+
+    def test_update_asset_readonly_blocked(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that update is blocked in readonly mode."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: True)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "update", "asset-1", "--name", "X"])
+        assert result.exit_code != 0
+        assert "readonly" in result.output.lower()
+
+
+# =============================================================================
+# asset delete command tests
+# =============================================================================
+
+
+class TestDeleteAsset:
+    """Tests for the asset delete command."""
+
+    def test_delete_asset_with_force(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test deleting an asset with --force."""
+        patch_keyring(monkeypatch)
+
+        captured_payloads: List[Any] = []
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            if payload:
+                captured_payloads.append(payload)
+            if "/assets/" in url and "delete" not in url:
+                return MockResponse(SAMPLE_ASSET)
+            return MockResponse({})
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "delete", "asset-1", "--force"])
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert any(isinstance(p, dict) and p.get("ids") == ["asset-1"] for p in captured_payloads)
+
+    def test_delete_asset_cancelled(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that delete is cancelled when user says no."""
+        patch_keyring(monkeypatch)
+
+        def mock_request(
+            method: str,
+            url: str,
+            payload: Any = None,
+            **_: Any,
+        ) -> Any:
+            return MockResponse(SAMPLE_ASSET)
+
+        monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "delete", "asset-1"], input="n\n")
+        assert "cancelled" in result.output.lower()
+
+    def test_delete_asset_readonly_blocked(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test that delete is blocked in readonly mode."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: True)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["asset", "delete", "asset-1", "--force"])
+        assert result.exit_code != 0
+        assert "readonly" in result.output.lower()


### PR DESCRIPTION
## Summary

Implements the full Asset Management CLI module (`slcli asset`) covering all three phases from the asset command proposal.

## Changes

### New Files
- **asset_click.py** — Complete asset command module (~1220 lines, 8 commands)
- **test_asset_click.py** — 73 unit tests across 12 test classes (87%+ coverage)

### Modified Files
- **main.py** — Registered `register_asset_commands`
- **README.md** — Added Asset Management documentation section

## Commands

### Phase 1 — Core Read Operations
- `slcli asset list` — List/filter assets (13 filter options, pagination, table/JSON output)
- `slcli asset get <id>` — Get asset details (optional calibration history)
- `slcli asset summary` — Asset fleet summary with status breakdown

### Phase 2 — History & Diagnostics
- `slcli asset calibration <id>` — View calibration history
- `slcli asset location-history <id>` — View location/connection history with date filtering

### Phase 3 — Mutation Operations
- `slcli asset create` — Create assets with full property support (readonly-mode protected)
- `slcli asset update <id>` — Update asset fields (readonly-mode protected)
- `slcli asset delete <id>` — Delete with confirmation prompt and `--force` flag (readonly-mode protected)

## Design Decisions
- Uses NI APM v1 REST API (`/niapm/v1/`) with skip/take pagination
- Filter syntax uses API-native format (`ModelName.Contains("...")`) — no `@0` substitutions
- Custom properties via repeatable `--property key=value` options
- Extracted `_parse_properties()` helper for DRY compliance
- Direct unit tests for `_query_all_assets()` pagination logic
- `UniversalResponseHandler` for consistent response processing
- `handle_api_error()` / `format_success()` for standardized output
- `check_readonly_mode()` guard on all mutation commands

## Validation
- ✅ `poetry run black .` — clean
- ✅ `poetry run mypy slcli tests` — no issues
- ✅ `poetry run ni-python-styleguide lint` — clean
- ✅ `poetry run pytest tests/unit -q` — 510 passed (0 failures)