### PR TITLE
fix: Performance improvements, bug fixes, and a new Agent Skills definition for slcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ operations dispatched to systems.
 ### List Systems
 
 ```bash
-# List all systems (paginated table, 25 per page)
+# List all systems (paginated table, 100 per page)
 slcli system list
 
 # Filter by alias (contains match)
@@ -406,7 +406,7 @@ slcli system list --workspace "Production"
 # Advanced filter with API filter syntax
 slcli system list --filter 'connected.data.state = "CONNECTED" and grains.data.kernel = "Windows"'
 
-# JSON output (all results, no pagination)
+# JSON output (up to --take limit, default 100)
 slcli system list -f json
 
 # Order by alias
@@ -543,8 +543,9 @@ slcli feed delete --id <feed-id> --yes
 
 ### Pagination & Formats
 
-- All list commands support `--format` (`table` default, `json`) and `--take` (default 25) for pagination.
-- JSON outputs return full results without pagination.
+- All list commands support `--format` (`table` default, `json`) and `--take` for pagination.
+- Table outputs: `--take` controls items per page (default 25 for most commands, 100 for systems).
+- JSON outputs: `--take` controls maximum items returned (default 25 for most commands, 100 for systems).
 
 ## Authentication
 

--- a/docs/Proposed 10 New Questions
+++ b/docs/Proposed 10 New Questions
@@ -1,0 +1,194 @@
+# 10 New Proposed Questions Answerable with slcli
+
+Based on analysis of actual server data using slcli, here are 10 new questions
+that demonstrate realistic, data-driven scenarios answerable using the
+SystemLink CLI:
+
+## 1. **Which operators have the highest failure rates and what equipment should they focus on?**
+
+**Intent:** Operator performance and training needs analysis  
+**Example:** "Analyze operator failure patterns - show me which operators
+have >15% failure rates on their test program variants and what factors
+correlate (test programs, DUTs, conditions)"
+
+**Answerable with:**
+
+- `slcli testmonitor result list --operator "xli" --status FAILED --summary`
+- Filter across 350+ test executions per operator to identify high performers
+  vs. those needing support
+- Data available: 358 tests for xli, 349 for wtan, 347 for klee (top operators
+  have 300-360 executions each)
+
+---
+
+## 2. **Which assets are most overdue for calibration and blocking test execution?**
+
+**Intent:** Maintenance and compliance tracking  
+**Example:** "Show me all assets past calibration due dates, grouped by system
+they're in, and what tests would be affected if we temporarily removed them"
+
+**Answerable with:**
+
+- `slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE --take 5`
+- Asset summary: 70 assets past due, 2 approaching, 7 out for calibration
+- Retrieve parent system and test impact for each overdue asset
+
+**Data available:** 2,555 total assets (244 active, 2,311 inactive), 70 are past
+calibration date
+
+---
+
+## 3. **What is the test time distribution across test stations and where are bottlenecks?**
+
+**Intent:** Capacity planning and resource optimization  
+**Example:** "Calculate average test duration per test program and show which
+test stations have the longest queue times. Recommend load balancing strategy"
+
+**Answerable with:**
+
+- `slcli testmonitor result list --take 100 | jq '.[].totalTimeInSeconds'`
+- Group by hostName to identify station-specific patterns
+- Calculate percentiles to find outliers causing delays
+
+**Data available:** 2.3M+ test results with execution time data, multiple test
+hosts
+
+---
+
+## 4. **Which connected systems lack specific measurement capabilities?**
+
+**Intent:** Equipment discovery and test planning  
+**Example:** "Find all systems that don't have temperature measurement
+capability but are assigned to environmental stress tests"
+
+**Answerable with:**
+
+- `slcli system list --connected -f json | filter for measurement type`
+- Join with asset list to check installed instruments
+- Cross-reference with test requirements
+
+**Data available:** 3,138 connected systems with asset configurations
+
+---
+
+## 5. **How many units per product variant are past their first-pass yield expectations?**
+
+**Intent:** Quality metrics and product health  
+**Example:** "For battery products, show the variance from expected yield rates.
+Alert on products trending below 82% pass rate (current baseline)"
+
+**Answerable with:**
+
+- `slcli testmonitor product list --part-number "BATT*" -f json`
+- Aggregate pass/fail counts per product variant
+- Calculate yield rates and identify degradation
+
+**Data available:** 15 battery products (BATT-0 through BATT-14) with 82-85%
+historical pass rates
+
+---
+
+## 6. **Which test programs have the longest runtimes and highest complexity?**
+
+**Intent:** Test optimization and schedule planning  
+**Example:** "Identify the top 5 longest-running test programs and suggest which
+could run in parallel to reduce overall test time"
+
+**Answerable with:**
+
+- `slcli testmonitor result list --take 500 | jq '.[] | {programName, totalTimeInSeconds}'`
+- Group by program and calculate statistics (mean, median, p95)
+- Compare program variants to identify complexity patterns
+
+**Data available:** SOH_SCT_HPPC variants (0-9), each with hundreds of
+executions
+
+---
+
+## 7. **What is the geographic or location-based distribution of test failures?**
+
+**Intent:** Environmental or facility-based root cause analysis  
+**Example:** "Show failure rates by test location (Austin, Dallas, CA lab,
+etc.). Are there facility-specific issues causing higher failure rates?"
+
+**Answerable with:**
+
+- Extract location from systemId or hostname
+- `slcli testmonitor result list --take 200 | filter by location`
+- Calculate failure rates per facility
+
+**Data available:** 5,952 systems total, multiple facility locations implied by
+naming conventions
+
+---
+
+## 8. **Which PAtools test fixtures need recalibration soon and what capacity would we lose?**
+
+**Intent:** Test coverage planning and preventive maintenance  
+**Example:** "Show all PAtools fixtures approaching calibration due dates with
+their test capacities (BattCell_1CN, BattCell_4x parallel, etc.) to assess
+impact"
+
+**Answerable with:**
+
+- `slcli asset list --vendor-name "PAtools" --asset-type FIXTURE -f json`
+- Filter by `calibrationStatus` for approaching dates
+- Join with system configuration to show test parallelism capacity
+
+**Data available:** 31 PAtools fixtures in NI_PXIe-8881 alone, with RTS and
+application type details
+
+---
+
+## 9. **How is test execution distributed across product families and can we rebalance workload?**
+
+**Intent:** Production planning and system utilization  
+**Example:** "Show execution volume by product family (BATT, SOH, PM, etc.).
+Identify which systems handle which products and suggest optimizations"
+
+**Answerable with:**
+
+- `slcli testmonitor result list -f json | jq '.[] | {partNumber, programName, totalTimeInSeconds, systemId}'`
+- Group by product prefix and system
+- Calculate utilization metrics
+
+**Data available:** 2.3M+ test results across multiple product lines (BATT,
+SOH_SCT_HPPC, test programs)
+
+---
+
+## 10. **Are there patterns in test failures by environmental condition (temperature, humidity, voltage)?**
+
+**Intent:** Root cause analysis and specification compliance  
+**Example:** "For failed battery tests, show the temperature, voltage, and
+capacity ranges. Are failures concentrated in specific operating condition
+ranges suggesting spec violations?"
+
+**Answerable with:**
+
+- `slcli testmonitor result list --status FAILED | jq '.[] | {properties: {MaxTemp, MaxVoltage, MinVoltage, ActualCapacity}}'`
+- Analyze distribution of environmental properties
+- Identify clustered failure modes
+
+**Data available:** 7,961+ failed test results with detailed measurement
+properties (temperature: 60-69°C, voltage: 2-5V ranges, capacity: 40-49Ah)
+
+---
+
+## Query Complexity & API Capabilities Used
+
+| Question | Filtering        | Grouping        | Aggregation          | Complexity |
+| -------- | ---------------- | --------------- | -------------------- | ---------- |
+| 1        | Operator, Status | Program Name    | Count, Rate          | Medium     |
+| 2        | Cal Status       | System          | Count, Impact        | Medium     |
+| 3        | Host Name        | Station         | Duration Stats       | Low-Med    |
+| 4        | Connected, Type  | Capability      | Capability Check     | High       |
+| 5        | Part Number      | Product         | Pass/Fail Rate       | Medium     |
+| 6        | Program Name     | Test Variant    | Duration Percentiles | Medium     |
+| 7        | Location         | Facility        | Failure Rate         | Low        |
+| 8        | Vendor, Type     | Status          | Capacity Loss        | Medium     |
+| 9        | Part Number      | Product Famil   | Utilization          | Medium     |
+| 10       | Status           | Condition Range | Distribution         | Medium     |
+
+All questions are answerable with current slcli capabilities demonstrated
+through successful queries on live data.

--- a/docs/niapm-2.json
+++ b/docs/niapm-2.json
@@ -1,0 +1,4509 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Asset Management",
+    "description": "Asset Management Service HTTP API. Track asset location, utilization and calibration.",
+    "contact": {
+      "name": "National Instruments",
+      "url": "https://www.ni.com/systemlink",
+      "email": "support@ni.com"
+    },
+    "version": "1"
+  },
+  "paths": {
+    "/niapm/v1/assets": {
+      "get": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Get assets",
+        "parameters": [
+          {
+            "name": "Skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "CalibratableOnly",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ReturnCount",
+            "in": "query",
+            "description": "Whether to return the total number of assets which match the provided filter, disregarding the take value.",
+            "schema": {
+              "type": "boolean",
+              "example": false
+            },
+            "example": false
+          },
+          {
+            "name": "ResponseFormat",
+            "in": "query",
+            "description": "Gets or sets the return type. Valid options are \"JSON\" and \"CSV\".",
+            "deprecated": true,
+            "schema": {
+              "enum": [
+                "JSON",
+                "CSV"
+              ],
+              "type": "string",
+              "deprecated": true
+            }
+          },
+          {
+            "name": "Destination",
+            "in": "query",
+            "description": "Gets or sets the destination of the request. \"INLINE\" (default) returns the list of resources as the body of the response. \"DOWNLOAD\" returns the list of resources as the body of the response and indicates to the client that it should be downloaded as a file. \"FILE_SERVICE\" sends the list of resources to the file ingestion service and returns the ID of the file to the client in a JSON object.",
+            "deprecated": true,
+            "schema": {
+              "enum": [
+                "INLINE",
+                "DOWNLOAD",
+                "FILE_SERVICE"
+              ],
+              "type": "string",
+              "deprecated": true
+            }
+          },
+          {
+            "name": "FileIngestionWorkspace",
+            "in": "query",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "deprecated": true,
+            "schema": {
+              "type": "string",
+              "example": "846e294a-a007-47ac-9fc2-fac07eab240e",
+              "deprecated": true
+            },
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          },
+          {
+            "name": "x-ni-api-key",
+            "in": "header",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Create assets",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAssetsPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/asset-summary": {
+      "get": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Get asset summary",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetSummaryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/query-assets": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Query assets",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/export-assets": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Export assets report",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportAssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/metadata": {
+      "patch": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Update asset metadata",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMetadataRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMetadataRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMetadataRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMetadataRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMetadataRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAssetsPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/niapm/v1/update-assets": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Update assets",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateAssetsPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/history/query-location": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Query asset location history",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-ni-api-key",
+            "in": "header",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationHistoryRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationHistoryRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationHistoryRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationHistoryRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionHistoryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/delete-assets": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Delete assets",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}": {
+      "get": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Get asset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetModel"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/file": {
+      "post": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Link files to asset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkFilesRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkFilesRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkFilesRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkFilesRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkFilesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinkFilesPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/files/{fileId}": {
+      "delete": {
+        "tags": [
+          "Asset"
+        ],
+        "summary": "Unlink file from asset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoContentResult"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/history/delete-calibrations": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Delete one or more calibration history entries for an asset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteCalibrationHistoryRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteCalibrationHistoryRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteCalibrationHistoryRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteCalibrationHistoryRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteCalibrationHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Partial success: one or more entries could not be deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteCalibrationsPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No content: all entries were successfully deleted"
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/history/calibration": {
+      "get": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Get asset calibration history",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "ReturnCount",
+            "in": "query",
+            "description": "Whether to return the total number of calibration history entries, disregarding the take value.",
+            "schema": {
+              "type": "boolean",
+              "example": false
+            },
+            "example": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalibrationHistoryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/{assetId}/history/export-calibration": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Export calibration history",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCalibrationHistoryRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCalibrationHistoryRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCalibrationHistoryRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCalibrationHistoryRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportCalibrationHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created: a report has been created in file service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportCalibrationHistoryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/receive-from-calibration-dry-run": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Simulate receiving an asset from calibration lab, the purpose of doing a dry run is to offer the UI a list of\nvalidation errors and warnings that the UI can't know otherwise.",
+        "requestBody": {
+          "description": "Model containing information for asset update and location movement for assets returning from calibration.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/receive-from-calibration": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Move assets from calibration to locations.",
+        "requestBody": {
+          "description": "Model containing forecast query parameters.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiveFromCalibrationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/send-for-calibration-dry-run": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Simulate sending an asset to calibration lab, the purpose of doing a dry run is to offer the UI a list of\nvalidation errors and warnings that the UI can't know otherwise.",
+        "requestBody": {
+          "description": "Model containing information for asset update and location movement for assets sent to calibration.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/send-for-calibration": {
+      "post": {
+        "tags": [
+          "Calibration"
+        ],
+        "summary": "Send an asset to calibration lab",
+        "requestBody": {
+          "description": "Model containing information for asset update and location movement for assets sent to calibration.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/SendForCalibrationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/move-location-dry-run": {
+      "post": {
+        "tags": [
+          "LocationMovement"
+        ],
+        "summary": "Simulate moving an assets location, the purpose of doing a dry run is to offer the UI a list of\nvalidation errors and warnings that the UI can't know otherwise.",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/move-location": {
+      "post": {
+        "tags": [
+          "LocationMovement"
+        ],
+        "summary": "Moving an asset to a new location",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveAssetsLocationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MoveAssetsLocationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/query-location-moves": {
+      "post": {
+        "tags": [
+          "LocationMovement"
+        ],
+        "summary": "Query the ids of assets that are in progress of moving.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationMovesRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationMovesRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationMovesRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationMovesRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryLocationMovesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryLocationMovesResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm": {
+      "get": {
+        "tags": [
+          "RootEndpoint"
+        ],
+        "summary": "Get information about the service API",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/niapm/v1": {
+      "get": {
+        "tags": [
+          "RootEndpoint"
+        ],
+        "summary": "Get information about the service V1 API",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/niapm/v1/materialized/search-assets": {
+      "post": {
+        "tags": [
+          "SearchableAsset"
+        ],
+        "summary": "Advanced asset search.",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchAssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/materialized/export-assets": {
+      "post": {
+        "tags": [
+          "SearchableAsset"
+        ],
+        "summary": "Export materialized assets report",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportMaterializedAssetsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportMaterializedAssetsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportMaterializedAssetsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportMaterializedAssetsRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportMaterializedAssetsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportAssetsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/query-asset-utilization-history": {
+      "post": {
+        "tags": [
+          "Utilization"
+        ],
+        "summary": "Query asset utilization history",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetUtilizationHistoryRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetUtilizationHistoryRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetUtilizationHistoryRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetUtilizationHistoryRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryAssetUtilizationHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetUtilizationHistoryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/start-utilization": {
+      "post": {
+        "tags": [
+          "Utilization"
+        ],
+        "summary": "Start utilization",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartUtilizationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartUtilizationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartUtilizationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/StartUtilizationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/StartUtilizationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartUtilizationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/end-utilization": {
+      "post": {
+        "tags": [
+          "Utilization"
+        ],
+        "summary": "End utilization",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndUtilizationRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndUtilizationRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndUtilizationRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/EndUtilizationRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/EndUtilizationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateUtilizationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/niapm/v1/assets/utilization-heartbeat": {
+      "post": {
+        "tags": [
+          "Utilization"
+        ],
+        "summary": "Utilization heartbeat",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UtilizationHeartbeatRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UtilizationHeartbeatRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UtilizationHeartbeatRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/UtilizationHeartbeatRequest"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UtilizationHeartbeatRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateUtilizationPartialSuccessResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssetCreateModel": {
+        "type": "object",
+        "properties": {
+          "modelName": {
+            "type": "string",
+            "description": "Gets or sets model name of the asset.",
+            "nullable": true,
+            "example": "NI PXIe-6368"
+          },
+          "modelNumber": {
+            "type": "integer",
+            "description": "Gets or sets model number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 123
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "Gets or sets serial number of the asset.",
+            "nullable": true,
+            "example": "01BB877A"
+          },
+          "vendorName": {
+            "type": "string",
+            "description": "Gets or sets vendor name of the asset.",
+            "nullable": true,
+            "example": "NI"
+          },
+          "vendorNumber": {
+            "type": "integer",
+            "description": "Gets or sets vendor number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 4244
+          },
+          "busType": {
+            "enum": [
+              "BUILT_IN_SYSTEM",
+              "PCI_PXI",
+              "USB",
+              "GPIB",
+              "VXI",
+              "SERIAL",
+              "TCP_IP",
+              "CRIO",
+              "SCXI",
+              "CDAQ",
+              "SWITCH_BLOCK",
+              "SCC",
+              "FIRE_WIRE",
+              "ACCESSORY",
+              "CAN",
+              "SWITCH_BLOCK_DEVICE",
+              "SLSC"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported bus types for an asset.",
+            "nullable": true,
+            "example": "BUILT_IN_SYSTEM"
+          },
+          "name": {
+            "type": "string",
+            "description": "Gets or sets name of the asset.",
+            "nullable": true,
+            "example": "PCISlot2"
+          },
+          "assetType": {
+            "enum": [
+              "GENERIC",
+              "DEVICE_UNDER_TEST",
+              "FIXTURE",
+              "SYSTEM"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported asset types.",
+            "nullable": true,
+            "example": "GENERIC"
+          },
+          "firmwareVersion": {
+            "type": "string",
+            "description": "Gets or sets firmware version of the asset.",
+            "nullable": true,
+            "example": "A1"
+          },
+          "hardwareVersion": {
+            "type": "string",
+            "description": "Gets or sets hardware version of the asset.",
+            "nullable": true,
+            "example": "12A"
+          },
+          "visaResourceName": {
+            "type": "string",
+            "description": "Gets or sets VISA resource name of the asset.",
+            "nullable": true,
+            "example": "vs-1234"
+          },
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.\nThe maximum number of temperature sensors allowed per asset is 1000.",
+            "nullable": true
+          },
+          "supportsSelfCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsExternalCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports external calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "customCalibrationInterval": {
+            "type": "integer",
+            "description": "Gets or sets the interval represented in months used for computing calibration due date. If not set, the recommended calibration interval from the calibration model is used.",
+            "format": "int32",
+            "nullable": true,
+            "example": 24
+          },
+          "selfCalibration": {
+            "$ref": "#/components/schemas/SelfCalibrationModel"
+          },
+          "isNIAsset": {
+            "type": "boolean",
+            "description": "Gets or sets whether this asset is an NI asset (true) or a third-party asset (false).",
+            "nullable": true,
+            "example": true
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The ID of the workspace containing the asset.",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          },
+          "location": {
+            "$ref": "#/components/schemas/AssetLocationWithPresenceModel"
+          },
+          "externalCalibration": {
+            "$ref": "#/components/schemas/ExternalCalibrationWithChecksumModel"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets properties of the asset.\nThe maximum number of properties allowed per asset is 1000.",
+            "nullable": true,
+            "example": {
+              "Key1": "Value1"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets keywords of the asset.\nThe maximum number of keywords allowed per asset is 1000.",
+            "nullable": true,
+            "example": [
+              "Keyword1"
+            ]
+          },
+          "discoveryType": {
+            "enum": [
+              "AUTOMATIC",
+              "MANUAL"
+            ],
+            "type": "string",
+            "description": "Gets or sets the discovery type.",
+            "default": "MANUAL"
+          },
+          "fileIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets the IDs of the files linked to the asset.\nThe maximum number of file IDs allowed per asset is 1000.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          },
+          "supportsSelfTest": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-test.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsReset": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports reset.",
+            "nullable": true,
+            "example": true
+          },
+          "partNumber": {
+            "type": "string",
+            "description": "Gets or sets part number of the asset.",
+            "nullable": true,
+            "example": "A1234 B5"
+          },
+          "scanCode": {
+            "type": "string",
+            "description": "Gets or sets the scan code of the asset.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for an object describing the properties for creating an asset.\n            \nUnique Asset Identification is required to create an asset. See AssetIdentificationModel for details."
+      },
+      "AssetIdentificationModel": {
+        "type": "object",
+        "properties": {
+          "modelName": {
+            "type": "string",
+            "description": "Gets or sets model name of the asset.",
+            "nullable": true,
+            "example": "NI PXIe-6368"
+          },
+          "modelNumber": {
+            "type": "integer",
+            "description": "Gets or sets model number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 123
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "Gets or sets serial number of the asset.",
+            "nullable": true,
+            "example": "01BB877A"
+          },
+          "vendorName": {
+            "type": "string",
+            "description": "Gets or sets vendor name of the asset.",
+            "nullable": true,
+            "example": "NI"
+          },
+          "vendorNumber": {
+            "type": "integer",
+            "description": "Gets or sets vendor number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 4244
+          },
+          "busType": {
+            "enum": [
+              "BUILT_IN_SYSTEM",
+              "PCI_PXI",
+              "USB",
+              "GPIB",
+              "VXI",
+              "SERIAL",
+              "TCP_IP",
+              "CRIO",
+              "SCXI",
+              "CDAQ",
+              "SWITCH_BLOCK",
+              "SCC",
+              "FIRE_WIRE",
+              "ACCESSORY",
+              "CAN",
+              "SWITCH_BLOCK_DEVICE",
+              "SLSC"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported bus types for an asset.",
+            "nullable": true,
+            "example": "BUILT_IN_SYSTEM"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing properties which identify an asset. An asset is uniquely identified by a combination of:\n    - busType\n    - modelName or modelNumber\n    - vendorName or vendorNumber\n    - serialNumber or minionId (part of the Location)"
+      },
+      "AssetLocationModel": {
+        "type": "object",
+        "properties": {
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the asset is located.",
+            "nullable": true,
+            "example": "NI_PXIe-8135_Embedded_Controller--MAC-00-80-2F-23-52-65"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets the physical location of the asset. An asset can be either in a system, in which case it has a\nMinionID, or be in a physical location.",
+            "nullable": true,
+            "example": "Cabinet 1"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent of the asset.",
+            "nullable": true,
+            "example": "Chassis1"
+          },
+          "resourceUri": {
+            "type": "string",
+            "description": "Gets or sets identifier of a resource.",
+            "nullable": true,
+            "example": "1/4243/1949942980/01BB877A/3"
+          },
+          "slotNumber": {
+            "type": "integer",
+            "description": "Gets or sets the number of the slot in which the asset is located.",
+            "format": "int32",
+            "nullable": true,
+            "example": 2
+          },
+          "state": {
+            "$ref": "#/components/schemas/AssetPresenceWithSystemConnectionModel"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for information about the asset location, presence and the connection status of the system in which it resides."
+      },
+      "AssetLocationWithPresenceModel": {
+        "type": "object",
+        "properties": {
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the asset is located.",
+            "nullable": true,
+            "example": "NI_PXIe-8135_Embedded_Controller--MAC-00-80-2F-23-52-65"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets the physical location of the asset. An asset can be either in a system, in which case it has a\nMinionID, or be in a physical location.",
+            "nullable": true,
+            "example": "Cabinet 1"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent of the asset.",
+            "nullable": true,
+            "example": "Chassis1"
+          },
+          "resourceUri": {
+            "type": "string",
+            "description": "Gets or sets identifier of a resource.",
+            "nullable": true,
+            "example": "1/4243/1949942980/01BB877A/3"
+          },
+          "slotNumber": {
+            "type": "integer",
+            "description": "Gets or sets the number of the slot in which the asset is located.",
+            "format": "int32",
+            "nullable": true,
+            "example": 2
+          },
+          "state": {
+            "$ref": "#/components/schemas/AssetPresenceModel"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for information about the asset location and presence. Used in create or update operations."
+      },
+      "AssetLocationWithPresenceUpdateModel": {
+        "type": "object",
+        "properties": {
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the asset is located.",
+            "nullable": true,
+            "example": "NI_PXIe-8135_Embedded_Controller--MAC-00-80-2F-23-52-65"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets the physical location of the asset. An asset can be either in a system, in which case it has a\nMinionID, or be in a physical location.",
+            "nullable": true,
+            "example": "Cabinet 1"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent of the asset.",
+            "nullable": true,
+            "example": "Chassis1"
+          },
+          "resourceUri": {
+            "type": "string",
+            "description": "Gets or sets identifier of a resource.",
+            "nullable": true,
+            "example": "1/4243/1949942980/01BB877A/3"
+          },
+          "slotNumber": {
+            "type": "integer",
+            "description": "Gets or sets the number of the slot in which the asset is located.",
+            "format": "int32",
+            "nullable": true,
+            "example": 2
+          },
+          "state": {
+            "$ref": "#/components/schemas/AssetPresenceUpdateModel"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for information about the asset location and presence. Used in create or update operations."
+      },
+      "AssetModel": {
+        "type": "object",
+        "properties": {
+          "modelName": {
+            "type": "string",
+            "description": "Gets or sets model name of the asset.",
+            "nullable": true,
+            "example": "NI PXIe-6368"
+          },
+          "modelNumber": {
+            "type": "integer",
+            "description": "Gets or sets model number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 123
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "Gets or sets serial number of the asset.",
+            "nullable": true,
+            "example": "01BB877A"
+          },
+          "vendorName": {
+            "type": "string",
+            "description": "Gets or sets vendor name of the asset.",
+            "nullable": true,
+            "example": "NI"
+          },
+          "vendorNumber": {
+            "type": "integer",
+            "description": "Gets or sets vendor number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 4244
+          },
+          "busType": {
+            "enum": [
+              "BUILT_IN_SYSTEM",
+              "PCI_PXI",
+              "USB",
+              "GPIB",
+              "VXI",
+              "SERIAL",
+              "TCP_IP",
+              "CRIO",
+              "SCXI",
+              "CDAQ",
+              "SWITCH_BLOCK",
+              "SCC",
+              "FIRE_WIRE",
+              "ACCESSORY",
+              "CAN",
+              "SWITCH_BLOCK_DEVICE",
+              "SLSC"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported bus types for an asset.",
+            "nullable": true,
+            "example": "BUILT_IN_SYSTEM"
+          },
+          "name": {
+            "type": "string",
+            "description": "Gets or sets name of the asset.",
+            "nullable": true,
+            "example": "PCISlot2"
+          },
+          "assetType": {
+            "enum": [
+              "GENERIC",
+              "DEVICE_UNDER_TEST",
+              "FIXTURE",
+              "SYSTEM"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported asset types.",
+            "nullable": true,
+            "example": "GENERIC"
+          },
+          "discoveryType": {
+            "enum": [
+              "AUTOMATIC",
+              "MANUAL"
+            ],
+            "type": "string",
+            "description": "Gets or sets the discovery type.",
+            "nullable": true,
+            "example": "MANUAL"
+          },
+          "firmwareVersion": {
+            "type": "string",
+            "description": "Gets or sets firmware version of the asset.",
+            "nullable": true,
+            "example": "A1"
+          },
+          "hardwareVersion": {
+            "type": "string",
+            "description": "Gets or sets hardware version of the asset.",
+            "nullable": true,
+            "example": "12A"
+          },
+          "visaResourceName": {
+            "type": "string",
+            "description": "Gets or sets VISA resource name of the asset.",
+            "nullable": true,
+            "example": "vs-1234"
+          },
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.",
+            "nullable": true
+          },
+          "supportsSelfCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsExternalCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports external calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "customCalibrationInterval": {
+            "type": "integer",
+            "description": "Gets or sets the interval represented in months used for computing calibration due date. If not set, the recommended calibration interval from the calibration model is used.",
+            "format": "int32",
+            "nullable": true,
+            "example": 24
+          },
+          "selfCalibration": {
+            "$ref": "#/components/schemas/SelfCalibrationProjectedModel"
+          },
+          "isNIAsset": {
+            "type": "boolean",
+            "description": "Gets or sets whether this asset is an NI asset (true) or a third-party asset (false).",
+            "nullable": true,
+            "example": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Gets or sets unique identifier of the asset.",
+            "nullable": true,
+            "example": "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+          },
+          "location": {
+            "$ref": "#/components/schemas/AssetLocationModel"
+          },
+          "calibrationStatus": {
+            "enum": [
+              "OK",
+              "APPROACHING_RECOMMENDED_DUE_DATE",
+              "PAST_RECOMMENDED_DUE_DATE",
+              "OUT_FOR_CALIBRATION"
+            ],
+            "type": "string",
+            "description": "Gets or sets the calibration category the asset belongs to based on the next due calibration date.",
+            "nullable": true
+          },
+          "isSystemController": {
+            "type": "boolean",
+            "description": "Gets or sets whether this asset represents a System Controller.",
+            "nullable": true,
+            "example": true
+          },
+          "externalCalibration": {
+            "$ref": "#/components/schemas/ExternalCalibrationModel"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace.",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets key-value-pair metadata associated with an asset.",
+            "nullable": true,
+            "example": {
+              "Key1": "Value1"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets words or phrases associated with an asset.",
+            "nullable": true,
+            "example": [
+              "Keyword1"
+            ]
+          },
+          "lastUpdatedTimestamp": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date that the asset has had a property update.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2018-05-07T18:58:05.219692Z"
+          },
+          "fileIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets all files linked to the asset.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          },
+          "supportsSelfTest": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-test.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsReset": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports reset.",
+            "nullable": true,
+            "example": true
+          },
+          "partNumber": {
+            "type": "string",
+            "description": "Gets or sets part number of the asset.",
+            "nullable": true,
+            "example": "A1234 B5"
+          },
+          "outForCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset is out for calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "scanCode": {
+            "type": "string",
+            "description": "Gets or sets the scan code of the asset.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for an object describing an asset with all of its properties."
+      },
+      "AssetPresenceModel": {
+        "type": "object",
+        "properties": {
+          "assetPresence": {
+            "enum": [
+              "NOT_PRESENT",
+              "PRESENT",
+              "INITIALIZING",
+              "UNKNOWN"
+            ],
+            "type": "string",
+            "description": "Gets or sets the status of an asset's presence in a system."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the presence of an asset. Wraps the AssetPresenceStatus into an object."
+      },
+      "AssetPresenceUpdateModel": {
+        "type": "object",
+        "properties": {
+          "assetPresence": {
+            "enum": [
+              "NOT_PRESENT",
+              "PRESENT",
+              "REMOVED",
+              "INITIALIZING",
+              "UNKNOWN"
+            ],
+            "type": "string",
+            "description": "Gets or sets the status of an asset's presence in a system."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the presence of an asset. Wraps the AssetPresenceStatus into an object."
+      },
+      "AssetPresenceWithSystemConnectionModel": {
+        "type": "object",
+        "properties": {
+          "assetPresence": {
+            "enum": [
+              "NOT_PRESENT",
+              "PRESENT",
+              "INITIALIZING",
+              "UNKNOWN"
+            ],
+            "type": "string",
+            "description": "Gets or sets the status of an asset's presence in a system.",
+            "nullable": true
+          },
+          "systemConnection": {
+            "enum": [
+              "APPROVED",
+              "DISCONNECTED",
+              "CONNECTED_UPDATE_PENDING",
+              "CONNECTED",
+              "CONNECTED_UPDATE_FAILED",
+              "UNSUPPORTED",
+              "ACTIVATED",
+              "CONNECTED_UPDATE_SUCCESSFUL"
+            ],
+            "type": "string",
+            "description": "Gets or sets whether or not the minion is connected to the server and has updated the server with its data.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the presence of an asset and the connection of the system in which it resides."
+      },
+      "AssetSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "active": {
+            "type": "integer",
+            "description": "Gets or sets number of assets which are active, i.e. present in a connected system.",
+            "format": "int32",
+            "example": 12
+          },
+          "notActive": {
+            "type": "integer",
+            "description": "Gets or sets number of assets which are not active.",
+            "format": "int32",
+            "example": 5
+          },
+          "total": {
+            "type": "integer",
+            "description": "Gets or sets total number of managed assets.",
+            "format": "int32",
+            "example": 17
+          },
+          "inUse": {
+            "type": "integer",
+            "description": "Gets or sets total number of used assets.",
+            "format": "int32",
+            "nullable": true,
+            "example": 10
+          },
+          "notInUse": {
+            "type": "integer",
+            "description": "Gets or sets total number of unused assets.",
+            "format": "int32",
+            "nullable": true,
+            "example": 7
+          },
+          "withAlarms": {
+            "type": "integer",
+            "description": "Gets or sets total number of assets with alarms",
+            "format": "int32",
+            "nullable": true,
+            "example": 3
+          },
+          "approachingRecommendedDueDate": {
+            "type": "integer",
+            "description": "Gets or sets number of assets approaching calibration date.",
+            "format": "int32",
+            "example": 3
+          },
+          "pastRecommendedDueDate": {
+            "type": "integer",
+            "description": "Gets or sets number of assets past their calibration date.",
+            "format": "int32",
+            "example": 4
+          },
+          "totalCalibrated": {
+            "type": "integer",
+            "description": "Gets or sets total number of assets supporting calibration.",
+            "format": "int32",
+            "nullable": true,
+            "example": 7
+          },
+          "outForCalibration": {
+            "type": "integer",
+            "description": "Gets or sets total number of assets out of calibration.",
+            "format": "int32",
+            "example": 2
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for asset summary response containing the total number of assets, the number of assets which are active, i.e. present in a connected system, and the number of assets which are not active."
+      },
+      "AssetUpdateModel": {
+        "type": "object",
+        "properties": {
+          "modelName": {
+            "type": "string",
+            "description": "Gets or sets model name of the asset.",
+            "nullable": true,
+            "example": "NI PXIe-6368"
+          },
+          "modelNumber": {
+            "type": "integer",
+            "description": "Gets or sets model number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 123
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "Gets or sets serial number of the asset.",
+            "nullable": true,
+            "example": "01BB877A"
+          },
+          "vendorName": {
+            "type": "string",
+            "description": "Gets or sets vendor name of the asset.",
+            "nullable": true,
+            "example": "NI"
+          },
+          "vendorNumber": {
+            "type": "integer",
+            "description": "Gets or sets vendor number of the asset.",
+            "format": "int32",
+            "nullable": true,
+            "example": 4244
+          },
+          "busType": {
+            "enum": [
+              "BUILT_IN_SYSTEM",
+              "PCI_PXI",
+              "USB",
+              "GPIB",
+              "VXI",
+              "SERIAL",
+              "TCP_IP",
+              "CRIO",
+              "SCXI",
+              "CDAQ",
+              "SWITCH_BLOCK",
+              "SCC",
+              "FIRE_WIRE",
+              "ACCESSORY",
+              "CAN",
+              "SWITCH_BLOCK_DEVICE",
+              "SLSC"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported bus types for an asset.",
+            "nullable": true,
+            "example": "BUILT_IN_SYSTEM"
+          },
+          "name": {
+            "type": "string",
+            "description": "Gets or sets name of the asset.",
+            "nullable": true,
+            "example": "PCISlot2"
+          },
+          "assetType": {
+            "enum": [
+              "GENERIC",
+              "DEVICE_UNDER_TEST",
+              "FIXTURE",
+              "SYSTEM"
+            ],
+            "type": "string",
+            "description": "Gets or sets all supported asset types.",
+            "nullable": true,
+            "example": "GENERIC"
+          },
+          "firmwareVersion": {
+            "type": "string",
+            "description": "Gets or sets firmware version of the asset.",
+            "nullable": true,
+            "example": "A1"
+          },
+          "hardwareVersion": {
+            "type": "string",
+            "description": "Gets or sets hardware version of the asset.",
+            "nullable": true,
+            "example": "12A"
+          },
+          "visaResourceName": {
+            "type": "string",
+            "description": "Gets or sets VISA resource name of the asset.",
+            "nullable": true,
+            "example": "vs-1234"
+          },
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.\nThe maximum number of temperature sensors allowed per asset is 1000.",
+            "nullable": true
+          },
+          "supportsSelfCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsExternalCalibration": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports external calibration.\nNote that when an asset is updated to no longer support external calibration, its calibration data and calibration history are deleted.",
+            "nullable": true,
+            "example": true
+          },
+          "customCalibrationInterval": {
+            "type": "integer",
+            "description": "Gets or sets the interval represented in months used for computing calibration due date. If not set, the recommended calibration interval from the calibration model is used.",
+            "format": "int32",
+            "nullable": true,
+            "example": 24
+          },
+          "selfCalibration": {
+            "$ref": "#/components/schemas/SelfCalibrationModel"
+          },
+          "isNIAsset": {
+            "type": "boolean",
+            "description": "Gets or sets whether this asset is an NI asset (true) or a third-party asset (false).",
+            "nullable": true,
+            "example": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Gets or sets unique identifier of the asset.",
+            "nullable": true,
+            "example": "123;01BB877A;4244;0"
+          },
+          "location": {
+            "$ref": "#/components/schemas/AssetLocationWithPresenceUpdateModel"
+          },
+          "externalCalibration": {
+            "$ref": "#/components/schemas/ExternalCalibrationWithChecksumModel"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The ID of the workspace containing the asset.",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets properties of the asset.\nThe maximum number of properties allowed per asset is 1000.",
+            "nullable": true,
+            "example": {
+              "Key1": "Value1"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets keywords of the asset.\nThe maximum number of keywords allowed per asset is 1000.",
+            "nullable": true,
+            "example": [
+              "Keyword1"
+            ]
+          },
+          "fileIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets the FileIds of the asset.\nThe maximum number of file IDs allowed per asset is 1000.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          },
+          "supportsSelfTest": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports self-test.",
+            "nullable": true,
+            "example": true
+          },
+          "supportsReset": {
+            "type": "boolean",
+            "description": "Gets or sets whether the asset supports reset.",
+            "nullable": true,
+            "example": true
+          },
+          "partNumber": {
+            "type": "string",
+            "description": "Gets or sets part number of the asset.",
+            "nullable": true,
+            "example": "A1234 B5"
+          },
+          "outForCalibration": {
+            "type": "boolean",
+            "description": "Get or set whether the asset is out for calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "scanCode": {
+            "type": "string",
+            "description": "Gets or sets the scan code of the asset.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for an object describing the properties for updating an asset.\n            \nUnique Asset Identification is required to create an asset. If the id property is not specified, a set of properties are required to identify an asset. See AssetIdentificationModel for details. If the id is specified on the model, the following properties will be ignored: busType, modelName, modelNumber, vendorName, vendorNumber and serialNumber."
+      },
+      "AssetUtilizationHistoryItem": {
+        "type": "object",
+        "properties": {
+          "utilizationIdentifier": {
+            "type": "string",
+            "description": "Gets or sets string representing the unique identifier of an asset utilization history record.",
+            "nullable": true
+          },
+          "assetIdentifier": {
+            "type": "string",
+            "description": "Gets or sets string representing the unique identifier of an asset.",
+            "nullable": true
+          },
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the asset is located.",
+            "nullable": true
+          },
+          "category": {
+            "type": "string",
+            "description": "Gets or sets string representing the utilization task category.",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "description": "Gets or sets string representing the name of the task.",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "description": "Gets or sets string representing the name of the operator who utilized the asset.",
+            "nullable": true
+          },
+          "startTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the start of an utilization.\nThis parameter has the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time"
+          },
+          "endTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the end of an utilization.\nThis parameter has the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "heartbeatTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the heartbeat of an utilization.\nThis parameter has the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssetUtilizationHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "assetUtilizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetUtilizationHistoryItem"
+            },
+            "description": "Gets or sets array of asset utilizations.",
+            "nullable": true
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Gets or sets a token which allows the user to resume a query at the next item in the matching asset utilization history set. When querying for asset utilization history, a token will be returned if a query may be continued. To obtain the next page of asset utilization history records, pass the token to the service on a subsequent request.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssetsResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetModel"
+            },
+            "description": "Gets or sets array of assets.",
+            "nullable": true
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "The number of matching assets, if returnCount is true. This value is set to -1 if returnCount is false.",
+            "format": "int32",
+            "example": 1
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for assets Response containing the assets satisfying the query and the total count of matching assets."
+      },
+      "BaseResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CalibrationHistoryModel": {
+        "type": "object",
+        "properties": {
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.",
+            "nullable": true
+          },
+          "isLimited": {
+            "type": "boolean",
+            "description": "Gets or sets whether the last external calibration of the asset was a limited calibration.",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date the asset was externally calibrated.",
+            "format": "date-time"
+          },
+          "recommendedInterval": {
+            "type": "integer",
+            "description": "Gets or sets the manufacturer's recommended calibration interval in months.",
+            "format": "int32",
+            "nullable": true
+          },
+          "nextRecommendedDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the recommended date for the next external calibration.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "nextCustomDueDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the date for the next external calibration.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "resolvedDueDate": {
+            "type": "string",
+            "description": "Gets ISO-8601 formatted timestamp specifying the resolved due date for external calibration. This\ntakes into account NextCustomDueDate, Asset.CustomCalibrationInterval and NextRecommendedDate.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "comments": {
+            "type": "string",
+            "description": "Gets or sets calibration comments provided by an operator.",
+            "nullable": true
+          },
+          "entryType": {
+            "enum": [
+              "AUTOMATIC",
+              "MANUAL"
+            ],
+            "type": "string",
+            "description": "Gets or sets whether SystemLink automatically discovered the calibration data for an asset or if it was manually entered.",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Gets or sets the calibration entry identifier.",
+            "nullable": true
+          },
+          "calibrationType": {
+            "enum": [
+              "SELF_CALIBRATION",
+              "EXTERNAL_CALIBRATION"
+            ],
+            "type": "string",
+            "description": "Gets or sets the type of calibration the asset received, such as self or external calibration."
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the creation date of the entry.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "Gets or sets the user id who created the calibration entry.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the calibration history for an asset."
+      },
+      "CalibrationHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "calibrationHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CalibrationHistoryModel"
+            },
+            "description": "Gets or sets array of calibration history entries.",
+            "nullable": true
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "The number of calibration history entries, if returnCount is true. This value is set to -1 if returnCount is false.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for calibration history response containing all calibration history entries for the requested asset."
+      },
+      "ConnectionHistoryModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Gets or sets unique identifier of the connection history entry.",
+            "nullable": true,
+            "example": "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+          },
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the asset is located.",
+            "nullable": true,
+            "example": "NI_PXIe-8135_Embedded_Controller--MAC-00-80-2F-23-52-65"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets identifier of the physical location where the asset is located.",
+            "nullable": true,
+            "example": "Cabinet"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent of the asset.",
+            "nullable": true,
+            "example": "Chassis1"
+          },
+          "resourceUri": {
+            "type": "string",
+            "description": "Gets or sets identifier of a resource.",
+            "nullable": true,
+            "example": "1/4243/1949942980/01BB877A/3"
+          },
+          "slotNumber": {
+            "type": "integer",
+            "description": "Gets or sets the number of the slot in which the asset is located.",
+            "format": "int32",
+            "example": 2
+          },
+          "startTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value when the start event happened.\nThis parameter has the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time"
+          },
+          "startSystemConnection": {
+            "enum": [
+              "DISCONNECTED",
+              "CONNECTED"
+            ],
+            "type": "string",
+            "description": "Gets or sets the system connection of the first event."
+          },
+          "startAssetPresence": {
+            "enum": [
+              "NOT_PRESENT",
+              "PRESENT",
+              "INITIALIZING",
+              "UNKNOWN"
+            ],
+            "type": "string",
+            "description": "Gets or sets the asset presence of the first event."
+          },
+          "endTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value when the end event happened.\nThis parameter has the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endSystemConnection": {
+            "enum": [
+              "APPROVED",
+              "DISCONNECTED",
+              "CONNECTED_UPDATE_PENDING",
+              "CONNECTED",
+              "CONNECTED_UPDATE_FAILED",
+              "UNSUPPORTED",
+              "ACTIVATED",
+              "CONNECTED_UPDATE_SUCCESSFUL"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "endAssetPresence": {
+            "enum": [
+              "NOT_PRESENT",
+              "PRESENT",
+              "INITIALIZING",
+              "UNKNOWN"
+            ],
+            "type": "string",
+            "description": "Gets or sets the asset presence of the end event.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConnectionHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "historyItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConnectionHistoryModel"
+            },
+            "nullable": true
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Gets or sets a token which allows the user to resume a query at the next item in the matching asset location history set. When querying for asset location history, a token will be returned if a query may be continued. To obtain the next page of asset location history records, pass the token to the service on a subsequent request.",
+            "nullable": true,
+            "example": null
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateAssetsPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetModel"
+            },
+            "description": "Gets or sets array of created assets.",
+            "nullable": true
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetCreateModel"
+            },
+            "description": "Gets or sets array of assets create requests that failed.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for create Assets Partial Success Response."
+      },
+      "CreateAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetCreateModel"
+            },
+            "description": "Gets or sets multiple assets that should be created.\nThe maximum number of assets allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request body containing an array of assets that should be created."
+      },
+      "DeleteAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets multiple asset IDs for which to delete all data.\nThe maximum number of asset IDs allowed per request is 1000.",
+            "nullable": true,
+            "example": [
+              "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request body containing IDs of the assets to delete all information for."
+      },
+      "DeleteAssetsResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of asset identifiers which were deleted.",
+            "nullable": true,
+            "example": [
+              "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+            ]
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of asset identifiers that failed to delete.",
+            "nullable": true,
+            "example": [
+              "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for delete Assets Response containing the ids of the assets which were deleted, the ids of the assets which failed to be deleted and any errors encountered."
+      },
+      "DeleteCalibrationHistoryRequest": {
+        "type": "object",
+        "properties": {
+          "calibrationIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets IDs of the calibration entries to delete.\nThe maximum number of calibration IDs allowed per request is 1000.",
+            "nullable": true,
+            "example": [
+              "5c4f0834174ae321b8a95a03"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeleteCalibrationsPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "calibrationIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of calibration entry identifiers that were deleted.",
+            "nullable": true,
+            "example": [
+              "5c4f0834174ae321b8a95a03"
+            ]
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of calibration entry identifiers that failed to delete.",
+            "nullable": true,
+            "example": [
+              "5c4f0834174ae321b8a95a03"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for delete Calibrations Partial Success Response."
+      },
+      "EndUtilizationRequest": {
+        "type": "object",
+        "properties": {
+          "utilizationIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array representing the unique identifier of an asset utilization history record.",
+            "nullable": true,
+            "example": [
+              "2916201B245D642430"
+            ]
+          },
+          "utilizationTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the end of an asset utilization.\nThis parameter must have the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time",
+            "example": "2019-05-01T00:00:00.519Z"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for assets. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and'. Example: 'x and y'\n- Logical OR operator 'or'. Example: 'x or y'\n- Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'\n- Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'\n            \nValid asset properties that can be used in the filter:\n- AssetIdentifier: String representing the unique identifier of an asset.\n- SerialNumber: String representing the serial number of an asset.\n- ModelName: String representing the model name of an asset.\n- ModelNumber: Unsigned integer representing the model number of an asset.\n- VendorName: String representing the vendor name of an asset.\n- VendorNumber: Unsigned integer representing the vendor number of an asset.\n- PartNumber: String representing the part number of an asset.\n- AssetName: String representing the asset name.\n- AssetType: String enumeration representing the asset type. Possible values are: GENERIC, DEVICE_UNDER_TEST, FIXTURE, SYSTEM.\n- FirmwareVersion: String representing the firmware version of an asset.\n- HardwareVersion: String representing the hardware version of an asset.\n- BusType: String enumeration representing the bus type of an asset. Possible values are: BUILT_IN_SYSTEM, PCI_PXI, USB, GPIB, VXI, SERIAL, TCP_IP, CRIO, SCXI, CDAQ, SWITCH_BLOCK, SCC, FIRE_WIRE, ACCESSORY, CAN, SWITCH_BLOCK_DEVICE, SLSC.\n- IsNIAsset: Boolean flag specifying whether the asset is an NI asset or a third-party asset.\n- Keywords: Collection of string values representing asset metadata keywords. Example: 'Keywords=[\"keyword1\", \"keyword2\"]'.\n- Properties: Collection of key-value pairs, each key-value pair representing an asset metadata property. Example: 'Properties=[\"key1\":\"value1\", \"key2\":\"value2\"]'.\n- Location.MinionId: String representing the identifier of the minion in which the asset is located in.\n- Location.SlotNumber: Unsigned integer representing the slot number the asset is located in.\n- Location.AssetState.SystemConnection: String enumeration representing the connection state of the system the asset is currently located in. Possible values are: DISCONNECTED, CONNECTED. To maintain compatibility with previous versions of SystemLink, the values [APPROVED, UNSUPPORTED, ACTIVATED] are considered equivalent to DISCONNECTED and [CONNECTED_UPDATE_PENDING, CONNECTED_UPDATE_SUCCESSFUL, CONNECTED_UPDATE_FAILED] are equivalent to CONNECTED.\n- Location.AssetState.AssetPresence: String enumeration representing the present status of an asset in a system. Possible values are: INITIALIZING, UNKNOWN, NOT_PRESENT, PRESENT.\n- SupportsSelfCalibration: Boolean flag specifying whether the asset supports self-calibration.\n- SelfCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was self-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- SupportsExternalCalibration: Boolean flag specifying whether the asset supports external calibration.\n- CalibrationStatus: String enumeration representing the calibration status of an asset. Possible values are: OK, APPROACHING_RECOMMENDED_DUE_DATE, PAST_RECOMMENDED_DUE_DATE, OUT_FOR_CALIBRATION.\n- ExternalCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was externally-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- ExternalCalibration.NextRecommendedDate: ISO-8601 formatted timestamp string specifying the recommended date for the next external calibration. Example: \"2018-05-20T00:00:00Z\".\nThis value is overwritten by the NextCustomDueDate if it is set, otherwise it is calculated based on the RecommendedInterval.\n- ExternalCalibration.RecommendedInterval: Integer representing the manufacturer-recommended calibration interval, in months.\n- ExternalCalibration.Comments: String representing any external calibration comments.\n- ExternalCalibration.IsLimited: Boolean flag specifying whether the last external calibration was a limited calibration.",
+            "nullable": true,
+            "example": ""
+          },
+          "responseFormat": {
+            "enum": [
+              "CSV"
+            ],
+            "type": "string",
+            "description": "Gets or sets the return type. Valid option is \"CSV\"."
+          },
+          "destination": {
+            "enum": [
+              "DOWNLOAD",
+              "FILE_SERVICE"
+            ],
+            "type": "string",
+            "description": "Gets or sets the destination of the request. \"DOWNLOAD\" returns the list of resources as the body of the response and indicates to the client that it should be downloaded as a file. \"FILE_SERVICE\" sends the list of resources to the file ingestion service and returns the ID of the file to the client in a JSON object."
+          },
+          "fileIngestionWorkspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportAssetsResponse": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "description": "Gets or sets file identifier in the file ingestion service.",
+            "nullable": true,
+            "example": "608a5684800e325b48837c2a"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportCalibrationHistoryRequest": {
+        "type": "object",
+        "properties": {
+          "responseFormat": {
+            "enum": [
+              "CSV"
+            ],
+            "type": "string",
+            "description": "Gets or sets the return type."
+          },
+          "destination": {
+            "enum": [
+              "DOWNLOAD",
+              "FILE_SERVICE"
+            ],
+            "type": "string",
+            "description": "Gets or sets the destination of the request."
+          },
+          "fileIngestionWorkspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing options for exporting history."
+      },
+      "ExportCalibrationHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "description": "Gets or sets file identifier in the file ingestion service.",
+            "nullable": true,
+            "example": "608a5684800e325b48837c2a"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExportMaterializedAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for assets.",
+            "nullable": true,
+            "example": ""
+          },
+          "responseFormat": {
+            "enum": [
+              "CSV"
+            ],
+            "type": "string",
+            "description": "Gets or sets the return type. Valid option is \"CSV\"."
+          },
+          "destination": {
+            "enum": [
+              "DOWNLOAD",
+              "FILE_SERVICE"
+            ],
+            "type": "string",
+            "description": "Gets or sets the destination of the request. \"DOWNLOAD\" returns the list of resources as the body of the response and indicates to the client that it should be downloaded as a file. \"FILE_SERVICE\" sends the list of resources to the file ingestion service and returns the ID of the file to the client in a JSON object."
+          },
+          "fileIngestionWorkspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for exporting materialized assets."
+      },
+      "ExternalCalibrationModel": {
+        "type": "object",
+        "properties": {
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.",
+            "nullable": true
+          },
+          "isLimited": {
+            "type": "boolean",
+            "description": "Gets or sets whether the last external calibration of the asset was a limited calibration.",
+            "nullable": true,
+            "example": true
+          },
+          "date": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date the asset was externally calibrated.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2022-11-14T18:13:04.182Z"
+          },
+          "recommendedInterval": {
+            "type": "integer",
+            "description": "Gets or sets the manufacturer's recommended calibration interval in months.",
+            "format": "int32",
+            "nullable": true,
+            "example": 12
+          },
+          "nextRecommendedDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the recommended date for the next external calibration.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2023-11-14T18:13:04.182Z"
+          },
+          "nextCustomDueDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the date for the next external calibration.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2023-06-07T18:58:05.000Z"
+          },
+          "resolvedDueDate": {
+            "type": "string",
+            "description": "Gets ISO-8601 formatted timestamp specifying the resolved due date for external calibration. This\ntakes into account NextCustomDueDate, Asset.CustomCalibrationInterval and NextRecommendedDate.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "comments": {
+            "type": "string",
+            "description": "Gets or sets calibration comments provided by an operator.",
+            "nullable": true,
+            "example": "This is a comment."
+          },
+          "entryType": {
+            "enum": [
+              "AUTOMATIC",
+              "MANUAL"
+            ],
+            "type": "string",
+            "description": "Gets or sets whether SystemLink automatically discovered the calibration data for an asset or if it was manually entered.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ExternalCalibrationWithChecksumModel": {
+        "type": "object",
+        "properties": {
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.\nThe maximum number of temperature sensors allowed per external calibration is 1000.",
+            "nullable": true
+          },
+          "isLimited": {
+            "type": "boolean",
+            "description": "Gets or sets whether the last external calibration of the asset was a limited calibration.",
+            "nullable": true,
+            "example": false
+          },
+          "date": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date the asset was externally calibrated.\nA date newer the the current calibration date will set the out for calibration flag to false.",
+            "format": "date-time",
+            "example": "2022-11-14T20:42:11.583Z"
+          },
+          "recommendedInterval": {
+            "type": "integer",
+            "description": "Gets or sets the manufacturer's recommended calibration interval in months.",
+            "format": "int32",
+            "example": 12
+          },
+          "nextRecommendedDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the recommended date for the next external calibration.",
+            "format": "date-time",
+            "example": "2023-11-14T20:42:11.583Z"
+          },
+          "nextCustomDueDate": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the date for the next external calibration.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2024-11-14T20:42:11.583Z"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Gets or sets calibration comments provided by an operator.",
+            "nullable": true,
+            "example": "This is a comment."
+          },
+          "entryType": {
+            "enum": [
+              "AUTOMATIC",
+              "MANUAL"
+            ],
+            "type": "string",
+            "description": "Gets or sets whether SystemLink automatically discovered the calibration data for an asset or if it was manually entered.",
+            "nullable": true
+          },
+          "checksum": {
+            "type": "string",
+            "description": "Gets or sets checksum for the external calibration.",
+            "nullable": true,
+            "example": "7d9f4953655d48a6a5fd68e9dfd41345"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for data from the last external calibration including checksum."
+      },
+      "HttpError": {
+        "title": "Error",
+        "required": [
+          "name",
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "String error code",
+            "example": "AssetPerformanceManagement.InvalidAssetIdentifier"
+          },
+          "code": {
+            "type": "integer",
+            "description": "Numeric error code",
+            "format": "int32",
+            "nullable": true,
+            "example": -253442
+          },
+          "message": {
+            "type": "string",
+            "description": "Complete error message",
+            "example": "Asset identifier 62254711-c4d8-4aab-b3cd-c8caeeaa3875 is invalid."
+          },
+          "resourceType": {
+            "type": "string",
+            "description": "Type of resource associated with the error",
+            "nullable": true,
+            "example": "Asset"
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "Identifier of the resource associated with the error",
+            "nullable": true,
+            "example": "62254711-c4d8-4aab-b3cd-c8caeeaa3875"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Positional argument values for the error code",
+            "example": [
+              "62254711-c4d8-4aab-b3cd-c8caeeaa3875"
+            ]
+          },
+          "innerErrors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HttpError"
+            },
+            "description": "Inner errors when the top-level error represents more than one error",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Contains error information.",
+        "example": {
+          "name": "Skyline.OneOrMoreErrorsOccurred",
+          "code": -251041,
+          "message": "One or more errors occurred. See the contained list for details of each error.",
+          "args": [ ],
+          "innerErrors": [
+            {
+              "name": "AssetPerformanceManagement.InvalidAssetIdentifier",
+              "code": -253442,
+              "message": "Asset identifier 62254711-c4d8-4aab-b3cd-c8caeeaa3875 is invalid.",
+              "resourceType": "Asset",
+              "resourceId": "62254711-c4d8-4aab-b3cd-c8caeeaa3875",
+              "args": [
+                "62254711-c4d8-4aab-b3cd-c8caeeaa3875"
+              ],
+              "innerErrors": [ ]
+            }
+          ]
+        }
+      },
+      "LinkFilesPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "succeeded": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The file ids which were successfully linked.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The file ids which failed to link.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for link files Partial Success Response."
+      },
+      "LinkFilesRequest": {
+        "type": "object",
+        "properties": {
+          "fileIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets file IDs associated with an asset.\nThe maximum number of file IDs allowed per request is 1000.",
+            "nullable": true,
+            "example": [
+              "608a5684800e325b48837c2a"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the asset link files request."
+      },
+      "MoveAssetLocationModel": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorCode": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "currentJobId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "enum": [
+              "QUEUED",
+              "IN_PROGRESS",
+              "CANCELING",
+              "FAILED"
+            ],
+            "type": "string",
+            "description": "Status of MoveAssetLocation operation"
+          },
+          "progress": {
+            "enum": [
+              "NOT_STARTED",
+              "REMOVE_JOB_CREATED",
+              "REMOVE_JOB_COMPLETED",
+              "ADD_JOB_CREATED",
+              "ADD_JOB_COMPLETED"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MoveAssetLocationOperation": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the asset being moved.",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "systemId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the system to which the asset is being moved.\nEither this, or PhysicalLocation are mandatory",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets physical location to which the asset is being moved.\nEither this, or SystemId are mandatory",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent within the target location to which the asset is being moved.",
+            "nullable": true,
+            "example": "Chassis 1"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MoveAssetsLocationPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "validLocationMovements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidLocationMovementModel"
+            },
+            "description": "Gets or sets array of move operations that can be performed successfully.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model which represents a success response for moving assets."
+      },
+      "MoveAssetsLocationRequest": {
+        "type": "object",
+        "properties": {
+          "assetLocationMoveOperations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveAssetLocationOperation"
+            },
+            "description": "Gets or sets a list of operations that will move an asset from one location to another.\nThe maximum number of move operations allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "NoContentResult": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueryAssetUtilizationHistoryRequest": {
+        "type": "object",
+        "properties": {
+          "utilizationFilter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for asset utilization. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and'. Example: 'x and y'\n- Logical OR operator 'or'. Example: 'x or y'\n- Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'\n- Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'\nValid asset utilization properties that can be used in the filter:\n- MinionId: String representing the identifier of a minion in which an asset might be located in.\n- Category: String representing the utilization task category.\n- UserName: String representing the name of the operator who utilized the asset.\n- TaskName: String representing the name of the task.\n- StartTimestamp:\n    description: >-\n      A date time value which can be used to specify the start of an utilization.\n            \n      This parameter is required to have the \"ISO 8601\" format in order to be considered valid.\n    type: string\n    format: date-time\n    example: '2019-05-20T00:00:00Z'\n- EndTimestamp:\n    description: >-\n      A date time value which can be used to specify the end of an utilization.\n            \n      This parameter is required to have the \"ISO 8601\" format in order to be considered valid.\n    type: string\n    format: date-time\n    example: '2019-05-20T00:00:00Z'",
+            "nullable": true,
+            "example": ""
+          },
+          "assetFilter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for assets. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and'. Example: 'x and y'\n- Logical OR operator 'or'. Example: 'x or y'\n- Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'\n- Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'\n            \nValid asset properties that can be used in the filter:\n- AssetIdentifier: String representing the unique identifier of an asset.\n- SerialNumber: String representing the serial number of an asset.\n- ModelName: String representing the model name of an asset.\n- ModelNumber: Unsigned integer representing the model number of an asset.\n- VendorName: String representing the vendor name of an asset.\n- VendorNumber: Unsigned integer representing the vendor number of an asset.\n- PartNumber: String representing the part number of an asset.\n- AssetName: String representing the asset name.\n- FirmwareVersion: String representing the firmware version of an asset.\n- HardwareVersion: String representing the hardware version of an asset.\n- BusType: String enumeration representing the bus type of an asset. Possible values are: BUILT_IN_SYSTEM, PCI_PXI, USB, GPIB, VXI, SERIAL, TCP_IP, CRIO, SCXI, CDAQ, SWITCH_BLOCK, SCC, FIRE_WIRE, ACCESSORY, CAN, SWITCH_BLOCK_DEVICE, SLSC.\n- IsNIAsset: Boolean flag specifying whether the asset is an NI asset or a third-party asset.\n- Keywords: Collection of string values representing asset metadata keywords. Example: 'Keywords=[\"keyword1\", \"keyword2\"]'.\n- Properties: Collection of key-value pairs, each key-value pair representing an asset metadata property. Example: 'Properties=[\"key1\":\"value1\", \"key2\":\"value2\"]'.\n- Location.MinionId: String representing the identifier of the minion in which the asset is located in.\n- Location.SlotNumber: Unsigned integer representing the slot number the asset is located in.\n- Location.AssetState.SystemConnection: String enumeration representing the connection state of the system the asset is currently located in. Possible values are: DISCONNECTED, CONNECTED. To maintain compatibility with previous versions of SystemLink, the values [APPROVED, UNSUPPORTED, ACTIVATED] are considered equivalent to DISCONNECTED and [CONNECTED_UPDATE_PENDING, CONNECTED_UPDATE_SUCCESSFUL, CONNECTED_UPDATE_FAILED] are equivalent to CONNECTED.\n- Location.AssetState.AssetPresence: String enumeration representing the present status of an asset in a system. Possible values are: INITIALIZING, UNKNOWN, NOT_PRESENT, PRESENT.\n- SupportsSelfCalibration: Boolean flag specifying whether the asset supports self-calibration.\n- SelfCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was self-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- SupportsExternalCalibration: Boolean flag specifying whether the asset supports external calibration.\n- CalibrationStatus: String enumeration representing the calibration status of an asset. Possible values are: OK, APPROACHING_RECOMMENDED_DUE_DATE, PAST_RECOMMENDED_DUE_DATE.\n- ExternalCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was externally-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- ExternalCalibration.NextRecommendedDate: ISO-8601 formatted timestamp string specifying the recommended date for the next external calibration. Example: \"2018-05-20T00:00:00Z\"\n- ExternalCalibration.RecommendedInterval: Integer representing the manufacturer-recommended calibration interval, in months.\n- ExternalCalibration.Comments: String representing any external calibration comments.\n- ExternalCalibration.IsLimited: Boolean flag specifying whether the last external calibration was a limited calibration.",
+            "nullable": true,
+            "example": ""
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Gets or sets a token which allows the user to resume a query at the next item in the matching asset utilization history set. When querying for asset utilization history, a token will be returned if a query may be continued. To obtain the next page of asset utilization history records, pass the token to the service on a subsequent request.",
+            "nullable": true,
+            "example": null
+          },
+          "take": {
+            "type": "integer",
+            "description": "Gets or sets the maximum number of asset utilization history records to return.",
+            "format": "int32",
+            "example": 10000
+          },
+          "orderBy": {
+            "enum": [
+              "START_TIMESTAMP"
+            ],
+            "type": "string",
+            "description": "Gets or sets an enumeration of all fields in an Asset Utilization History record. If not provided, default ordering is applied.",
+            "nullable": true
+          },
+          "orderByDescending": {
+            "type": "boolean",
+            "description": "Gets or sets whether to return the asset utilization history records in descending order.",
+            "example": false
+          },
+          "startTime": {
+            "type": "string",
+            "description": "Start of the date range. Defaults to 90 days ago.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endTime": {
+            "type": "string",
+            "description": "End of the date range. Defaults to current time.",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing filters for asset utilization and assets. When continuation token is used, the orderBy parameter needs to be provided as well."
+      },
+      "QueryAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets identifiers of the assets to be retrieved.",
+            "nullable": true,
+            "example": [
+              "69e95bf9-8b52-4e46-924b-abbd5ee19bbf"
+            ],
+            "deprecated": true
+          },
+          "projection": {
+            "type": "string",
+            "description": "Projection string",
+            "nullable": true,
+            "example": "new(name, serialNumber)"
+          },
+          "responseFormat": {
+            "enum": [
+              "JSON",
+              "CSV"
+            ],
+            "type": "string",
+            "description": "Gets or sets the return type. Valid options are \"JSON\" and \"CSV\".",
+            "deprecated": true
+          },
+          "destination": {
+            "enum": [
+              "INLINE",
+              "DOWNLOAD",
+              "FILE_SERVICE"
+            ],
+            "type": "string",
+            "description": "Gets or sets the destination of the request. \"INLINE\" (default) returns the list of resources as the body of the response. \"DOWNLOAD\" returns the list of resources as the body of the response and indicates to the client that it should be downloaded as a file. \"FILE_SERVICE\" sends the list of resources to the file ingestion service and returns the ID of the file to the client in a JSON object.",
+            "deprecated": true
+          },
+          "fileIngestionWorkspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e",
+            "deprecated": true
+          },
+          "skip": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to skip in the result when paging. For example, a list of 100 resources with a skip value of 50 will return entries 51 through 100.",
+            "format": "int32",
+            "example": 0
+          },
+          "take": {
+            "type": "integer",
+            "description": "Gets or sets how many resources to return in the result, or -1 to use a default defined by the service. The maximum value for Take is 1000. For example, a list of 100 resources with a take value of 25 will return entries 1 through 25.",
+            "format": "int32",
+            "example": -1
+          },
+          "orderBy": {
+            "enum": [
+              "LAST_UPDATED_TIMESTAMP",
+              "ID"
+            ],
+            "type": "string",
+            "description": "Field by which assets can be ordered/sorted. If OrderBy is not specified, no sorting will applied. OrderBy is supported only for the `INLINE` destination option.",
+            "nullable": true,
+            "example": "LAST_UPDATED_TIMESTAMP"
+          },
+          "descending": {
+            "type": "boolean",
+            "description": "Whether to return the assets in the descending order. If OrderBy is not specified, this property is ignored. If OrderBy is specified, this property defaults to false.",
+            "example": true
+          },
+          "calibratableOnly": {
+            "type": "boolean",
+            "description": "Gets or sets whether to generate a report with calibrated asset specific columns.\nWhen the destination is \"DOWNLOAD or \"FILE_SERVICE\" this property is used as follows:\n- It determines the type of the report. When true, the file will be a calibration report. If this is false, the file will be an asset report.\n- If asset ids are in the request, this property will not be used for filtering. If no asset ids are in the request, setting this property to true will generate a report only for the calibrated assets.",
+            "example": false
+          },
+          "returnCount": {
+            "type": "boolean",
+            "description": "Whether to return the total number of assets which match the provided filter, disregarding the take value.",
+            "nullable": true,
+            "example": false
+          },
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for assets. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and'. Example: 'x and y'\n- Logical OR operator 'or'. Example: 'x or y'\n- Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'\n- Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'\n            \nValid asset properties that can be used in the filter:\n- AssetIdentifier: String representing the unique identifier of an asset.\n- SerialNumber: String representing the serial number of an asset.\n- ModelName: String representing the model name of an asset.\n- ModelNumber: Unsigned integer representing the model number of an asset.\n- VendorName: String representing the vendor name of an asset.\n- VendorNumber: Unsigned integer representing the vendor number of an asset.\n- PartNumber: String representing the part number of an asset.\n- AssetName: String representing the asset name.\n- AssetType: String enumeration representing the asset type. Possible values are: GENERIC, DEVICE_UNDER_TEST, FIXTURE, SYSTEM.\n- FirmwareVersion: String representing the firmware version of an asset.\n- HardwareVersion: String representing the hardware version of an asset.\n- BusType: String enumeration representing the bus type of an asset. Possible values are: BUILT_IN_SYSTEM, PCI_PXI, USB, GPIB, VXI, SERIAL, TCP_IP, CRIO, SCXI, CDAQ, SWITCH_BLOCK, SCC, FIRE_WIRE, ACCESSORY, CAN, SWITCH_BLOCK_DEVICE, SLSC.\n- IsNIAsset: Boolean flag specifying whether the asset is an NI asset or a third-party asset.\n- Keywords: Collection of string values representing asset metadata keywords. Example: 'Keywords=[\"keyword1\", \"keyword2\"]'.\n- Properties: Collection of key-value pairs, each key-value pair representing an asset metadata property. Example: 'Properties=[\"key1\":\"value1\", \"key2\":\"value2\"]'.\n- Location.MinionId: String representing the identifier of the minion in which the asset is located in.\n- Location.SlotNumber: Unsigned integer representing the slot number the asset is located in.\n- Location.AssetState.SystemConnection: String enumeration representing the connection state of the system the asset is currently located in. Possible values are: DISCONNECTED, CONNECTED. To maintain compatibility with previous versions of SystemLink, the values [APPROVED, UNSUPPORTED, ACTIVATED] are considered equivalent to DISCONNECTED and [CONNECTED_UPDATE_PENDING, CONNECTED_UPDATE_SUCCESSFUL, CONNECTED_UPDATE_FAILED] are equivalent to CONNECTED.\n- Location.AssetState.AssetPresence: String enumeration representing the present status of an asset in a system. Possible values are: INITIALIZING, UNKNOWN, NOT_PRESENT, PRESENT.\n- SupportsSelfCalibration: Boolean flag specifying whether the asset supports self-calibration.\n- SelfCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was self-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- SupportsExternalCalibration: Boolean flag specifying whether the asset supports external calibration.\n- CalibrationStatus: String enumeration representing the calibration status of an asset. Possible values are: OK, APPROACHING_RECOMMENDED_DUE_DATE, PAST_RECOMMENDED_DUE_DATE, OUT_FOR_CALIBRATION.\n- ExternalCalibration.CalibrationDate: ISO-8601 formatted timestamp string specifying the last date the asset was externally-calibrated. Example: \"2018-05-20T00:00:00Z\"\n- ExternalCalibration.NextRecommendedDate: ISO-8601 formatted timestamp string specifying the recommended date for the next external calibration. Example: \"2018-05-20T00:00:00Z\".\nThis value is overwritten by the NextCustomDueDate if it is set, otherwise it is calculated based on the RecommendedInterval.\n- ExternalCalibration.RecommendedInterval: Integer representing the manufacturer-recommended calibration interval, in months.\n- ExternalCalibration.Comments: String representing any external calibration comments.\n- ExternalCalibration.IsLimited: Boolean flag specifying whether the last external calibration was a limited calibration.",
+            "nullable": true,
+            "example": ""
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing filters to apply when retrieving assets. If no assets match the filter and the destination is \"DOWNLOAD\" or \"FILE_SERVICE\", an empty report will be generated."
+      },
+      "QueryLocationHistoryRequest": {
+        "type": "object",
+        "properties": {
+          "take": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Gets or sets a token which allows the user to resume a query at the next item in the matching asset location history set. When querying for asset location history, a token will be returned if a query may be continued. To obtain the next page of asset location history records, pass the token to the service on a subsequent request.",
+            "nullable": true,
+            "example": null
+          },
+          "responseFormat": {
+            "enum": [
+              "JSON",
+              "CSV"
+            ],
+            "type": "string",
+            "description": "Gets or sets the return type. Valid options are \"JSON\" and \"CSV\"."
+          },
+          "destination": {
+            "enum": [
+              "INLINE",
+              "DOWNLOAD",
+              "FILE_SERVICE"
+            ],
+            "type": "string",
+            "description": "Gets or sets the destination of the request. \"INLINE\" (default) returns the list of resources as the body of the response. \"DOWNLOAD\" returns the list of resources as the body of the response and indicates to the client that it should be downloaded as a file. \"FILE_SERVICE\" sends the list of resources to the file ingestion service and returns the ID of the file to the client in a JSON object."
+          },
+          "fileIngestionWorkspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace to put the file into, if the destination is \"FILE_SERVICE\".",
+            "nullable": true,
+            "example": "846e294a-a007-47ac-9fc2-fac07eab240e"
+          },
+          "locationFilter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for location. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and'. Example: 'x and y'\n- Logical OR operator 'or'. Example: 'x or y'\n- Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'\n- Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'\n            \nValid location properties that can be used in the filter:\n- MinionId: String representing the minion id of the location of an asset.\n- PhysicalLocation: String representing the physical location of the location of an asset.\n- Parent: String representing the parent of the location of an asset.\n- SlotNumber: Integer representing the slot number of the location of an asset.",
+            "nullable": true,
+            "example": ""
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing options for querying history."
+      },
+      "QueryLocationMovesRequest": {
+        "type": "object",
+        "properties": {
+          "assetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets an array of asset IDs that the client requests.\nThe maximum number of asset IDs allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model which represents which assets the clients requests"
+      },
+      "QueryLocationMovesResponse": {
+        "type": "object",
+        "properties": {
+          "moveAssets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoveAssetLocationModel"
+            },
+            "description": "Gets or sets an array of assets that are moving.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model which represents the assets that are currently moving to another location."
+      },
+      "ReceiveFromCalibrationOperations": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the asset being moved.",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "systemId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the system to which the asset is being moved.\nEither this, or PhysicalLocation are mandatory",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets physical location to which the asset is being moved.\nEither this, or SystemId are mandatory",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent within the target location to which the asset is being moved.",
+            "nullable": true,
+            "example": "Chassis 1"
+          },
+          "calibrationData": {
+            "$ref": "#/components/schemas/ExternalCalibrationWithChecksumModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReceiveFromCalibrationRequest": {
+        "type": "object",
+        "properties": {
+          "receiveFromCalibrationOperations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReceiveFromCalibrationOperations"
+            },
+            "description": "Gets or sets a list of operations that will update the asset calibration and  move an asset from one location to another.\nThe maximum number of operations allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for assets.",
+            "nullable": true,
+            "example": ""
+          },
+          "skip": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to skip in the result when paging. For example, a list of 100 resources with a skip value of 50 will return entries 51 through 100.",
+            "format": "int32",
+            "example": 0
+          },
+          "take": {
+            "type": "integer",
+            "description": "Gets or sets how many resources to return in the result, or -1 to use a default defined by the service. For example, a list of 100 resources with a take value of 25 will return entries 1 through 25.",
+            "format": "int32",
+            "nullable": true,
+            "example": 1000
+          },
+          "orderBy": {
+            "enum": [
+              "LAST_UPDATED_TIMESTAMP",
+              "ID"
+            ],
+            "type": "string",
+            "description": "Field by which assets can be ordered/sorted. If Filter is set but OrderBy is not specified, no sorting will applied.\nIf neiter Filter, not OrderBy is specified, the assets will be sorted based on their workspace and location.",
+            "nullable": true,
+            "example": "LAST_UPDATED_TIMESTAMP"
+          },
+          "descending": {
+            "type": "boolean",
+            "description": "Whether to return the assets in the descending order. If OrderBy is not specified, this property is ignored. If OrderBy is specified, this property defaults to false.",
+            "example": true
+          },
+          "projection": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of projected fields",
+            "nullable": true,
+            "example": [
+              "name",
+              "serialNumber"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing filters to apply when searching assets."
+      },
+      "SearchAssetsResponse": {
+        "type": "object",
+        "properties": {
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetModel"
+            },
+            "description": "Gets or sets array of assets.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for search assets response containing the assets satisfying the query"
+      },
+      "SelfCalibrationModel": {
+        "type": "object",
+        "properties": {
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.\nThe maximum number of temperature sensors allowed per self calibration is 1000.",
+            "nullable": true
+          },
+          "isLimited": {
+            "type": "boolean",
+            "description": "Gets or sets whether the last self-calibration of the asset was a limited calibration.",
+            "nullable": true,
+            "example": false
+          },
+          "date": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date the asset was self-calibrated.",
+            "format": "date-time",
+            "example": "2022-06-07T18:58:05.000Z"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SelfCalibrationProjectedModel": {
+        "type": "object",
+        "properties": {
+          "temperatureSensors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TemperatureSensorModel"
+            },
+            "description": "Gets or sets an array of temperature sensor information.\nThe maximum number of temperature sensors allowed per self calibration is 1000.",
+            "nullable": true
+          },
+          "isLimited": {
+            "type": "boolean",
+            "description": "Gets or sets whether the last self-calibration of the asset was a limited calibration.",
+            "nullable": true,
+            "example": false
+          },
+          "date": {
+            "type": "string",
+            "description": "Gets or sets ISO-8601 formatted timestamp specifying the last date the asset was self-calibrated.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2022-06-07T18:58:05.000Z"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for self calibration, that supports projection"
+      },
+      "SendForCalibrationOperation": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the asset being moved.",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "physicalLocation": {
+            "type": "string",
+            "description": "Gets or sets physical location to which the asset is being moved.",
+            "nullable": true,
+            "example": "a1b2c3d4-e5f6-47a8-90ab-cdef12345678"
+          },
+          "parent": {
+            "type": "string",
+            "description": "Gets or sets the parent within the target location to which the asset is being moved.",
+            "nullable": true,
+            "example": "Chassis 1"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SendForCalibrationRequest": {
+        "type": "object",
+        "properties": {
+          "sendForCalibrationOperations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SendForCalibrationOperation"
+            },
+            "description": "Gets or sets a list of operations that will be performed.\nThe maximum number of operations allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StartUtilizationPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "assetsWithStartedUtilization": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetIdentificationModel"
+            },
+            "description": "Gets or sets array containing the asset identification data for the assets that started being utilized.",
+            "nullable": true
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetIdentificationModel"
+            },
+            "description": "Gets or sets array containing the asset identification data for the assets that failed to start being utilized.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StartUtilizationRequest": {
+        "type": "object",
+        "properties": {
+          "utilizationIdentifier": {
+            "type": "string",
+            "description": "Gets or sets string representing the unique identifier of an asset utilization history record.",
+            "nullable": true,
+            "example": "2916201B245D642430"
+          },
+          "minionId": {
+            "type": "string",
+            "description": "Gets or sets identifier of the minion where the utilized assets are located.",
+            "nullable": true,
+            "example": "NI_PXIe-8135_Embedded_Controller--MAC-00-80-2F-23-52-65"
+          },
+          "assetIdentifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetIdentificationModel"
+            },
+            "description": "Gets or sets array of the identification information for the assets which are utilized.\nThe maximum number of asset identifications allowed per request is 100.",
+            "nullable": true
+          },
+          "utilizationCategory": {
+            "type": "string",
+            "description": "Gets or sets string representing the utilization category.",
+            "nullable": true,
+            "example": "Test"
+          },
+          "taskName": {
+            "type": "string",
+            "description": "Gets or sets string representing the name of the task.",
+            "nullable": true,
+            "example": "DUTTestingRoutine"
+          },
+          "userName": {
+            "type": "string",
+            "description": "Gets or sets string representing the name of the operator who utilized the asset.",
+            "nullable": true,
+            "example": "johnDoe"
+          },
+          "utilizationTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the start of an utilization.\nThis parameter must have the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TemperatureSensorModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Gets or sets sensor name.",
+            "nullable": true,
+            "example": "Sensor0"
+          },
+          "reading": {
+            "type": "number",
+            "description": "Gets or sets sensor reading.",
+            "format": "double",
+            "nullable": true,
+            "example": 25.8
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateAssetsPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetModel"
+            },
+            "description": "Gets or sets array of updated assets.",
+            "nullable": true
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetUpdateModel"
+            },
+            "description": "Gets or sets array of assets update requests that failed.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for update Assets Partial Success Response."
+      },
+      "UpdateAssetsRequest": {
+        "type": "object",
+        "properties": {
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssetUpdateModel"
+            },
+            "description": "Gets or sets multiple assets that should be updated.\nThe maximum number of assets allowed per request is 1000.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request body containing an array of assets to update."
+      },
+      "UpdateMetadataRequest": {
+        "type": "object",
+        "properties": {
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets keywords associated with an asset.\nThe maximum number of keywords allowed per request is 1000.",
+            "nullable": true,
+            "example": [
+              "Keyword1"
+            ]
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets properties associated with an asset.\nThe maximum number of properties allowed per request is 1000.",
+            "nullable": true,
+            "example": {
+              "Key1": "Value1"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for the asset metadata information to be updated."
+      },
+      "UpdateUtilizationPartialSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "updatedUtilizationIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of utilization identifiers for the entries that were updated.",
+            "nullable": true
+          },
+          "failed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of utilization identifiers for the entries that failed to update.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UtilizationHeartbeatRequest": {
+        "type": "object",
+        "properties": {
+          "utilizationIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array representing the unique identifier of an asset utilization history record.",
+            "nullable": true,
+            "example": [
+              "2916201B245D642430"
+            ]
+          },
+          "utilizationTimestamp": {
+            "type": "string",
+            "description": "Gets or sets a date time value which can be used to specify the end of an asset utilization.\nThis parameter must have the \"ISO 8601\" format in order to be considered valid.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object containing a collection of utilization identifiers with a timestamp."
+      },
+      "ValidLocationMovementModel": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "nullable": true
+          },
+          "warning": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model which represents the validation result of a single asset move location operation"
+      }
+    },
+    "securitySchemes": {
+      "apikey": {
+        "type": "apiKey",
+        "name": "X-NI-API-KEY",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "apikey": [ ]
+    }
+  ]
+}

--- a/docs/nisysmgmt.json
+++ b/docs/nisysmgmt.json
@@ -1,0 +1,3088 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Systems Management",
+    "description": "Systems Management Service HTTP API. Manage and monitor your distributed systems.",
+    "contact": {
+      "name": "National Instruments",
+      "url": "https://www.ni.com/systemlink",
+      "email": "support@ni.com"
+    },
+    "version": "1"
+  },
+  "paths": {
+    "/nisysmgmt/v1/jobs": {
+      "get": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Get jobs",
+        "parameters": [
+          {
+            "name": "systemId",
+            "in": "query",
+            "description": "The ID of the system to that the jobs belong",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jid",
+            "in": "query",
+            "description": "The ID of the job",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "The state of the jobs",
+            "schema": {
+              "$ref": "#/components/schemas/JobState"
+            }
+          },
+          {
+            "name": "function",
+            "in": "query",
+            "description": "The salt function to run on the client",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many jobs to skip",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "description": "How many jobs to return",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The jobs that matched the criteria",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Job"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Job"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Job"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If the request is invalid",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Create job",
+        "requestBody": {
+          "description": "An instance of NationalInstruments.SystemsManagementService.Model.API.CreateJobRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateJobRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateJobRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateJobRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateJobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The job that was created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateJobResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateJobResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateJobResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If the request is invalid",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authorized to create a job",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/get-jobs-summary": {
+      "get": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Get jobs summary",
+        "responses": {
+          "200": {
+            "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.JobsSummaryResponse",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsSummaryResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsSummaryResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsSummaryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/query-jobs": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Query jobs",
+        "requestBody": {
+          "description": "An instance of NationalInstruments.SystemsManagementService.Model.API.QueryJobsRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryJobsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryJobsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryJobsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryJobsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The list of jobs that match the query",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryJobsResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryJobsResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryJobsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If the request is invalid",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/cancel-jobs": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Cancel jobs",
+        "requestBody": {
+          "description": "A list of NationalInstruments.SystemsManagementService.Model.API.CancelJobRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CancelJobRequest"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CancelJobRequest"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CancelJobRequest"
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CancelJobRequest"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "200": {
+            "description": "The errors that appear while attempting the operation",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If the request is invalid",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpError"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "If the user is not authorized to cancel jobs",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt": {
+      "get": {
+        "tags": [
+          "RootEndpoint"
+        ],
+        "summary": "API information",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1": {
+      "get": {
+        "tags": [
+          "RootEndpoint"
+        ],
+        "summary": "API version information",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/query-systems": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Query systems",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.QuerySystemsRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuerySystemsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuerySystemsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuerySystemsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/QuerySystemsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The list of systems matching the query",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SystemsResponse"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SystemsResponse"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SystemsResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/generate-systems-report": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Generate systems report",
+        "requestBody": {
+          "description": "An instance of NationalInstruments.SystemsManagementService.Model.API.SystemsReportRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemsReportRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemsReportRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemsReportRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemsReportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The system report",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/get-pending-systems-summary": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get pending systems summary",
+        "responses": {
+          "200": {
+            "description": "The pending system summary",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPendingSystemsSummaryResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPendingSystemsSummaryResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPendingSystemsSummaryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/get-systems-summary": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get systems summary",
+        "responses": {
+          "200": {
+            "description": "The system summary",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemsSummaryResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemsSummaryResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemsSummaryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/get-systems-keys": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get systems keys for all systems",
+        "responses": {
+          "200": {
+            "description": "The system keys",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get keys for a set of systemes",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListSystemsKeysRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListSystemsKeysRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListSystemsKeysRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ListSystemsKeysRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The system keys",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSystemsKeysResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/manage-systems-keys": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Manage systems keys",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.ManageKeysRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManageKeysRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManageKeysRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManageKeysRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/ManageKeysRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "200": {
+            "description": "The errors that appear while attempting the operation",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/virtual": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Create virtual system",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.CreateVirtualSystemRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVirtualSystemRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVirtualSystemRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVirtualSystemRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVirtualSystemRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The minion ID of the created virtual system",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateVirtualSystemResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateVirtualSystemResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateVirtualSystemResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/virtual/generate-system-apikey": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Generate API key for a virtual system",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.GenerateSystemApiKeyRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateSystemApiKeyRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateSystemApiKeyRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateSystemApiKeyRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateSystemApiKeyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The generated API key",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateSystemApiKeyResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateSystemApiKeyResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateSystemApiKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "System not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/systems": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get systems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "The ID of the system whose metadata to return",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The metadata of the system that matches the ID",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": { }
+                },
+                "example": [
+                  {
+                    "id": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "alias": "MySystem",
+                    "scanCode": "e20aadfb-91fe-4596-97e8-e8cb67ff786a",
+                    "createdTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "connected": {
+                      "lastPresentTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "state": "CONNECTED"
+                      }
+                    },
+                    "grains": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "kernel": "Windows",
+                        "osversion": "10.0.19042.928",
+                        "osmanufacturer": "Microsoft Corporation",
+                        "host": "MyComputer",
+                        "cpuarch": "AMD64",
+                        "deviceclass": "Desktop"
+                      }
+                    },
+                    "status": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "http_connected": true
+                      }
+                    },
+                    "packages": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "ni-apal-errors": {
+                          "arch": "windows_x64",
+                          "description": "NI device driver error code descriptions (infrastructure)\nError code descriptions common to many NI device drivers.",
+                          "displayname": "NI-APAL Error Code Descriptions (infrastructure)",
+                          "displayversion": "2023 Q1",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "1184118",
+                          "url": "https://www.ni.com",
+                          "version": "23.0.0.49253-0+f101"
+                        },
+                        "ni-curl": {
+                          "arch": "windows_x64",
+                          "description": "NI Curl provides the build of the \"C URL\" library that is an open-source command line tool and library for transferring data with URL syntax.",
+                          "displayname": "NI Curl",
+                          "displayversion": "21.3.0",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "2096594",
+                          "url": "https://www.ni.com",
+                          "version": "21.3.0.49152-0+f0"
+                        }
+                      }
+                    },
+                    "feeds": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-digital-2023 Q1-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released"
+                          }
+                        ],
+                        "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-sv-toolkit-2021-2021-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released"
+                          }
+                        ]
+                      }
+                    },
+                    "keywords": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": [
+                        "Running",
+                        "InUse"
+                      ]
+                    },
+                    "properties": {
+                      "LastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "RunningTestsVersion": "3.9.2",
+                        "TestStandVersion": "2020"
+                      }
+                    },
+                    "workspace": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "orgId": "e740733d-da55-4031-b32f-fb7cd8961810",
+                    "removed": false
+                  }
+                ]
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { }
+                },
+                "example": [
+                  {
+                    "id": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "alias": "MySystem",
+                    "scanCode": "e20aadfb-91fe-4596-97e8-e8cb67ff786a",
+                    "createdTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "connected": {
+                      "lastPresentTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "state": "CONNECTED"
+                      }
+                    },
+                    "grains": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "kernel": "Windows",
+                        "osversion": "10.0.19042.928",
+                        "osmanufacturer": "Microsoft Corporation",
+                        "host": "MyComputer",
+                        "cpuarch": "AMD64",
+                        "deviceclass": "Desktop"
+                      }
+                    },
+                    "status": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "http_connected": true
+                      }
+                    },
+                    "packages": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "ni-apal-errors": {
+                          "arch": "windows_x64",
+                          "description": "NI device driver error code descriptions (infrastructure)\nError code descriptions common to many NI device drivers.",
+                          "displayname": "NI-APAL Error Code Descriptions (infrastructure)",
+                          "displayversion": "2023 Q1",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "1184118",
+                          "url": "https://www.ni.com",
+                          "version": "23.0.0.49253-0+f101"
+                        },
+                        "ni-curl": {
+                          "arch": "windows_x64",
+                          "description": "NI Curl provides the build of the \"C URL\" library that is an open-source command line tool and library for transferring data with URL syntax.",
+                          "displayname": "NI Curl",
+                          "displayversion": "21.3.0",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "2096594",
+                          "url": "https://www.ni.com",
+                          "version": "21.3.0.49152-0+f0"
+                        }
+                      }
+                    },
+                    "feeds": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-digital-2023 Q1-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released"
+                          }
+                        ],
+                        "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-sv-toolkit-2021-2021-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released"
+                          }
+                        ]
+                      }
+                    },
+                    "keywords": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": [
+                        "Running",
+                        "InUse"
+                      ]
+                    },
+                    "properties": {
+                      "LastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "RunningTestsVersion": "3.9.2",
+                        "TestStandVersion": "2020"
+                      }
+                    },
+                    "workspace": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "orgId": "e740733d-da55-4031-b32f-fb7cd8961810",
+                    "removed": false
+                  }
+                ]
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { }
+                },
+                "example": [
+                  {
+                    "id": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "alias": "MySystem",
+                    "scanCode": "e20aadfb-91fe-4596-97e8-e8cb67ff786a",
+                    "createdTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                    "connected": {
+                      "lastPresentTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "state": "CONNECTED"
+                      }
+                    },
+                    "grains": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "kernel": "Windows",
+                        "osversion": "10.0.19042.928",
+                        "osmanufacturer": "Microsoft Corporation",
+                        "host": "MyComputer",
+                        "cpuarch": "AMD64",
+                        "deviceclass": "Desktop"
+                      }
+                    },
+                    "status": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "http_connected": true
+                      }
+                    },
+                    "packages": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "ni-apal-errors": {
+                          "arch": "windows_x64",
+                          "description": "NI device driver error code descriptions (infrastructure)\nError code descriptions common to many NI device drivers.",
+                          "displayname": "NI-APAL Error Code Descriptions (infrastructure)",
+                          "displayversion": "2023 Q1",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "1184118",
+                          "url": "https://www.ni.com",
+                          "version": "23.0.0.49253-0+f101"
+                        },
+                        "ni-curl": {
+                          "arch": "windows_x64",
+                          "description": "NI Curl provides the build of the \"C URL\" library that is an open-source command line tool and library for transferring data with URL syntax.",
+                          "displayname": "NI Curl",
+                          "displayversion": "21.3.0",
+                          "group": "Infrastructure",
+                          "packager": "National Instruments <support@ni.com>",
+                          "priority": "standard",
+                          "size": "2096594",
+                          "url": "https://www.ni.com",
+                          "version": "21.3.0.49152-0+f0"
+                        }
+                      }
+                    },
+                    "feeds": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-digital-2023 Q1-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-d/ni-digital/23.0/released"
+                          }
+                        ],
+                        "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released": [
+                          {
+                            "configurable": true,
+                            "enabled": true,
+                            "name": "ni-sv-toolkit-2021-2021-released",
+                            "ni-managed": true,
+                            "uri": "https://download.ni.com/support/nipkg/products/ni-s/ni-sv-toolkit-2021/21.5/released"
+                          }
+                        ]
+                      }
+                    },
+                    "keywords": {
+                      "lastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": [
+                        "Running",
+                        "InUse"
+                      ]
+                    },
+                    "properties": {
+                      "LastUpdatedTimestamp": "2026-02-10T20:37:48.1988502Z",
+                      "data": {
+                        "RunningTestsVersion": "3.9.2",
+                        "TestStandVersion": "2020"
+                      }
+                    },
+                    "workspace": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+                    "orgId": "e740733d-da55-4031-b32f-fb7cd8961810",
+                    "removed": false
+                  }
+                ]
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/remove-systems": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Remove systems",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.RemoveSystemsRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveSystemsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveSystemsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveSystemsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveSystemsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The job ID of the job to remove the systems and the IDs of the removed systems",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoveSystemsResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoveSystemsResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoveSystemsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/update-systems": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Update systems metadata",
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.UpdateSystemsRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSystemsRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSystemsRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSystemsRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSystemsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The errors that may have appeared while attempting the operation",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nisysmgmt/v1/systems/managed/{id}": {
+      "patch": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Update system metadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the system to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "An instance of a NationalInstruments.SystemsManagementService.Model.API.SystemPatchRequest",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemPatchRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemPatchRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemPatchRequest"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemPatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "200": {
+            "description": "The errors that appear while attempting the operation",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BaseResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BaseResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a basic response object containing an optional error."
+      },
+      "CancelJobRequest": {
+        "type": "object",
+        "properties": {
+          "jid": {
+            "type": "string",
+            "description": "Gets or sets the job ID of the job to cancel.",
+            "nullable": true,
+            "example": "54af4b95-ea89-48df-b21f-dddf56083476"
+          },
+          "systemId": {
+            "type": "string",
+            "description": "Gets or sets the system ID that the job to cancel targets.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateJobRequest": {
+        "type": "object",
+        "properties": {
+          "arg": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": { }
+            },
+            "description": "List of arguments to the functions specified in the \"fun\" property.",
+            "nullable": true,
+            "example": [
+              [
+                "A description"
+              ]
+            ]
+          },
+          "tgt": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of system IDs on which to run the job.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+            ]
+          },
+          "fun": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Functions contained in the job.",
+            "nullable": true,
+            "example": [
+              "system.set_computer_desc"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Additional information of the job.",
+            "nullable": true,
+            "example": {
+              "queued": true,
+              "refresh_minion_cache": {
+                "grains": true
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateJobResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "jid": {
+            "type": "string",
+            "description": "Gets or sets the ID of the job.",
+            "nullable": true,
+            "example": "d762dfad-f644-4470-8ecd-6b9e0769e22d"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Gets or sets the metadata of the job.",
+            "nullable": true,
+            "example": {
+              "queued": true,
+              "refresh_minion_cache": {
+                "grains": true
+              },
+              "user_id": "a-user-id",
+              "user_login": "John Doe",
+              "orgId": "an-org-id",
+              "fun": [
+                null,
+                {
+                  "_update_minion_db_col_root": "grains.data",
+                  "_update_minion_db_strip_data_on_success": true
+                }
+              ]
+            }
+          },
+          "arg": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": { }
+            },
+            "description": "Gets or sets the arguments of the salt functions contained in the job.",
+            "nullable": true,
+            "example": [
+              [
+                "A description"
+              ]
+            ]
+          },
+          "tgt": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets the target systems of the job.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+            ]
+          },
+          "fun": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets the salt functions of the job.",
+            "nullable": true,
+            "example": [
+              "system.set_computer_desc",
+              "nisysmgmt.grains_items"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateVirtualSystemRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string",
+            "description": "Alias of the virtual system",
+            "nullable": true,
+            "example": "MyVirtualSystem"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "Workspace to create the virtual system in",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Location to create the virtual system in",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateVirtualSystemResponse": {
+        "type": "object",
+        "properties": {
+          "minionId": {
+            "type": "string",
+            "description": "Id of the virtual system",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FailedUnregisterRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Gets or sets the ID of the system on which unregister operation failed.",
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenerateSystemApiKeyRequest": {
+        "type": "object",
+        "properties": {
+          "systemId": {
+            "type": "string",
+            "description": "Gets or sets a string representing the system ID for which to generated the API key.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request for permanent api key to be used by SystemLink Client."
+      },
+      "GenerateSystemApiKeyResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "apiKey": {
+            "type": "string",
+            "description": "Permanent api key",
+            "nullable": true,
+            "example": "gcm7LNGO7-b13gJNQnckgbG4Hd142NMSmhPPqTu2qb"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for permanent api key response for SystemLink Client to use when communicating with salt master."
+      },
+      "GetPendingSystemsSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "pendingCount": {
+            "type": "integer",
+            "description": "Gets or sets number of systems pending approval to connect to the server.",
+            "format": "int64",
+            "example": 5
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for summary information about the systems attempting to connect to the server but aren't accepted yet."
+      },
+      "GetSystemsKeysResponse": {
+        "type": "object",
+        "properties": {
+          "systemsPending": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets an object of system ID to key pairs that are pending approval or rejection. Keys may be pending when they are not pre-seeded via the automated registration process and attempt to connect to the master.",
+            "nullable": true,
+            "example": {
+              "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEKXgqqHjU93r5LL4SeE\nCEjCtlUzQQBJ73tgmXIGyvDNo9FaOuw1yM+FAD/FSuoX9fwMuLXD52etaImZGV4b\nUrGy7mWiRzTa1U20/Jt2G/IwSowM5zHdpCWXKrnAi0talC5/XUSs3qYpuI8FQaVi\nG5Wilyddj5GY3VLxPBAvLd6Q0gMBb0HhZ5QR4f6Nw7bpwtVBkHdlh95eDXw/w9Zp\n0cAui6tkXBXtVKECRqaTjNa0UBcUrXKLDnf20ILTuYUiMcW+FRLLOLmpBFvJnxW/\nCY0htWHyeM1vY8mUSu6UKrJEa+TZ6EhRGzBkcV27y64hXD5RBKxdmE45pppHjTyl\n0QIDAQAB\n-----END PUBLIC KEY-----"
+            }
+          },
+          "systemsDenied": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets an object of system ID to key pairs that have been denied. A key is denied when a system is trying to connect the master with a different key than the one that is accepted. This can occur if two systems have the same ID or if a key is removed from a system.",
+            "nullable": true,
+            "example": {
+              "30BFS51M16--SN-S4LT7442--MAC-A4-AE-11-11-0F-B2": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2yTEUog12AX1wM5Vfr15\nIr37JZK2Oeks47mDDdivuAfZv28ah2RpYqcCalZ7ozcKFrT+B7T66fBk2R+TzSoI\nEX9FA6AqkF/6DLQGckxOx49Ir0ulG0INB3pYSC7TsW8uIrmCQdAKK7hIYghAUEGw\nvqNJs34eS1F26p/ej/uErzDrbuluQpMRArpe0CvNQGPtdh4vTKLujiQoAdjFvLMg\n4smFE9fcFEYb4OsSlpZsCeXq1jTJL6mp95iR4yd/iO40G7/RyoD+xWeM0hgqB0XT\ntmsYc6HdHbLeHy5UPmYocFnbPJxwfdno6q9bpgV/fT1y5mga/8yaxj44bCyoxQcS\n1wIDAQAB\n-----END PUBLIC KEY-----"
+            }
+          },
+          "systemsApproved": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets an object of system ID to key pairs that have been approved. These could have been approved explicitly by the user or pre-seeded via the automated registration process.",
+            "nullable": true,
+            "example": {
+              "HVM_domU--SN-ec2c5434-6181-b837-fdd3-21d8d9478227--MAC-0E-7A-04-25-97-43": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqisA5iVwbwCfYiQHQAlT\nr5iqr0Gyws6XXft2LvtHbdDV09OuxQ1IJdf+B/xWOCEzCn+Flh9JGxKxGP/7IOiK\nH//6TkD3owtpqjnVOW0wbu2WOfnpsCMMo+IlCQk03CBhcrdSg5y6IGTIsgciqyRU\nD2NqYDGbabmEJ2xByj4REiq/PirNkdu6i2mXHDvZCCiTCUQOouj9Yq8Azl6ok6IL\n5cOLaLfaTUgXP3osjrjJuMBuAHlRuWVXSnA2zZ0oquZeXC80H/S7xmiKnfPivPQe\nsddnztHjkvJe5GVHM0AbsDxal1jcf22pgGqo3kFBOPuuQYe6h6dkOwNWtEB+y7ao\nfwIDAQAB\n-----END PUBLIC KEY-----"
+            }
+          },
+          "systemsRejected": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets an object of system ID to key pairs that have been rejected. Keys are rejected explicitly by the user.",
+            "nullable": true,
+            "example": {
+              "HVM_domU--SN-ec2c5434-6181-b837-fdd3-21d8d9478227--MAC-0E-7A-04-25-97-43": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtIPmfDCJLz3r9kybnOma\ng+PV8dhc4qmzyM9+koId6fmTdEcMXa3pURfMqlFJ3iFU+m980Pj0/58LeH/oXJyl\n93SfNLEyk7iJmGJsKYYMYUkhPLpwgUIrEMThpi5aTTKaQfWdFv+vLUTG097qytDE\n0N0Z8ZqFEn7+OGxddu8Pc+3EobnxUmYCTrhbkRx6kNzmlfsrHZ22Nzf001RxOL+o\nUWEpJlxOllna1vkthdNu3+bBjW8+1v8CAFcolndwy2udiXKM54b5tTenLu1jdIeB\nuY4c+N8myu8q0/Rrmpg5yhdXH9L2+EVP6IpiUg5NEdSxkCkTax0LWY94bC3yiOxl\n1wIDAQAB\n-----END PUBLIC KEY-----"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for an object containing pending, denied, approved, and rejected system keys. If there are no entries in a given category, then the key representing that category is omitted. The value for the keys is in itself a dictionary, with the key representing the system ID and the value the public authorization key used."
+      },
+      "HttpError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Gets the fully-qualified name that identifies the error code, such as\nthe output of M:NationalInstruments.SystemLink.ServiceBase.ErrorHandling.ErrorCode.ToString.",
+            "nullable": true,
+            "example": "Skyline.UnknownWorkspace"
+          },
+          "code": {
+            "type": "integer",
+            "description": "Gets the optional NationalInstruments.SystemLink.ServiceBase.ErrorHandling.ErrorCode.NumericCode (not HTTP status code)\nthat identifies the error code.",
+            "format": "int32",
+            "nullable": true,
+            "example": -251048
+          },
+          "message": {
+            "type": "string",
+            "description": "Gets the formatted error message, which is the NationalInstruments.SystemLink.ServiceBase.ErrorHandling.ErrorCode.Message\nwith NationalInstruments.SystemLink.ServiceBase.HttpError.Args inserted into any placeholders.",
+            "nullable": true,
+            "example": "Workspace '{0}' does not exist."
+          },
+          "resourceType": {
+            "type": "string",
+            "description": "Gets the type of resource associated with the error, if any. Typically only\nused for instances within NationalInstruments.SystemLink.ServiceBase.HttpError.InnerErrors.",
+            "nullable": true,
+            "example": "Resource type"
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "Gets the ID of the resource associated with the error, if any. Typically only\nused for instances within NationalInstruments.SystemLink.ServiceBase.HttpError.InnerErrors.",
+            "nullable": true,
+            "example": "f0d90565fe4b4c1ea78b7bd433d4d214"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets the arguments that produced NationalInstruments.SystemLink.ServiceBase.HttpError.Message.",
+            "nullable": true,
+            "example": [
+              "Workspace"
+            ]
+          },
+          "innerErrors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HttpError"
+            },
+            "description": "Gets any nested errors if this instance represents more than one error. Typically\nonly set for instances related to NationalInstruments.SystemLink.ServiceBase.ErrorHandling.SkylineErrorCodes.OneOrMoreErrorsOccurred.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents the standard error structure."
+      },
+      "Job": {
+        "type": "object",
+        "properties": {
+          "jid": {
+            "type": "string",
+            "description": "The job ID.",
+            "nullable": true,
+            "example": "54af4b95-ea89-48df-b21f-dddf56083476"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the system that the job targets.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+          },
+          "createdTimestamp": {
+            "type": "string",
+            "description": "The timestamp representing when the job was created.",
+            "format": "date-time",
+            "example": "2024-03-15T15:15:13.378Z"
+          },
+          "lastUpdatedTimestamp": {
+            "type": "string",
+            "description": "The timestamp representing when the job was last updated.",
+            "format": "date-time",
+            "example": "2024-03-20T15:15:13.378Z"
+          },
+          "dispatchedTimestamp": {
+            "type": "string",
+            "description": "The timestamp representing when the job was dispatched.",
+            "format": "date-time",
+            "nullable": true,
+            "example": "2024-03-20T15:15:13.378Z"
+          },
+          "state": {
+            "$ref": "#/components/schemas/JobState"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Metadata of the job.",
+            "nullable": true,
+            "example": {
+              "queued": true
+            }
+          },
+          "config": {
+            "$ref": "#/components/schemas/JobConfig"
+          },
+          "result": {
+            "$ref": "#/components/schemas/JobResult"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobConfig": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "string",
+            "description": "The user who created the job.",
+            "nullable": true,
+            "example": "a-valid-user-id"
+          },
+          "tgt": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Target system of the job.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+            ]
+          },
+          "fun": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Salt functions related to the job.",
+            "nullable": true,
+            "example": [
+              "system.set_computer_desc"
+            ]
+          },
+          "arg": {
+            "type": "array",
+            "items": { },
+            "description": "Arguments of the salt functions.",
+            "nullable": true,
+            "example": [
+              "A description"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobResult": {
+        "type": "object",
+        "properties": {
+          "jid": {
+            "type": "string",
+            "description": "The job ID.",
+            "nullable": true,
+            "example": "54af4b95-ea89-48df-b21f-dddf56083476"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the system that the job targeted.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51"
+          },
+          "retcode": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "description": "Return code of the job.",
+            "nullable": true,
+            "example": [
+              0
+            ]
+          },
+          "return": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Return code of the job.",
+            "nullable": true,
+            "example": [
+              "SUCCESS"
+            ]
+          },
+          "success": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            },
+            "description": "Whether the job succeeded or not.",
+            "nullable": true,
+            "example": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JobState": {
+        "enum": [
+          "SUCCEEDED",
+          "OUTOFQUEUE",
+          "INQUEUE",
+          "INPROGRESS",
+          "CANCELED",
+          "FAILED"
+        ],
+        "type": "string"
+      },
+      "JobsSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "activeCount": {
+            "type": "integer",
+            "description": "Gets or sets number of active jobs.",
+            "format": "int32",
+            "example": 5
+          },
+          "failedCount": {
+            "type": "integer",
+            "description": "Gets or sets number of failed jobs.",
+            "format": "int32",
+            "example": 5
+          },
+          "succeededCount": {
+            "type": "integer",
+            "description": "Gets or sets number of succeeded jobs.",
+            "format": "int32",
+            "example": 5
+          }
+        },
+        "additionalProperties": false
+      },
+      "KeyAction": {
+        "enum": [
+          "ACCEPT",
+          "REJECT",
+          "DELETE"
+        ],
+        "type": "string",
+        "description": "Model for action to be performed.\n  * ACCEPT: Accept the associated key.\n  * REJECT: Reject the associated key.\n  * DELETE: Delete the associated key."
+      },
+      "KeyRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Gets or sets a string representing the system ID.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+          },
+          "action": {
+            "$ref": "#/components/schemas/KeyAction"
+          },
+          "key": {
+            "type": "string",
+            "description": "Gets or sets a string representing the public authorization key. If this field is specified, verification that the system ID is associated with this auth key will happen before the desired action is executed.",
+            "nullable": true
+          },
+          "workspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace.",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for object defining a system ID and the action that should be performed over the key."
+      },
+      "ListSystemsKeysRequest": {
+        "type": "object",
+        "properties": {
+          "systemIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of system ids for which to return keys.",
+            "nullable": true,
+            "example": [
+              "NI_PXIe-8840_Quad-Core--SN-03103DD2--MAC-00-80-2F-16-48-7E"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManageKeysRequest": {
+        "type": "object",
+        "properties": {
+          "isAsync": {
+            "type": "boolean",
+            "description": "Deprecated"
+          },
+          "keyActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KeyRequest"
+            },
+            "description": "Gets or sets the list of NationalInstruments.SystemsManagementService.Model.API.KeyRequest",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request to perform specific acceptance actions to system keys."
+      },
+      "QueryJobsRequest": {
+        "type": "object",
+        "properties": {
+          "skip": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to skip.",
+            "format": "int64",
+            "example": 0
+          },
+          "take": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to return. The maximum value is 1000.",
+            "format": "int64",
+            "nullable": true,
+            "example": 1000
+          },
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for jobs or systems. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and' or '&&'. Example: 'x and y'\n- Logical OR operator 'or' or '||'. Example: 'x or y'\n- Contains operator '.Contains()', used to check if a list contains an element. Example: 'x.Contains(y)'\n- Not Contains operator '!.Contains()', used to check if a list does not contain an element. Example: '!x.Contains(y)'\n            \nValid job properties that can be used in the filter:\n- jid : String representing the ID of the job.\n- id : String representing the ID of the system.\n- createdTimestamp: ISO-8601 formatted timestamp string specifying the date when the job was created.\n- lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the job was updated.\n- dispatchedTimestamp: ISO-8601 formatted timestamp string specifying the date when the job was actually sent to the system.\n- state: String representing the state of the job.\n- metadata: Object containg the the metadata of job. Example: metadata.queued\n- config.user: String representing the user who created the job.\n- config.tgt: List of strings representing the targeted systems. Example: config.tgt.Contains(\"id\")\n- config.fun: List of strings representing the functions to be executed within the job. Example: config.fun.Contains(\"nisysmgmt.set_blackout\")\n- config.arg: An array of arrays of variable type elements that are arguments to the function specified by the \"fun\" property. Example: config.arg[0].Contains(\"test\")\n- result.return: An array of objects representing return values for each executed function. Example:\n  result.return[0].Contains(\"Success\")\n            \n- result.retcode: An array of integers representing code values for each executed function. Example: result.retcode\n- result.success: An array of booleans representing success values for each executed function. Example:\n  result.success.Contains(false)",
+            "nullable": true,
+            "example": "result.success.Contains(false)"
+          },
+          "projection": {
+            "type": "string",
+            "description": "Gets or sets specifies the projection for resources. Use this field to receive specific properties of the model.\nExamples:\n    - 'new(id,jid,state)'\n    - 'new(id,jid,config.user as user)'\n    - 'new(id,jid,state,lastUpdatedTimestamp,metadata.queued as queued)'",
+            "nullable": true,
+            "example": "new(id,jid,state,lastUpdatedTimestamp,metadata.queued as queued)"
+          },
+          "orderBy": {
+            "type": "string",
+            "description": "Gets or sets the order in which data returns.",
+            "nullable": true,
+            "example": "createdTimestamp descending"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueryJobsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": { },
+            "description": "Gets or sets the data returned by query.",
+            "nullable": true
+          },
+          "count": {
+            "type": "integer",
+            "description": "Gets or sets the total number of resources that matched the query.",
+            "format": "int64",
+            "example": 5
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for response of a query request."
+      },
+      "QuerySystemsRequest": {
+        "type": "object",
+        "properties": {
+          "skip": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to skip.",
+            "format": "int32",
+            "example": 0
+          },
+          "take": {
+            "type": "integer",
+            "description": "Gets or sets the number of resources to return. The maximum value is 1000.",
+            "format": "int32",
+            "example": 1000
+          },
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets the filter criteria for jobs or systems. Consists of a string of queries composed using AND/OR operators. String values and date strings need to be enclosed in double quotes. Parenthesis can be used around filters to better define the order of operations.\nFilter syntax: '[property name][operator][operand] and [property name][operator][operand]'\n            \nOperators:\n- Equals operator '='. Example: 'x = y'\n- Not equal operator '!='. Example: 'x != y'\n- Greater than operator '>'. Example: 'x > y'\n- Greater than or equal operator '>='. Example: 'x >= y'\n- Less than operator '<'. Example: 'x < y'\n- Less than or equal operator '<='. Example: 'x <= y'\n- Logical AND operator 'and' or '&&'. Example: 'x and y'\n- Logical OR operator 'or' or '||'. Example: 'x or y'\n- Contains operator '.Contains()', used to check if a list contains an element. Example: 'x.Contains(y)'\n- Not Contains operator '!.Contains()', used to check if a list does not contain an element. Example: '!x.Contains(y)'\n            \nValid system properties that can be used in the filter:\n- id : String representing the ID of the system.\n- createdTimestamp: ISO-8601 formatted timestamp string specifying the date when the system was registered.\n- lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system was updated.\n- alias: String representing the alias of the system.\n- activation.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system activation was updated.\n- activation.data.activated: Boolean representing whether the system is activated or not.\n- activation.data.licenseName: String representing the name of the license.\n- activation.data.licenseVersion: String representing the license version.\n- connected.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system connection was updated.\n- connected.data.state: String representing the state of the system.\n- grains.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system grains were updated.\n- grains.data: Dictionary of string to object representing general information about the system. Example: grains.data.os == \"Windows\"\n- packages.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system installed packages were updated.\n- packages.data: Dictionary representing software packages installed on the system. Example: packages.data.ni-package-manager-upgrader.version: String representing the installed version of ni-package-manager-upgrader package.\n- feeds.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system configured feeds were updated.\n- feeds.data: Dictionary representing the feeds configured on the system.\n- keywords.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system keywords were updated.\n- keywords.data: Array of strings representing the keywords of the system. Example: keywords.data.Contains(\"test\")\n- properties.lastUpdatedTimestamp: ISO-8601 formatted timestamp string specifying the last date the system properties were updated.\n- properties.data: Dictionary of string to string representing metadata information about a system. Example: properties.data.owner == \"admin\"\n- status.data.http_connected: Boolean representing the status of the http connection to the master.",
+            "nullable": true,
+            "example": "status.data.http_connected.Equals(true)"
+          },
+          "projection": {
+            "type": "string",
+            "description": "Gets or sets specifies the projection for resources. Use this field to receive specific properties of the model.\nExamples:\n    - 'new(id,connected)'\n    - 'new(id,alias,grains.data.host as host)'\n    - 'new(id,lastUpdatedTimestamp,properties.data.location as location)'",
+            "nullable": true,
+            "example": "new(id,alias,grains.data.host as host)"
+          },
+          "orderBy": {
+            "type": "string",
+            "description": "Gets or sets the order in which data returns.",
+            "nullable": true,
+            "example": "alias"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemoveSystemsRequest": {
+        "type": "object",
+        "properties": {
+          "tgt": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets array of strings representing the IDs of systems to remove from SystemLink.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+            ]
+          },
+          "force": {
+            "type": "boolean",
+            "description": "Gets or sets a Boolean which specifies whether to remove systems from the database immediately (True) or wait until the unregister job returns from systems (False). If True, unregister job failures are not cached.",
+            "default": true,
+            "example": false
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request to unregister systems from the server."
+      },
+      "RemoveSystemsResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/HttpError"
+          },
+          "jid": {
+            "type": "string",
+            "description": "Gets or sets the job ID of the unregistration job sent to connected systems.",
+            "nullable": true
+          },
+          "removedIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets an array of system IDs removed from the database immediately.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+            ]
+          },
+          "failedIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FailedUnregisterRequest"
+            },
+            "description": "Gets or sets an array of objects defining failed unregister operations.",
+            "nullable": true,
+            "example": [
+              "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for response of the request to unregister systems."
+      },
+      "ReportType": {
+        "enum": [
+          "SOFTWARE",
+          "HARDWARE"
+        ],
+        "type": "string",
+        "description": "Model for the type of the report to be created.\n * SOFTWARE: The report will contain the installed software packages.\n * HARDWARE: The report will contain information about the hardware configuration of the system."
+      },
+      "SystemMetadata": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace.",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Gets or sets the location id of the system.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets the properties (key, value).",
+            "nullable": true,
+            "example": {
+              "property_name": "pancakesort"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SystemPatchRequest": {
+        "type": "object",
+        "properties": {
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gets or sets the new keywords assigned to the system.",
+            "nullable": true,
+            "example": [
+              "This",
+              "is",
+              "a list",
+              "of",
+              "keywords"
+            ]
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets the new properties assigned to the system.",
+            "nullable": true,
+            "example": {
+              "property_name": "pancakesort"
+            }
+          },
+          "alias": {
+            "type": "string",
+            "description": "Gets or sets the new  alias of the system.",
+            "nullable": true,
+            "example": "Some example system"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "Gets or sets the ID of the workspace.",
+            "nullable": true,
+            "example": "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+          },
+          "scanCode": {
+            "type": "string",
+            "description": "Gets or sets the scan code of the system.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Gets or sets the location id of the system.",
+            "nullable": true,
+            "example": "e20aadfb-91fe-4596-97e8-e8cb67ff786a"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SystemUpdateInformation": {
+        "type": "object",
+        "properties": {
+          "systemId": {
+            "type": "string",
+            "description": "Gets or sets the system id.",
+            "nullable": true,
+            "example": "HVM_domU--SN-ec200972-eeca-062e-5bf5-017a25451b39--MAC-0A-E1-20-D6-96-2B"
+          },
+          "systemMetadata": {
+            "$ref": "#/components/schemas/SystemMetadata"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for system ids and changes that need to be applied to the systems."
+      },
+      "SystemsReportRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ReportType"
+          },
+          "filter": {
+            "type": "string",
+            "description": "Gets or sets specifies the filter criteria for systems.",
+            "nullable": true,
+            "example": "status.data.http_connected.Equals(true)"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for request containing the report type followed by a query filter that will be applied on systems."
+      },
+      "SystemsResponse": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "Gets or sets the total number of resources that matched the query.",
+            "format": "int64"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Id of the system",
+                "example": "6b70e1df-ae93-4ded-9fe0-dc775732289b"
+              },
+              "alias": {
+                "type": "string",
+                "description": "Alias of the systme",
+                "example": "MySystem"
+              },
+              "createdTimestamp": {
+                "type": "string",
+                "description": "Timestamp that represents the time the system was approved",
+                "format": "date-time",
+                "example": "2026-02-10T20:37:48.1949908Z"
+              },
+              "lastUpdatedTimestamp": {
+                "type": "string",
+                "description": "Timestamp that represents the last time the system entry has been changed",
+                "format": "date-time",
+                "example": "2026-02-10T20:37:48.1949908Z"
+              },
+              "connected": {
+                "type": "object",
+                "properties": {
+                  "lastPresentTimestamp": {
+                    "type": "string",
+                    "description": "The time at which the last connection heartbeat was received for the system.",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "description": "Timestamp that represents the last time when the system connection information has changed.",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "state": {
+                        "title": "SystemsState",
+                        "enum": [
+                          "ACTIVATED_WITHOUT_CONNECTION",
+                          "APPROVED",
+                          "DISCONNECTED",
+                          "CONNECTED_REFRESH_PENDING",
+                          "CONNECTED",
+                          "CONNECTED_REFRESH_FAILED",
+                          "VIRTUAL"
+                        ],
+                        "type": "enum",
+                        "description": "Specifies whether the system is connected to the server and has updated the server with its data",
+                        "example": "CONNECTED"
+                      }
+                    }
+                  }
+                },
+                "description": "The connected information of a system"
+              },
+              "grains": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "example": "pancakesort"
+                    }
+                  }
+                },
+                "description": "The grains information of a system"
+              },
+              "status": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "example": "pancakesort"
+                    }
+                  }
+                },
+                "description": "The status information of a systme"
+              },
+              "packages": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "example": "pancakesort"
+                    }
+                  }
+                },
+                "description": "The packages information of a system"
+              },
+              "feeds": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "example": "pancakesort"
+                    }
+                  }
+                },
+                "description": "The feeds information of a system"
+              },
+              "keywords": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "array"
+                  }
+                },
+                "description": "The keywords information of a system"
+              },
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "lastUpdatedTimestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2026-02-10T20:37:48.1949908Z"
+                  },
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "example": "pancakesort"
+                    }
+                  }
+                },
+                "description": "The properties information of a system"
+              },
+              "workspace": {
+                "type": "string",
+                "description": "The workspace information of a system",
+                "example": "6b70e1df-ae93-4ded-9fe0-dc775732289b"
+              },
+              "removed": {
+                "type": "boolean",
+                "description": "Indicates whether the system is being removed",
+                "example": false
+              }
+            },
+            "description": "A system data"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for response of a query systems request."
+      },
+      "SystemsSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "connectedCount": {
+            "type": "integer",
+            "description": "Gets or sets number of systems connected to the server.",
+            "format": "int32",
+            "example": 5
+          },
+          "disconnectedCount": {
+            "type": "integer",
+            "description": "Gets or sets number of systems disconnected from the server.",
+            "format": "int32",
+            "example": 5
+          },
+          "virtualCount": {
+            "type": "integer",
+            "description": "Gets or sets number of virtual systems that have no connection to the server.",
+            "format": "int32",
+            "example": 5
+          }
+        },
+        "additionalProperties": false,
+        "description": "Model for summary information about the systems that have been approved to the server that are connected or disconnected."
+      },
+      "UpdateSystemsRequest": {
+        "type": "object",
+        "properties": {
+          "systemsUpdateInformation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SystemUpdateInformation"
+            },
+            "description": "Data with which to update the information of one or more systems.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "apikey": {
+        "type": "apiKey",
+        "name": "X-NI-API-KEY",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "apikey": [ ]
+    }
+  ]
+}

--- a/docs/nitestmonitor-v2.yml
+++ b/docs/nitestmonitor-v2.yml
@@ -1,0 +1,2832 @@
+﻿swagger: '2.0'
+info:
+  version: '2'
+  title: Test Monitor Service
+  description: Test Monitor HTTP API
+  contact:
+    name: NI
+    url: 'https://www.ni.com/systemlink'
+    email: support@ni.com
+basePath: /nitestmonitor
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  apikey:
+    type: apiKey
+    name: x-ni-api-key
+    in: header
+security:
+  - apikey: []
+x-ni-routing-key: Skyline.TestMonitor
+definitions:
+  Error:
+    description: Contains error information
+    type: object
+    properties:
+      name:
+        description: String error code
+        type: string
+      code:
+        description: Numeric error code
+        type: integer
+        format: int32
+      resourceType:
+        description: Type of resource associated with the error
+        type: string
+      resourceId:
+        description: Identifier of the resource associated with the error
+        type: string
+      message:
+        description: Complete error message
+        type: string
+      args:
+        description: Positional argument values for the error code
+        type: array
+        items:
+          type: string
+      innerErrors:
+        type: array
+        items:
+          $ref: '#/definitions/Error'
+    example:
+      name: TestMonitorErrorCodes.OneOrMoreErrorsOccurred
+      code: -252921
+      message: >-
+        One or more errors occurred. See the contained list for details of each
+        error.
+      args: []
+      innerErrors:
+        - name: TestMonitor.InvalidId
+          code: -253700
+          resourceType: TestResult
+          resourceId: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+          message: Invalid Id.
+          args: []
+  Operation:
+    description: Operation provided by the API
+    type: object
+    properties:
+      available:
+        type: boolean
+        description: Whether the operation is available to the caller
+      version:
+        type: integer
+        format: int32
+        description: Version of the available operation
+    required: [available]
+    example:
+      available: true
+      version: 1
+  V1Operations:
+    title: V1 Operations
+    description: V1 operations
+    type: object
+    properties:
+      operations:
+        description: Available operations in the v1 version of the API.
+        type: object
+        properties:
+          getResults:
+            $ref: '#/definitions/Operation'
+          queryResults:
+            $ref: '#/definitions/Operation'
+          createResults:
+            $ref: '#/definitions/Operation'
+          updateResults:
+            $ref: '#/definitions/Operation'
+          deleteResult:
+            $ref: '#/definitions/Operation'
+          deleteManyResults:
+            $ref: '#/definitions/Operation'
+          getSteps:
+            $ref: '#/definitions/Operation'
+          querySteps:
+            $ref: '#/definitions/Operation'
+          createSteps:
+            $ref: '#/definitions/Operation'
+          updateSteps:
+            $ref: '#/definitions/Operation'
+          deleteStep:
+            $ref: '#/definitions/Operation'
+          deleteManySteps:
+            $ref: '#/definitions/Operation'
+  V2Operations:
+    title: V2 Operations
+    description: V2 operations
+    type: object
+    properties:
+      operations:
+        description: Available operations in the v2 version of the API.
+        type: object
+        properties:
+          getResults:
+            $ref: '#/definitions/Operation'
+          getResultsPropertyKeys:
+            $ref: '#/definitions/Operation'
+          queryResults:
+            $ref: '#/definitions/Operation'
+          createResults:
+            $ref: '#/definitions/Operation'
+          updateResults:
+            $ref: '#/definitions/Operation'
+          deleteResult:
+            $ref: '#/definitions/Operation'
+          deleteManyResults:
+            $ref: '#/definitions/Operation'
+          getSteps:
+            $ref: '#/definitions/Operation'
+          querySteps:
+            $ref: '#/definitions/Operation'
+          createSteps:
+            $ref: '#/definitions/Operation'
+          updateSteps:
+            $ref: '#/definitions/Operation'
+          deleteStep:
+            $ref: '#/definitions/Operation'
+          deleteManySteps:
+            $ref: '#/definitions/Operation'
+          getProducts:
+            $ref: '#/definitions/Operation'
+          queryProducts:
+            $ref: '#/definitions/Operation'
+          createProducts:
+            $ref: '#/definitions/Operation'
+          updateProducts:
+            $ref: '#/definitions/Operation'
+          deleteProducts:
+            $ref: '#/definitions/Operation'
+          deleteManyProducts:
+            $ref: '#/definitions/Operation'
+          queryPaths:
+            $ref: '#/definitions/Operation'
+  StatusObject:
+    title: Status Object
+    description: Status object comprised of a type and display name
+    type: object
+    required:
+      - statusType
+    properties:
+      statusType:
+        description: Status type enum
+        type: string
+        enum:
+          - LOOPING
+          - SKIPPED
+          - CUSTOM
+          - DONE
+          - PASSED
+          - FAILED
+          - RUNNING
+          - WAITING
+          - TERMINATED
+          - ERRORED
+          - TIMED_OUT
+        example: PASSED
+      statusName:
+        description: Status name
+        type: string
+        example: Passed
+  NamedValueObject:
+    title: Named Value
+    description: Represents a named value or parameter
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        description: The name of the value
+        type: string
+        example: Voltage
+      value:
+        description: The value
+        type: object
+        example: 1.3
+  OrderByComparisonType:
+    title: Order By Comparison Type
+    description: >-
+      An enumeration of comparison types that can be used for ordered queries.
+      For non-DEFAULT comparisons, values that cannot be converted will be considered the smallest value.
+    type: string
+    enum:
+      - DEFAULT
+      - LEXICOGRAPHIC
+      - NUMERIC
+  ProductValuesQueryField:
+    title: Product Values Query Field
+    description: An enumeration of product fields for which the values can be queried for.
+    type: string
+    enum:
+      - ID
+      - PART_NUMBER
+      - NAME
+      - FAMILY
+      - UPDATED_AT
+    example: FAMILY
+  ProductQueryOrderByField:
+    title: Product Query OrderBy Field
+    description: An enumeration of fields by which products can be ordered.
+    type: string
+    enum:
+      - ID
+      - PART_NUMBER
+      - NAME
+      - FAMILY
+      - UPDATED_AT
+    example: FAMILY
+  ProductField:
+    title: Product Field
+    description: An enumeration of all fields in a Product.
+    type: string
+    enum:
+      - ID
+      - PART_NUMBER
+      - NAME
+      - FAMILY
+      - WORKSPACE
+      - UPDATED_AT
+      - KEYWORDS
+      - PROPERTIES
+      - FILE_IDS
+    example: FAMILY
+  ResultValuesQueryField:
+    title: Result Values Query Field
+    description: An enumeration of result fields for which the values can be queried for.
+    type: string
+    enum:
+      - ID
+      - STARTED_AT
+      - UPDATED_AT
+      - PROGRAM_NAME
+      - SYSTEM_ID
+      - HOST_NAME
+      - OPERATOR
+      - SERIAL_NUMBER
+      - PART_NUMBER
+      - TOTAL_TIME_IN_SECONDS
+    example: PROGRAM_NAME
+  ResultQueryOrderByField:
+    title: Result Query OrderBy Field
+    description: An enumeration of fields by which results can be ordered.
+    type: string
+    enum:
+      - ID
+      - STARTED_AT
+      - UPDATED_AT
+      - PROGRAM_NAME
+      - SYSTEM_ID
+      - HOST_NAME
+      - OPERATOR
+      - SERIAL_NUMBER
+      - PART_NUMBER
+      - PROPERTIES
+      - TOTAL_TIME_IN_SECONDS
+    example: PROGRAM_NAME
+  ResultField:
+    title: Result Field
+    description: An enumeration of all fields in a Result.
+    type: string
+    enum:
+      - ID
+      - STATUS
+      - STARTED_AT
+      - UPDATED_AT
+      - PROGRAM_NAME
+      - SYSTEM_ID
+      - HOST_NAME
+      - OPERATOR
+      - SERIAL_NUMBER
+      - PART_NUMBER
+      - TOTAL_TIME_IN_SECONDS
+      - KEYWORDS
+      - PROPERTIES
+      - FILE_IDS
+      - DATA_TABLE_IDS
+      - STATUS_TYPE_SUMMARY
+      - WORKSPACE
+    example: PROGRAM_NAME
+  StepValuesQueryField:
+    title: Step Values Query Field
+    description: An enumeration of step fields for which the values can be queried for.
+    type: string
+    enum:
+      - NAME
+      - STEP_TYPE
+      - STEP_ID
+      - PARENT_ID
+      - RESULT_ID
+      - PATH
+      - TOTAL_TIME_IN_SECONDS
+      - STARTED_AT
+      - UPDATED_AT
+      - DATA_MODEL
+    example: STEP_TYPE
+  StepQueryOrderByField:
+    title: Step Query OrderBy Field
+    description: An enumeration of fields by which steps can be ordered.
+    type: string
+    enum:
+      - NAME
+      - STEP_TYPE
+      - STEP_ID
+      - PARENT_ID
+      - RESULT_ID
+      - PATH
+      - TOTAL_TIME_IN_SECONDS
+      - STARTED_AT
+      - UPDATED_AT
+      - DATA_MODEL
+    example: STEP_TYPE
+  StepField:
+    title: Step Field
+    description: An enumeration of all fields in a Step.
+    type: string
+    enum:
+      - NAME
+      - STEP_TYPE
+      - STEP_ID
+      - PARENT_ID
+      - RESULT_ID
+      - PATH
+      - PATH_IDS
+      - STATUS
+      - TOTAL_TIME_IN_SECONDS
+      - STARTED_AT
+      - UPDATED_AT
+      - INPUTS
+      - OUTPUTS
+      - DATA_MODEL
+      - DATA
+      - HAS_CHILDREN
+      - WORKSPACE
+      - KEYWORDS
+      - PROPERTIES
+    example: STEP_TYPE
+  PathQueryOrderByField:
+    title: Path Query OrderBy Field
+    description: An enumeration of fields by which paths can be ordered.
+    type: string
+    enum:
+      - ID
+      - PROGRAM_NAME
+      - PART_NUMBER
+      - PATH
+    example: PROGRAM_NAME
+  PathField:
+    title: Path Field
+    description: An enumeration of all fields in a Path.
+    type: string
+    enum:
+      - ID
+      - PROGRAM_NAME
+      - PART_NUMBER
+      - PATH
+      - PATH_NAMES
+      - INPUTS
+      - OUTPUTS
+      - MEASUREMENTS
+    example: PROGRAM_NAME
+  ValueType:
+    title: Value Type
+    description: An enumeration of the possible types of variant values.
+    type: string
+    enum:
+      - MIXED
+      - NULL
+      - BOOLEAN
+      - NUMBER
+      - STRING
+      - ARRAY
+      - OBJECT
+  ResponseFormat:
+    title: Response Format
+    description: Enum indicating the expected response format (CSV or JSON). If unspecified, JSON is the default.
+    type: string
+    enum:
+      - JSON
+      - CSV
+    default: 'JSON'
+  ProductQueryFilter:
+    title: Product Query Filter
+    description: |
+      The product query filter in [Dynamic Linq](https://github.com/ni/systemlink-OpenAPI-documents/wiki/Dynamic-Linq-Query-Language). Allowed properties in the filter are:
+        - `id`: String identifier of the product.
+        - `partNumber`: String representing the part number of the product.
+        - `name`: String name of the product.
+        - `family`: String representing the product family of the product.
+        - `updatedAt`: DateTime the product was last updated.
+        - `keywords`: Array of string values associated with the product.
+        - `properties`: Dictionary with string keys and values representing product metadata.
+        - `fileIds`: Array of string identifiers for files attached to the product.
+        - `updatedWithin`: TimeSpan indicating the difference between when the product was last updated (`updatedAt`) and the current server time.
+        - `workspace`: String identifier of the workspace to which the product belongs to.
+        - `workspaceName`: String name of the workspace to which the product belongs to. This property only supports comparison operators, such as `==`, `!=`, and `>`. Methods such as `Contains()` or `Any()` are not supported.
+    type: string
+    example: (name != 'cRIO-9030') && (family == @0)
+  ResultQueryFilter:
+    title: Result Query Filter
+    description: |
+      The result query filter in [Dynamic Linq](https://github.com/ni/systemlink-OpenAPI-documents/wiki/Dynamic-Linq-Query-Language). Allowed properties in the filter are:
+        - `id`: String identifier of the result.
+        - `status.statusType`: String enumeration representing the current state of the test result. Possible values are `Looping`, `Skipped`, `Custom`, `Done`, `Passed`, `Failed`, `Running`, `Waiting`, `Terminated`, `Errored`, and `TimedOut`.
+        - `status.statusName`: A custom display name string describing the status of the test result.
+        - `startedAt`: DateTime the test started at.
+        - `updatedAt`: DateTime the result was last updated.
+        - `programName`: String name of the test program which was executed to produce the result.
+        - `systemId`: String identifier of the system on which the test was executed.
+        - `hostName`: String value representing the host name of the system on which the test was executed.
+        - `operator`: String value representing the operator of the test result.
+        - `serialNumber`: String value representing the serial number of the device under test.
+        - `partNumber`: String representing the part number of the product or device under test.
+        - `productName`: String name of the product associated with the test. This property only supports comparison operators, such as `==`, `!=`, and `>`. Methods such as `Contains()` or `Any()` are not supported.
+        - `totalTimeInSeconds`: Double value representing the total time, in seconds, that the test took to execute.
+        - `keywords`: Array of string values associated with the result.
+        - `properties`: Dictionary with string keys and values representing test result metadata.
+        - `fileIds`: Array of string identifiers for files attached to the test result.
+        - `dataTableIds`: Array of string identifiers for data tables attached to the test result.
+        - `startedWithin`: TimeSpan indicating the difference between when the test started (`startedAt`) and the current server time.
+        - `updatedWithin`: TimeSpan indicating the difference between when the test was last updated (`updatedAt`) and the current server time.
+        - `workspace`: String identifier of the workspace to which the result belongs to.
+        - `workspaceName`: String name of the workspace to which the result belongs to. This property only supports comparison operators, such as `==`, `!=`, and `>`. Methods such as `Contains()` or `Any()` are not supported.
+    type: string
+    example: (operator == 'user1') || ((programName != 'MyProgram') && (totalTimeInSeconds < @0))
+  StepQueryFilter:
+    title: Step Query Filter
+    description: |
+      The step query filter in [Dynamic Linq](https://github.com/ni/systemlink-OpenAPI-documents/wiki/Dynamic-Linq-Query-Language). Allowed properties in the filter are:
+        - `stepId`: A string which uniquely identifies this step within its corresponding test result.
+        - `name`: String name of the test step.
+        - `stepType`: String identifier for the type of the test step.
+        - `parentId`: The `stepId` of this step's parent.
+        - `resultId`: The `id` of the result the step belongs to.
+        - `path`: String containing the `name` fields for all ancestor steps, separated by dots.
+        - `pathIds`: Array of `stepId` fields for all ancestor steps.
+        - `status.statusType`: String enumeration representing the current state of the test step. Possible values are `Looping`, `Skipped`, `Custom`, `Done`, `Passed`, `Failed`, `Running`, `Waiting`, `Terminated`, `Errored`, and `TimedOut`.
+        - `status.statusName`: A custom display name string describing the status of the test step.
+        - `totalTimeInSeconds`: The total time, in seconds, that the step took to execute.
+        - `startedAt`: DateTime the step started at.
+        - `updatedAt`: DateTime the step was last updated.
+        - `inputs`: Array of objects, each with a string name and a variant value, representing the inputs of the test step.
+        - `outputs`: Array of objects, each with a string name and a variant value, representing the outputs of the test step.
+        - `dataModel`: String identifier for the structure of the associated data object.
+        - `data.text`: String containing custom text associated with this step.
+        - `data.parameters`: Array of sets of string key-value pairs containing custom metadata such as limits and measurements
+        - `startedWithin`: TimeSpan indicating the difference between when the step started (`startedAt`) and the current server time.
+        - `updatedWithin`: TimeSpan indicating the difference between when the step was last updated (`updatedAt`) and the current server time.
+        - `hasChildren`: Boolean indicating whether the step has child steps.
+        - `keywords`: Array of string values associated with the step.
+        - `properties`: Dictionary with string keys and values representing step metadata.
+        - `workspace`: String identifier of the workspace to which the step belongs to.
+        - `workspaceName`: String name of the workspace to which the step belongs to. This property only supports comparison operators, such as `==`, `!=`, and `>`. Methods such as `Contains()` or `Any()` are not supported.
+    type: string
+    example: (stepType == 'NumericLimitTest') && (totalTimeInSeconds > @0)
+  PathQueryFilter:
+    title: Path Query Filter
+    description: |
+      The path query filter in [Dynamic Linq](https://github.com/ni/systemlink-OpenAPI-documents/wiki/Dynamic-Linq-Query-Language). Allowed properties in the filter are:
+        - `id`: String identifier of the path.
+        - `programName`: String name of the test program which contains steps with this path.
+        - `partNumber`: String representing the part number of the product or device under test.
+        - `path`: Array of strings containing the `name` fields for all ancestor steps.
+    type: string
+    example: (programName == \"MyTests.seq\") || (partNumber == \"cRIO-9030\")
+  ProductRequestObject:
+    title: Product Request
+    type: object
+    properties:
+      partNumber:
+        description: The part number of the product
+        type: string
+        example: 156502A-11L
+      name:
+        description: The name of the product
+        type: string
+        example: cRIO-9030
+      family:
+        description: The family of the product
+        type: string
+        example: cRIO
+      keywords:
+        description: Words or phrases associated with the product
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Key-value pairs associated with the product
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      fileIds:
+        description: Array of file IDs attached to the product. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5ccb19ce5aa0a3348872c3e3]
+      workspace:
+        description: The workspace the product belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  ProductResponseObject:
+    title: Product Response
+    type: object
+    properties:
+      id:
+        description: ID of the product
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      partNumber:
+        description: The part number of the product
+        type: string
+        example: 156502A-11L
+      name:
+        description: The name of the product
+        type: string
+        example: cRIO-9030
+      family:
+        description: The family of the product
+        type: string
+        example: cRIO
+      updatedAt:
+        description: >-
+          ISO-8601 formatted timestamp indicating when the product
+          was last updated.
+        type: string
+        format: date-time
+        example: '2018-05-09T15:07:42.527921Z'
+      keywords:
+        description: Words or phrases associated with the product
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Key-value pairs associated with the product
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      fileIds:
+        description: Array of file IDs attached to the product. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5e30934193cac8046851acb2]
+      workspace:
+        description: The workspace the product belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  ProductUpdateRequestObject:
+    title: Product Update Request
+    type: object
+    properties:
+      id:
+        description: ID of the product to update
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      name:
+        description: The name of the product
+        type: string
+        example: cRIO-9030
+      family:
+        description: The family of the product
+        type: string
+        example: cRIO
+      keywords:
+        description: Words or phrases associated with the product
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Key-value pairs associated with the product
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      fileIds:
+        description: Array of file IDs attached to the product. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5e30934193cac8046851acb2]
+      workspace:
+        description: The workspace the product belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  TestResultRequestObject:
+    title: Test Result Request
+    type: object
+    required: [programName, status]
+    properties:
+      programName:
+        description: Program name
+        type: string
+        example: My Program Name
+      status:
+        $ref: '#/definitions/StatusObject'
+      systemId:
+        description: System id
+        type: string
+        example: my-system
+      hostName:
+        description: Host name
+        type: string
+        example: My-Host
+      properties:
+        description: Test result properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      keywords:
+        description: Words or phrases associated with the test result
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      serialNumber:
+        description: Serial number
+        type: string
+        example: 123-456
+      operator:
+        description: Operator
+        type: string
+        example: admin
+      partNumber:
+        description: The part number of the device under test.
+        type: string
+        example: cRIO-9030
+      fileIds:
+        description: Array of file ids attached to the test result. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5e30934193cac8046851acb2]
+      dataTableIds:
+        description: Array of data table ids attached to the test result. This API does not verify that the data table IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [62333547f7521f2f2f4615e5]
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      totalTimeInSeconds:
+        description: Total run-time of the test in seconds
+        type: number
+        format: double
+        default: 0
+        example: 29.9
+      workspace:
+        description: The workspace the test result belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  TestResultResponseObject:
+    title: Test Result Response
+    type: object
+    required:
+      - id
+    properties:
+      status:
+        $ref: '#/definitions/StatusObject'
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      updatedAt:
+        description: ISO-8601 formatted timestamp indicating when the result was last updated
+        type: string
+        format: date-time
+        example: '2018-05-09T15:07:42.527921Z'
+      programName:
+        description: Program name
+        type: string
+        example: My test program
+      id:
+        description: Id of the test result
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      systemId:
+        description: Id of the system
+        type: string
+        example: 5e30931993cac8046850a996
+      hostName:
+        description: Host name of the system
+        type: string
+        example: My-Host
+      operator:
+        description: Name of the operator running the test
+        type: string
+        example: admin
+      partNumber:
+        description: The part number of the device under test.
+        type: string
+        example: cRIO-9030
+      serialNumber:
+        description: Sequential number of the device under test
+        type: string
+        example: abc-123
+      totalTimeInSeconds:
+        description: Total run-time of the test in seconds
+        type: number
+        format: double
+        example: 29.9
+      keywords:
+        description: Words or phrases associated with the test result
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Test result properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      fileIds:
+        description: Array of file ids attached to the test result. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: []
+      dataTableIds:
+        description: Array of data table ids attached to the test result. This API does not verify that the data table IDs included exist.
+        type: array
+        items:
+          type: string
+        example: []
+      statusTypeSummary:
+        description: Status type summary
+        type: object
+        additionalProperties:
+          type: integer
+          format: int32
+        example:
+          FAILED: 5
+      workspace:
+        description: The workspace the test result belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  TestResultUpdateFailureObject:
+    title: Test Result Update Failure Object
+    type: object
+    properties:
+      id:
+        description: Test result id to update
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      programName:
+        description: Program name
+        type: string
+        example: My Program Name
+      status:
+        $ref: '#/definitions/StatusObject'
+      systemId:
+        description: System id
+        type: string
+        example: my-system
+      hostName:
+        description: Host name
+        type: string
+        example: My-Host
+      properties:
+        description: Test result properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      keywords:
+        description: Words or phrases associated with the test result
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      serialNumber:
+        description: Serial number
+        type: string
+        example: 123-456
+      operator:
+        description: Operator
+        type: string
+        example: admin
+      partNumber:
+        description: The part number of the device under test.
+        type: string
+        example: cRIO-9030
+      fileIds:
+        description: Array of file ids attached to the test result. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5e30934193cac8046851acb2]
+      dataTableIds:
+        description: Array of data table ids attached to the test result. This API does not verify that the data table IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [62333547f7521f2f2f4615e5]
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      totalTimeInSeconds:
+        description: Total run-time of the test in seconds
+        type: number
+        format: double
+        default: 0
+        example: 29.9
+      workspace:
+        description: The workspace the test result belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  TestResultUpdateRequestObject:
+    title: Test Result Update
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        description: Test result id to update
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      programName:
+        description: Program name
+        type: string
+        example: My Program Name
+      status:
+        $ref: '#/definitions/StatusObject'
+      systemId:
+        description: System id
+        type: string
+        example: my-system
+      hostName:
+        description: Host name
+        type: string
+        example: My-Host
+      properties:
+        description: Test result properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+      keywords:
+        description: Words or phrases associated with the test result
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      serialNumber:
+        description: Serial number
+        type: string
+        example: 123-456
+      operator:
+        description: Operator
+        type: string
+        example: admin
+      partNumber:
+        description: The part number of the device under test.
+        type: string
+        example: cRIO-9030
+      fileIds:
+        description: Array of file ids attached to the test result. This API does not verify that the file IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [5e30934193cac8046851acb2]
+      dataTableIds:
+        description: Array of data table ids attached to the test result. This API does not verify that the data table IDs included exist.
+        type: array
+        items:
+          type: string
+        example: [62333547f7521f2f2f4615e5]
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      totalTimeInSeconds:
+        description: Total run-time of the test in seconds
+        type: number
+        format: double
+        default: 0
+        example: 29.9
+      workspace:
+        description: The workspace the test result belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+  UpdateTestResultsRequest:
+    title: Update Test Results Request
+    required:
+      - results
+    properties:
+      results:
+        description: Array of test results to update
+        type: array
+        items:
+          $ref: '#/definitions/TestResultUpdateRequestObject'
+      replace:
+        description: Replace the existing fields instead of merging them
+        type: boolean
+        default: false
+      determineStatusFromSteps:
+        description: Determine test result status from the test step statuses
+        type: boolean
+        default: false
+  ValueSummaryObject:
+    title: Value Summary
+    type: object
+    properties:
+      type:
+        $ref: '#/definitions/ValueType'
+      min:
+        description: The minimum recorded value, if `type` is "NUMBER".
+        type: number
+        example: 1.3
+      max:
+        description: The maximum recorded value, if `type` is "NUMBER".
+        type: number
+        example: 2.6
+  PathResponseObject:
+    title: Path Response Object
+    type: object
+    properties:
+      id:
+        description: >-
+          The unique ID of this path. Note that this value may change if
+          the collection is repaired.
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      path:
+        description: >-
+          Identifies the steps that this path is representative of.
+        type: string
+        example: MainSequence Callback
+          
+          My Step Name
+      programName:
+        description: The program name for which this path is defined.
+        type: string
+        example: MyProgram.seq
+      partNumber:
+        description: The part number for which this path is defined.
+        type: string
+        example: 156502A-11L
+      pathNames:
+        description: >-
+          The list of all ancestor step names for any step which corresponds
+          to this path.
+        type: array
+        items:
+          type: string
+        example: ['MainSequence Callback', 'VoltageTest']
+      inputs:
+        description: >-
+          The set of inputs that steps which correspond to this path may take.
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ValueSummaryObject'
+      outputs:
+        description: >-
+          The set of outputs that steps which correspond to this path may log.
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ValueSummaryObject'
+      measurements:
+        description: >-
+          The set of measurements that steps which correspond to this path may take.
+        type: object
+        additionalProperties:
+          type: object
+        example:
+          myMeasurement: {}
+  ProductsAdvancedQuery:
+    title: Advanced Query Object for Products
+    description: >-
+      Product fields that the response can be ordered by are 
+      `ID`, `PART_NUMBER`, `NAME`, `FAMILY`, and `UPDATED_AT`.
+    properties:
+      filter:
+        $ref: '#/definitions/ProductQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - "cRIO"
+      orderBy:
+        $ref: '#/definitions/ProductQueryOrderByField'
+      descending:
+        description: Whether to return the products in descending order.
+        type: boolean
+        default: false
+        example: false
+      projection:
+        description: >-
+          Specifies the product fields to project. When a field value is given here,
+          the corresponding field will be present in all returned products, and all
+          unspecified fields will be excluded. If no projection is specified,
+          all product fields will be returned.
+        type: array
+        items:
+          $ref: '#/definitions/ProductField'
+      take:
+        description: The maximum number of products to return.
+        type: integer
+        format: int32
+        default: 1000
+        minimum: -1
+        example: 1000
+      continuationToken:
+        description: >-
+          A token which allows the user to resume a query at the next item in
+          the matching product set. When querying for products, a token will
+          be returned if a query may be continued. To obtain the next page of
+          products, pass the token to the service on a subsequent request.
+        type: string
+        example: token
+      returnCount:
+        description: >-
+          Whether to return the total number of products which match the
+          provided filter, disregarding the take value.
+        type: boolean
+        default: false
+        example: false
+  PathsAdvancedQuery:
+    title: Advanced Query Object for Paths
+    description: >-
+      Path fields that the response can be ordered by are 
+      `ID`, `PROGRAM_NAME`, `PART_NUMBER`, and `PATH`.
+    properties:
+      filter:
+        $ref: '#/definitions/PathQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      orderBy:
+        $ref: '#/definitions/PathQueryOrderByField'
+      descending:
+        description: Whether to return the paths in descending order.
+        type: boolean
+        default: false
+        example: false
+      projection:
+        description: >-
+          Specifies the path fields to project. When a field value is given here,
+          the corresponding field will be present in all returned paths, and all
+          unspecified fields will be excluded. If no projection is specified,
+          all path fields will be returned.
+        type: array
+        items:
+          $ref: '#/definitions/PathField'
+      take:
+        description: The maximum number of paths to return.
+        type: integer
+        format: int32
+        default: 1000
+        minimum: -1
+        example: 1000
+      continuationToken:
+        description: >-
+          A token which allows the user to resume a query at the next item in
+          the matching path set. When querying for paths, a token will
+          be returned if a query may be continued. To obtain the next page of
+          paths, pass the token to the service on a subsequent request.
+        type: string
+        example: token
+      returnCount:
+        description: >-
+          Whether to return the total number of paths which match the
+          provided filter, disregarding the take value.
+        type: boolean
+        default: false
+        example: false
+  ResultsAdvancedQuery:
+    title: Advanced Query Object for Test Results
+    description: Results advanced query request object.
+    properties:
+      filter:
+        $ref: '#/definitions/ResultQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      productFilter:
+        $ref: '#/definitions/ProductQueryFilter'
+      productSubstitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - cRIO
+      orderBy:
+        $ref: '#/definitions/ResultQueryOrderByField'
+      descending:
+        description: Whether to return the results in descending order.
+        type: boolean
+        default: false
+        example: false
+      orderByKey:
+        description: >-
+          The property name to order by when ordering by PROPERTIES. Results that do not contain the orderByKey
+          will be considered the smallest value.
+        type: string
+        example: null
+      orderByComparisonType:
+        $ref: '#/definitions/OrderByComparisonType'
+      projection:
+        description: >-
+          Specifies the result fields to project. When a field value is given here,
+          the corresponding field will be present in all returned results, and all
+          unspecified fields will be excluded. If no projection is specified,
+          all result fields will be returned.
+        type: array
+        items:
+          $ref: '#/definitions/ResultField'
+      take:
+        description: The maximum number of products to return.
+        type: integer
+        format: int32
+        default: 1000
+        minimum: -1
+        example: 1000
+      continuationToken:
+        description: >-
+          A token which allows the user to resume a query at the next item in
+          the matching product set. When querying for products, a token will
+          be returned if a query may be continued. To obtain the next page of
+          products, pass the token to the service on a subsequent request.
+        type: string
+        example: token
+      returnCount:
+        description: >-
+          Whether to return the total number of products which match the
+          provided filter, disregarding the take value.
+        type: boolean
+        default: false
+        example: false
+      responseFormat:
+        $ref: '#/definitions/ResponseFormat'
+  StepsAdvancedQuery:
+    title: Advanced Query Object for Test Steps
+    description: >-
+      Test Step fields that the response can be ordered by are 
+      `NAME`, `STEP_TYPE`, `STEP_ID`, `PARENT_ID`, `RESULT_ID`, 
+      `PATH`, `TOTAL_TIME_IN_SECONDS`, `STARTED_AT`, `UPDATED_AT`,
+      and `DATA_MODEL`.
+    properties:
+      filter:
+        $ref: '#/definitions/StepQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      resultFilter:
+        $ref: '#/definitions/ResultQueryFilter'
+      resultSubstitutions:
+        description: >-
+          Makes substitutions in the query filter expression for results.
+          Substitutions for the query expression are indicated by non-negative
+          integers that are prefixed with the "at" symbol. Each substitution in
+          the given expression will be replaced by the element at the
+          corresponding index (zero-based) in this list. For example, "@0" in
+          the filter expression will be replaced with the element at the zeroth
+          index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - user1
+      orderBy:
+        $ref: '#/definitions/StepQueryOrderByField'
+      descending:
+        description: Whether to return the steps in descending order.
+        type: boolean
+        default: false
+        example: false
+      projection:
+        description: >-
+          Specifies the step fields to project. When a field value is given here,
+          the corresponding field will be present in all returned steps, and all
+          unspecified fields will be excluded. If no projection is specified,
+          all step fields will be returned.
+        type: array
+        items:
+          $ref: '#/definitions/StepField'
+      take:
+        description: The maximum number of steps to return.
+        type: integer
+        format: int32
+        default: 1000
+        minimum: -1
+        example: 1000
+      continuationToken:
+        description: >-
+          A token which allows the user to resume a query at the next item in
+          the matching step set. When querying for steps, a token will
+          be returned if a query may be continued. To obtain the next page of
+          steps, pass the token to the service on a subsequent request.
+        type: string
+        example: token
+      returnCount:
+        description: >-
+          Whether to return the total number of steps which match the
+          provided filter, disregarding the take value.
+        type: boolean
+        default: false
+        example: false
+      responseFormat:
+        $ref: '#/definitions/ResponseFormat'
+  ProductValuesQuery:
+    title: Product Values Query
+    required:
+      - field
+    properties:
+      field:
+        $ref: '#/definitions/ProductValuesQueryField'
+      filter:
+        $ref: '#/definitions/ProductQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      startsWith:
+        description: Only return string values prefixed by this value (case sensitive).
+        type: string
+        example: cR
+  ResultValuesQuery:
+    title: Result Values Query
+    required:
+      - field
+    properties:
+      field:
+        $ref: '#/definitions/ResultValuesQueryField'
+      filter:
+        $ref: '#/definitions/ResultQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      startsWith:
+        description: Only return string values prefixed by this value (case sensitive).
+        type: string
+        example: op
+  StepValuesQuery:
+    title: Step Values Query
+    required:
+      - field
+    properties:
+      field:
+        $ref: '#/definitions/StepValuesQueryField'
+      filter:
+        $ref: '#/definitions/StepQueryFilter'
+      substitutions:
+        description: >-
+          Makes substitutions in the query filter expression. Substitutions for the query expression
+          are indicated by non-negative integers that are prefixed with the "at" symbol. Each
+          substitution in the given expression will be replaced by the element at the corresponding
+          index (zero-based) in this list. For example, "@0" in the filter expression will be replaced with
+          the element at the zeroth index of the substitutions list.
+        type: array
+        items:
+          type: object
+        example:
+          - 2.5
+      startsWith:
+        description: Only return string values prefixed by this value (case sensitive).
+        type: string
+        example: op
+  StepIdResultIdPair:
+    title: Step Id / Result Id Pair
+    type: object
+    required:
+      - stepId
+      - resultId
+    properties:
+      stepId:
+        type: string
+        example: bd9126f5-b0b1-446a-8b08-dc6460047377
+      resultId:
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+  StepDataObject:
+    title: Step Data
+    description: Data returned by the test step
+    type: object
+    properties:
+      text:
+        description: Text string describing the output data
+        type: string
+        example: My output string
+      parameters:
+        description: Array of properties objects
+        type: array
+        items:
+          description: Dictionary of key-value property pairs
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            key1: value1
+        example:
+          - name: Voltage
+            status: Passed
+            measurement: "3.725"
+            lowLimit: "3.65"
+            highLimit: "3.8"
+            nominalValue: "3.7"
+            units: volt
+            comparisonType: GELE
+          - nitmParameterType: ADDITIONAL_RESULTS
+            additionalProp: myValue
+  TestStepsDeleteRequest:
+    title: Test Steps Delete Request
+    required:
+      - steps
+    properties:
+      steps:
+        description: Array of test step id and result id pairs to delete
+        type: array
+        items:
+          $ref: '#/definitions/StepIdResultIdPair'
+  TestStepRequestObject:
+    title: Test Step Request
+    type: object
+    properties:
+      stepId:
+        description: Step id
+        type: string
+        example: Step1
+      parentId:
+        description: Parent step id
+        type: string
+        example: root
+      resultId:
+        description: Result id
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      children:
+        description: Nested child steps
+        type: array
+        items:
+          $ref: '#/definitions/TestStepRequestObject'
+        example: []
+      data:
+        $ref: '#/definitions/StepDataObject'
+      dataModel:
+        description: Data model for the step
+        type: string
+        example: TestStand
+      name:
+        description: >-
+          Step name. Warning: Step path is not updated when a step's name is updated after creation.
+        type: string
+        example: My Step
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      status:
+        $ref: '#/definitions/StatusObject'
+      stepType:
+        description: Step type
+        type: string
+        example: NumericLimitTest
+      totalTimeInSeconds:
+        description: Total number of seconds the step took to execute
+        type: number
+        format: double
+        default: 0
+        example: 29.9
+      inputs:
+        description: Inputs and their values passed to the test
+        type: array
+        items:
+          $ref: '#/definitions/NamedValueObject'
+      outputs:
+        description: Outputs and their values logged by the test
+        type: array
+        items:
+          $ref: '#/definitions/NamedValueObject'
+      keywords:
+        description: Words or phrases associated with the step
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Test step properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+  TestStepCreateRequestObject:
+    title: Test Step Create Request
+    required:
+      - steps
+    properties:
+      steps:
+        description: Array of test steps to create
+        type: array
+        items:
+          $ref: '#/definitions/TestStepRequestObject'
+      updateResultTotalTime:
+        description: Determine test result total time from the test step total times.
+        type: boolean
+        default: false
+  TestStepUpdateRequestObject:
+    title: Test Step Update Request
+    required:
+      - steps
+    properties:
+      steps:
+        description: Array of test steps to update
+        type: array
+        items:
+          $ref: '#/definitions/TestStepRequestObject'
+      updateResultTotalTime:
+        description: Determine test result total time from the test step total times.
+        type: boolean
+        default: false
+      replaceKeywords:
+        description: Replace with existing keywords instead of merging them
+        type: boolean
+        default: false
+      replaceProperties:
+        description: Replace with existing properties instead of merging them
+        type: boolean
+        default: false
+  TestStepResponseObject:
+    title: Test Step Response
+    type: object
+    properties:
+      name:
+        description: Step name
+        type: string
+        example: My Step Name
+      stepType:
+        description: Step type
+        type: string
+        example: NumericLimitTest
+      stepId:
+        description: Step id
+        type: string
+        example: Step1
+      parentId:
+        description: Parent step id
+        type: string
+        example: root
+      resultId:
+        description: Result id
+        type: string
+        example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      path:
+        description: Step path. Step path is not updated when a step's name is updated after creation. Use pathIds to determine step hierarchy instead.
+        type: string
+        example: root.My Step Name
+      pathIds:
+        description: Ids of the steps in the path
+        type: array
+        items:
+          type: string
+        example:
+          - root
+          - Step1
+      status:
+        $ref: '#/definitions/StatusObject'
+      totalTimeInSeconds:
+        description: Total number of seconds the step took to execute
+        type: number
+        format: double
+        example: 0
+      startedAt:
+        description: ISO-8601 formatted timestamp indicating when the test result began
+        type: string
+        format: date-time
+        example: '2018-05-07T18:58:05.219692Z'
+      updatedAt:
+        description: ISO-8601 formatted timestamp indicating when the result was last updated
+        type: string
+        format: date-time
+        example: '2018-05-09T15:07:42.527921Z'
+      inputs:
+        description: Inputs and their values passed to the test
+        type: array
+        items:
+          $ref: '#/definitions/NamedValueObject'
+      outputs:
+        description: Outputs and their values logged by the test
+        type: array
+        items:
+          $ref: '#/definitions/NamedValueObject'
+      dataModel:
+        description: Custom string defining the model of the data object
+        type: string
+        example: TestStand
+      data:
+        $ref: '#/definitions/StepDataObject'
+      hasChildren:
+        description: >-
+          Whether this step object has any children step objects. When false, this means
+          that this step object is a leaf node.
+        type: boolean
+        example: false
+      workspace:
+        description: The workspace the test step belongs to
+        type: string
+        example: f94b178e-288c-4101-afb1-833992413aa7
+      keywords:
+        description: Words or phrases associated with the test step
+        type: array
+        items:
+          type: string
+        example:
+          - keyword1
+          - keyword2
+      properties:
+        description: Test step properties
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          key1: value1
+responses:
+  Error:
+    description: Error
+    schema:
+      description: Error response
+      title: ErrorResponse
+      type: object
+      properties:
+        error:
+          $ref: '#/definitions/Error'
+  Unauthorized:
+    description: Not authorized
+    headers:
+      WWW_Authenticate:
+        description: Information for how to authenticate
+        type: string
+  ProductsSuccessResponse:
+    description: Products Success Response
+    schema:
+      description: Products Success Response
+      title: ProductsSuccessResponse
+      type: object
+      required:
+        - products
+      properties:
+        products:
+          description: Array of products
+          type: array
+          items:
+            $ref: '#/definitions/ProductResponseObject'
+  ProductsPartialSuccessResponse:
+    description: Products Partial Success Response
+    schema:
+      description: Products Partial Success Response
+      title: ProductsPartialSuccessResponse
+      type: object
+      required:
+        - products
+      properties:
+        products:
+          description: Array of products
+          type: array
+          items:
+            $ref: '#/definitions/ProductResponseObject'
+        failed:
+          description: Array of product requests that failed
+          type: array
+          items:
+            $ref: '#/definitions/ProductRequestObject'
+        error:
+          $ref: '#/definitions/Error'
+  DeleteProductsResponse:
+    description: Delete Products Response
+    schema:
+      description: Delete Products Response
+      title: DeleteProductsResponse
+      type: object
+      required:
+        - ids
+      properties:
+        ids:
+          description: Array of product ids to delete
+          type: array
+          items:
+            type: string
+          example:
+            - 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+        failed:
+          description: Array of product ids that failed to delete
+          type: array
+          items:
+            type: string
+          example: []
+        error:
+          $ref: '#/definitions/Error'
+  ProductsQueryResponse:
+    description: Products Query Response
+    schema:
+      description: Products Query Response
+      title: ProductsQueryResponse
+      type: object
+      x-ni-sparse: true
+      required:
+        - products
+      properties:
+        products:
+          description: Array of products
+          type: array
+          items:
+            $ref: '#/definitions/ProductResponseObject'
+        continuationToken:
+          description: >-
+            A token which allows the user to resume this query at the next item
+            in the matching product set. In order to continue paginating a
+            query, pass this token to the service on a subsequent request. The
+            service will respond with a new continuation token. To paginate a
+            set of products, continue sending requests with the newest
+            continuation token provided by the service, until this value is
+            null.
+          type: string
+          example: "token"
+        totalCount:
+          description: >-
+            The number of matching products, if returnCount is true.
+            This value is not present if returnCount is false.
+          type: integer
+          format: int64
+          example: 1
+  ResultsSuccessResponse:
+    description: Test Results Success Response
+    schema:
+      description: Test Results Success Response
+      title: ResultsSuccessResponse
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          description: Array of test results
+          type: array
+          items:
+            $ref: '#/definitions/TestResultResponseObject'
+  ResultsPartialSuccessResponse:
+    description: Test Results Partial Success Response
+    schema:
+      description: Test Results Partial Success Response
+      title: ResultsPartialSuccessResponse
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          description: Array of test results
+          type: array
+          items:
+            $ref: '#/definitions/TestResultResponseObject'
+        failed:
+          description: Array of test result requests that failed
+          type: array
+          items:
+            $ref: '#/definitions/TestResultRequestObject'
+        error:
+          $ref: '#/definitions/Error'
+  ResultsUpdatePartialSuccessResponse:
+    description: Test Results Update Partial Success Response
+    schema:
+      description: Test Results Update Partial Success Response
+      title: ResultsUpdatePartialSuccessResponse
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          description: Array of test results
+          type: array
+          items:
+            $ref: '#/definitions/TestResultResponseObject'
+        failed:
+          description: Array of test result update requests that failed
+          type: array
+          items:
+            $ref: '#/definitions/TestResultUpdateFailureObject'
+        error:
+          $ref: '#/definitions/Error'
+  DeleteResultsResponse:
+    description: Delete Test Results Response
+    schema:
+      description: Delete Test Results Response
+      title: DeleteResultsResponse
+      type: object
+      required:
+        - ids
+      properties:
+        ids:
+          description: Array of test result ids to delete
+          type: array
+          items:
+            type: string
+        failed:
+          description: Array of test result ids that failed to delete
+          type: array
+          items:
+            type: string
+        error:
+          $ref: '#/definitions/Error'
+  ResultsQueryResponse:
+    description: Test Results Query Response
+    schema:
+      description: Test Results Query Response
+      title: ResultsQueryResponse
+      type: object
+      x-ni-sparse: true
+      required:
+        - results
+      properties:
+        results:
+          description: Array of test results
+          type: array
+          items:
+            $ref: '#/definitions/TestResultResponseObject'
+        continuationToken:
+          description: >-
+            A token which allows the user to resume this query at the next item
+            in the matching result set. In order to continue paginating a
+            query, pass this token to the service on a subsequent request. The
+            service will respond with a new continuation token. To paginate a
+            set of results, continue sending requests with the newest
+            continuation token provided by the service, until this value is
+            null.
+          type: string
+          example: "token"
+        totalCount:
+          description: >-
+            The number of matching test results, if returnCount is true.
+            This value is not present if returnCount is false.
+          type: integer
+          format: int64
+          example: 1
+    headers:
+      X-NI-Continuation-Token:
+        description: >-
+          Only returned if the response is text/csv; otherwise will be in the response body.
+          A token which allows the user to resume this query at the next
+          item in the matching result set. In order to continue paginating
+          a query, pass this token to the service on a subsequent request.
+          The service will respond with a new continuation token. To paginate
+          a set of results, continue sending requests with the newest
+          continuation token provided by the service, until this value is null.
+        schema:
+          type: string
+  StepsSuccessResponse:
+    description: Test Steps Success Response
+    schema:
+      description: Test Steps Success Response
+      title: StepsSuccessResponse
+      type: object
+      required:
+        - steps
+      properties:
+        steps:
+          description: Array of test steps
+          type: array
+          items:
+            $ref: '#/definitions/TestStepResponseObject'
+  StepsPartialSuccessResponse:
+    description: Test Steps Partial Success Response
+    schema:
+      description: Test Steps Partial Success Response
+      title: StepsPartialSuccessResponse
+      type: object
+      required:
+        - steps
+      properties:
+        steps:
+          description: Array of test steps
+          type: array
+          items:
+            $ref: '#/definitions/TestStepResponseObject'
+        failed:
+          description: Array of test step requests that failed
+          type: array
+          items:
+            $ref: '#/definitions/TestStepRequestObject'
+        error:
+          $ref: '#/definitions/Error'
+  StepsQueryResponse:
+    description: Test Steps Query Response
+    schema:
+      description: Test Steps Query Response
+      title: StepsQueryResponse
+      type: object
+      x-ni-sparse: true
+      required:
+        - steps
+      properties:
+        steps:
+          description: Array of test steps
+          type: array
+          items:
+            $ref: '#/definitions/TestStepResponseObject'
+        continuationToken:
+          description: >-
+            A token which allows the user to resume this query at the next item
+            in the matching step set. In order to continue paginating a
+            query, pass this token to the service on a subsequent request. The
+            service will respond with a new continuation token. To paginate a
+            set of steps, continue sending requests with the newest
+            continuation token provided by the service, until this value is
+            null.
+          type: string
+          example: "token"
+        totalCount:
+          description: >-
+            The number of matching test steps, if returnCount is true.
+            This value is not present if returnCount is false.
+          type: integer
+          format: int64
+          example: 1
+    headers:
+      X-NI-Continuation-Token:
+        description: >-
+          Only returned if the response is text/csv; otherwise will be in the response body.
+          A token which allows the user to resume this query at the next item
+          in the matching step set. In order to continue paginating a
+          query, pass this token to the service on a subsequent request. The
+          service will respond with a new continuation token. To paginate a
+          set of steps, continue sending requests with the newest
+          continuation token provided by the service, until this value is
+          null.
+        schema:
+          type: string
+  StepsDeletePartialSuccessResponse:
+    description: Delete Test Steps Partial Success Response
+    schema:
+      description: Delete Test Steps Partial Success Response
+      title: StepsDeletePartialSuccessResponse
+      type: object
+      required:
+        - steps
+      properties:
+        steps:
+          description: Array of test step id result id pairs that were deleted
+          type: array
+          items:
+            $ref: '#/definitions/StepIdResultIdPair'
+        failed:
+          description: Array of test step id result id pairs that failed to delete
+          type: array
+          items:
+            $ref: '#/definitions/StepIdResultIdPair'
+        error:
+          $ref: '#/definitions/Error'
+  ValuesResponse:
+    description: Values Response
+    schema:
+      description: Values Response
+      title: ValuesResponse
+      type: array
+      items:
+        type: string
+      example:
+        - operator1
+        - operator2
+  PathsQueryResponse:
+    description: Paths Query Response
+    schema:
+      description: Paths Query Response
+      title: PathsQueryResponse
+      type: object
+      x-ni-sparse: true
+      required:
+        - paths
+      properties:
+        paths:
+          description: An array of path objects.
+          type: array
+          items:
+            $ref: '#/definitions/PathResponseObject'
+        continuationToken:
+          description: >-
+            A token which allows the user to resume this query at the next item
+            in the matching path set. In order to continue paginating a
+            query, pass this token to the service on a subsequent request. The
+            service will respond with a new continuation token. To paginate a
+            set of paths, continue sending requests with the newest
+            continuation token provided by the service, until this value is
+            null.
+          type: string
+          example: "token"
+        totalCount:
+          description: >-
+            The number of matching paths, if returnCount is true.
+            This value is not present if returnCount is false.
+          type: integer
+          format: int64
+paths:
+  /:
+    get:
+      tags: [versioning]
+      summary: API information
+      description: Returns information about API versions and available operations.
+      operationId: root-endpoint
+      # Explicitly mark security as an empty array - this route does not require any privileges.
+      # Marking it this way prevents it from inheriting the top-level security settings.
+      security: []
+      responses:
+        200:
+          description: OK
+          schema:
+            description: Version information
+            title: RootEndpointResponse
+            type: object
+            properties:
+              v1:
+                $ref: '#/definitions/V1Operations'
+              v2:
+                $ref: '#/definitions/V2Operations'
+              version:
+                description: Implementation version of the web service
+                type: string
+  /v2:
+    get:
+      tags: [versioning]
+      summary: API version 2 information
+      description: Returns available operations for version 2 of the API.
+      operationId: root-endpoint-v2
+      # Explicitly mark security as an empty array - this route does not require any privileges.
+      # Marking it this way prevents it from inheriting the top-level security settings.
+      security: []
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/V2Operations'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/Error'
+  /v2/query-products:
+    post:
+      tags: [products]
+      summary: Queries products
+      description: >-
+        Uses the Dynamic Linq query language to specify a filter and return
+        product. An empty request body queries all products.
+      operationId: query-products-v2
+      x-ni-operation: queryProducts
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query filter
+          required: false
+          schema:
+            $ref: '#/definitions/ProductsAdvancedQuery'
+      responses:
+        200:
+          $ref: '#/responses/ProductsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/products:
+    get:
+      tags: [products]
+      summary: Gets products
+      description: Gets a list of products.
+      operationId: get-products-v2
+      x-ni-operation: getProducts
+      x-ni-auth: true
+      parameters:
+        - in: query
+          name: continuationToken
+          description: >-
+            A token which allows the user to resume a query at the next item in
+            the matching product set. When querying for products, a token will
+            be returned if a query may be continued. To obtain the next page of
+            products, pass the token to the service on a subsequent request.
+          type: string
+        - in: query
+          name: take
+          description: >-
+            The maximum number of products to return.
+          type: integer
+          format: int32
+          default: 1000
+          minimum: -1
+        - in: query
+          name: returnCount
+          description: >-
+            Whether to return the total number of products,
+            disregarding the take value.
+          type: boolean
+          default: false
+      responses:
+        200:
+          $ref: '#/responses/ProductsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    post:
+      tags: [products]
+      summary: Creates new products
+      description: Creates new products from the supplied models. The server automatically generates the product ids.
+      operationId: create-products-v2
+      x-ni-operation: createProducts
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Product object
+          required: true
+          schema:
+            description: Array of products to create
+            title: CreateProductsRequest
+            required:
+              - products
+            properties:
+              products:
+                description: Array of products to create
+                type: array
+                items:
+                  $ref: '#/definitions/ProductRequestObject'
+      responses:
+        200:
+          $ref: '#/responses/ProductsPartialSuccessResponse'
+        201:
+          $ref: '#/responses/ProductsSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/products/{productId}:
+    get:
+      tags: [products]
+      summary: Gets a product
+      description: Gets a single product.
+      operationId: get-product-v2
+      x-ni-operation: getProducts
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: productId
+          description: The id of the product to get.
+          type: string
+          required: true
+      responses:
+        200:
+          description: Get Product Response
+          schema:
+            $ref: '#/definitions/ProductResponseObject'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    delete:
+      tags: [products]
+      summary: Deletes a product
+      description: Deletes the product with the specified id. The request succeeds for products that do not exist.
+      operationId: delete-product-v2
+      x-ni-operation: deleteProduct
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: productId
+          description: Id of the product to delete
+          type: string
+          required: true
+      responses:
+        204:
+          description: The resource was deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-product-values:
+    post:
+      tags: [products]
+      summary: Queries values for a product field
+      description: >-
+        Queries known values for an indexed, scalar product field. Supported
+        fields are `ID`, `PART_NUMBER`, `NAME`, `FAMILY`, and `UPDATED_AT`.
+      operationId: query-product-values-v2
+      x-ni-operation: queryProducts
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query parameters
+          required: true
+          schema:
+            $ref: '#/definitions/ProductValuesQuery'
+      responses:
+        200:
+          $ref: '#/responses/ValuesResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/update-products:
+    post:
+      tags: [products]
+      summary: Updates existing products
+      description: Updates existing products by merging or replacing values.
+      operationId: update-products-v2
+      x-ni-operation: updateProducts
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Array of products to update
+          required: true
+          schema:
+            description: Array of products to update
+            title: UpdateProductsRequest
+            required:
+              - products
+            properties:
+              products:
+                description: Array of products to update
+                type: array
+                items:
+                  $ref: '#/definitions/ProductUpdateRequestObject'
+              replace:
+                description: Replace the existing fields instead of merging them
+                type: boolean
+                default: false
+      responses:
+        200:
+          $ref: '#/responses/ProductsPartialSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/delete-products:
+    post:
+      tags: [products]
+      summary: Deletes products
+      description: Deletes multiple products in a single request.
+      operationId: delete-products-v2
+      x-ni-operation: deleteProducts
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Array of products
+          required: true
+          schema:
+            description: Array of products
+            title: DeleteProductsRequest
+            required:
+              - ids
+            properties:
+              ids:
+                description: Array of product ids to delete
+                type: array
+                items:
+                  type: string
+                  example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+      responses:
+        200:
+          $ref: '#/responses/DeleteProductsResponse'
+        204:
+          description: The resources were deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-results:
+    post:
+      tags: [results]
+      summary: Queries test results
+      description: >-
+        Uses the Dynamic Linq query language to specify filters for results.
+        Both result and product filters can be specified and matching test
+        results are returned. An empty request body queries all test results.
+      operationId: query-results-v2
+      x-ni-operation: queryResults
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query filter
+          required: false
+          schema:
+            $ref: '#/definitions/ResultsAdvancedQuery'
+      produces:
+        - application/json
+        - text/csv
+      responses:
+        200:
+          $ref: '#/responses/ResultsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/results:
+    get:
+      tags: [results]
+      summary: Gets test results
+      description: Gets a list of test results.
+      operationId: get-results-v2
+      x-ni-operation: getResults
+      x-ni-auth: true
+      parameters:
+        - in: query
+          name: continuationToken
+          description: >-
+            A token which allows the user to resume a query at the next item in
+            the matching result set. When querying for results, a token will
+            be returned if a query may be continued. To obtain the next page of
+            results, pass the token to the service on a subsequent request.
+          type: string
+        - in: query
+          name: take
+          description: >-
+            The maximum number of results to return.
+          type: integer
+          format: int32
+          default: 1000
+          minimum: -1
+        - in: query
+          name: returnCount
+          description: >-
+            Whether to return the total number of results,
+            disregarding the take value.
+          type: boolean
+          default: false
+      responses:
+        200:
+          $ref: '#/responses/ResultsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    post:
+      tags: [results]
+      summary: Creates new test results
+      description: Creates new test results from the supplied models. The server automatically generates the result ids. The server will populate the start time if one is not provided.
+      operationId: create-results-v2
+      x-ni-operation: createResults
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Result object
+          required: true
+          schema:
+            description: Array of test results to create
+            title: CreateTestResultsRequest
+            required:
+              - results
+            properties:
+              results:
+                description: Array of test results to create
+                type: array
+                items:
+                  $ref: '#/definitions/TestResultRequestObject'
+      responses:
+        200:
+          $ref: '#/responses/ResultsPartialSuccessResponse'
+        201:
+          $ref: '#/responses/ResultsSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/results/{resultId}:
+    get:
+      tags: [results]
+      summary: Gets a test result
+      description: Gets a single test result.
+      operationId: get-result-v2
+      x-ni-operation: getResults
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: resultId
+          description: The id of the result to get.
+          type: string
+          required: true
+      responses:
+        200:
+          description: Get Test Result Response
+          schema:
+            $ref: '#/definitions/TestResultResponseObject'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    delete:
+      tags: [results]
+      summary: Deletes a test result
+      description: Deletes the test result with the specified id. The request succeeds for result ids that do not exist.
+      operationId: delete-result-v2
+      x-ni-operation: deleteResult
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: resultId
+          description: Id of the test result to delete
+          type: string
+          required: true
+        - in: query
+          name: deleteSteps
+          description: Indicates whether to delete the test steps associated with the test result
+          type: boolean
+          default: true
+      responses:
+        204:
+          description: The resource was deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-result-values:
+    post:
+      tags: [results]
+      summary: Queries values for a result field
+      description: >-
+        Queries known values for an indexed, scalar result field. Supported
+        fields are `ID`, `STARTED_AT`, `UPDATED_AT`, `PROGRAM_NAME`,
+        `SYSTEM_ID`, `HOST_NAME`, `OPERATOR`, `SERIAL_NUMBER`, `PART_NUMBER`,
+        and `TOTAL_TIME_IN_SECONDS`.
+      operationId: query-result-values-v2
+      x-ni-operation: queryResults
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query parameters
+          required: true
+          schema:
+            $ref: '#/definitions/ResultValuesQuery'
+      responses:
+        200:
+          $ref: '#/responses/ValuesResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/update-results:
+    post:
+      tags: [results]
+      summary: Updates existing test results
+      description: Updates existing test results by merging or replacing values.
+      operationId: update-results-v2
+      x-ni-operation: updateResults
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Array of test results to update
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateTestResultsRequest'
+      responses:
+        200:
+          $ref: '#/responses/ResultsUpdatePartialSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/delete-results:
+    post:
+      tags: [results]
+      summary: Deletes test results
+      description: Deletes multiple test results in a single request.
+      operationId: delete-results-v2
+      x-ni-operation: deleteResults
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Array of test result ids
+          required: true
+          schema:
+            description: Array of test result ids
+            title: DeleteResultsRequest
+            required:
+              - ids
+            properties:
+              ids:
+                description: Array of test result ids to delete
+                type: array
+                items:
+                  type: string
+                  example: 02600cf8-c2bb-4ff9-a139-031e943fb0c0
+              deleteSteps:
+                description: Indicates whether to delete the test steps associated with the test result
+                type: boolean
+                default: true
+      responses:
+        200:
+          $ref: '#/responses/DeleteResultsResponse'
+        204:
+          description: The resources were deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-steps:
+    post:
+      tags: [steps]
+      summary: Queries test steps
+      description: >-
+        Uses the Dynamic Linq query language to specify filters for steps.
+        Both step and result filters can be specified and matching test
+        steps are returned. An empty request body queries all test steps.
+      operationId: query-steps-v2
+      x-ni-operation: querySteps
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query filter
+          required: false
+          schema:
+            $ref: '#/definitions/StepsAdvancedQuery'
+      produces:
+        - application/json
+        - text/csv
+      responses:
+        200:
+          $ref: '#/responses/StepsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/steps:
+    get:
+      tags: [steps]
+      summary: Gets test steps
+      description: Gets a list of test steps.
+      operationId: get-steps-v2
+      x-ni-operation: getSteps
+      x-ni-auth: true
+      parameters:
+        - in: query
+          name: continuationToken
+          description: >-
+            A token which allows the user to resume a query at the next item in
+            the matching step set. When querying for steps, a token will
+            be returned if a query may be continued. To obtain the next page of
+            steps, pass the token to the service on a subsequent request.
+          type: string
+        - in: query
+          name: take
+          description: >-
+            The maximum number of steps to return.
+          type: integer
+          format: int32
+          default: 1000
+          minimum: -1
+        - in: query
+          name: returnCount
+          description: >-
+            Whether to return the total number of results,
+            disregarding the take value.
+          type: boolean
+          default: false
+      responses:
+        200:
+          $ref: '#/responses/StepsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    post:
+      tags: [steps]
+      summary: Creates new test steps
+      description: Creates new test steps from the supplied models. The result associated with the step must exist prior to step creation. The server automatically generates step ids if not supplied.
+      operationId: create-steps-v2
+      x-ni-operation: createSteps
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Test step object
+          required: true
+          schema:
+            $ref: '#/definitions/TestStepCreateRequestObject'
+      responses:
+        200:
+          $ref: '#/responses/StepsPartialSuccessResponse'
+        201:
+          $ref: '#/responses/StepsSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/results/{resultId}/steps/{stepId}:
+    get:
+      tags: [steps]
+      summary: Gets a test step
+      description: Gets a single test step.
+      operationId: get-step-v2
+      x-ni-operation: getSteps
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: resultId
+          description: The resultId of the step to get.
+          type: string
+          required: true
+        - in: path
+          name: stepId
+          description: The stepId of the step to get.
+          type: string
+          required: true
+      responses:
+        200:
+          description: Get Test Step Response
+          schema:
+            $ref: '#/definitions/TestStepResponseObject'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+    delete:
+      tags: [steps]
+      summary: Deletes a test step
+      description: Deletes the test step with the specified id. The request succeeds for step ids that do not exist.
+      operationId: delete-step-v2
+      x-ni-operation: deleteStep
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: resultId
+          description: Id of the test result the step belongs to
+          type: string
+          required: true
+        - in: path
+          name: stepId
+          description: Id of the test step to delete
+          type: string
+          required: true
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times.
+          type: boolean
+          default: false
+      responses:
+        204:
+          description: The resource was deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-step-values:
+    post:
+      tags: [steps]
+      summary: Queries values for a step field
+      description: >-
+        Queries known values for an indexed, scalar step field. Supported
+        fields are `NAME`, `STEP_TYPE`, `STEP_ID`, `PARENT_ID`, `RESULT_ID`,
+        `PATH`, `TOTAL_TIME_IN_SECONDS`, `STARTED_AT`, `UPDATED_AT`, and
+        `DATA_MODEL`.
+      operationId: query-step-values-v2
+      x-ni-operation: querySteps
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query parameters
+          required: true
+          schema:
+            $ref: '#/definitions/StepValuesQuery'
+      responses:
+        200:
+          $ref: '#/responses/ValuesResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/update-steps:
+    post:
+      tags: [steps]
+      summary: Updates existing test steps
+      description: >-
+        Updates existing steps by merging or replacing values. Note that
+        changing a step's name is not recommended, as the step path does
+        not update to reflect the new name.
+      operationId: update-steps-v2
+      x-ni-operation: updateSteps
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Array of test steps
+          required: true
+          schema:
+            $ref: '#/definitions/TestStepUpdateRequestObject'
+      responses:
+        200:
+          $ref: '#/responses/StepsPartialSuccessResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/delete-steps:
+    post:
+      tags: [steps]
+      summary: Deletes test steps
+      description: Deletes multiple test steps in a single request.
+      operationId: delete-steps-v2
+      x-ni-operation: deleteSteps
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: requestBody
+          description: Delete steps request
+          required: true
+          schema:
+            $ref: '#/definitions/TestStepsDeleteRequest'
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times.
+          type: boolean
+          default: false
+      responses:
+        200:
+          $ref: '#/responses/StepsDeletePartialSuccessResponse'
+        204:
+          description: The resources were deleted successfully.
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/paths:
+    get:
+      tags: [paths]
+      summary: Gets paths
+      description: Gets a list of paths.
+      operationId: get-paths-v2
+      x-ni-operation: queryPaths
+      x-ni-auth: true
+      parameters:
+        - in: query
+          name: continuationToken
+          description: >-
+            A token which allows the user to resume a query at the next item in
+            the matching path set. When querying for paths, a token will
+            be returned if a query may be continued. To obtain the next page of
+            paths, pass the token to the service on a subsequent request.
+          type: string
+        - in: query
+          name: take
+          description: >-
+            The maximum number of paths to return.
+          type: integer
+          format: int32
+          default: 1000
+          minimum: -1
+        - in: query
+          name: returnCount
+          description: >-
+            Whether to return the total number of paths,
+            disregarding the take value.
+          type: boolean
+          default: false
+      responses:
+        200:
+          $ref: '#/responses/PathsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/paths/{pathId}:
+    get:
+      tags: [paths]
+      summary: Gets a path
+      description: Gets a single path.
+      operationId: get-path-v2
+      x-ni-operation: queryPaths
+      x-ni-auth: true
+      parameters:
+        - in: path
+          name: pathId
+          description: The ID of the path to get.
+          type: string
+          required: true
+      responses:
+        200:
+          description: Get Path Response
+          schema:
+            $ref: '#/definitions/PathResponseObject'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+  /v2/query-paths:
+    post:
+      tags: [paths]
+      summary: Queries paths
+      description: >-
+        Uses the Dynamic Linq query language to specify a filter and return
+        paths. An empty request body queries all paths.
+      operationId: query-paths-v2
+      x-ni-operation: queryPaths
+      x-ni-auth: true
+      parameters:
+        - in: body
+          name: postBody
+          description: Query filter
+          required: false
+          schema:
+            $ref: '#/definitions/PathsAdvancedQuery'
+      responses:
+        200:
+          $ref: '#/responses/PathsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,389 @@
+# slcli skills
+
+## Summary
+
+`slcli` is the SystemLink command-line interface for managing SystemLink
+resources. It provides authentication, configuration, workspace selection, CRUD
+operations across multiple services, and local-to-remote workflows (init, pack,
+publish, import/export).
+
+## Global usage
+
+- **Command shape:** `slcli [OPTIONS] COMMAND [ARGS]...`
+- **Global options:**
+  - `-v, --version` — Show version and exit
+  - `-p, --profile TEXT` — Use a specific profile for this command
+  - `-h, --help` — Show help
+- **Profiles:** Set up multiple environments and switch between them using
+  `slcli config` and `slcli login`.
+
+## Capabilities by command group
+
+### asset
+
+Manage SystemLink assets (hardware tracked by Asset Management service).
+
+- **Filtering**: Supports Asset API expression language (e.g.,
+  `ModelName.Contains("PXI")`, `BusType = "PCI_PXI"`)
+- **Operations**: create, delete, get, list, update
+- **calibration**: Get calibration history for a specific asset
+- **location-history**: Get location/connection history for a specific asset
+- **summary**: Show fleet-wide asset summary statistics
+
+### auth
+
+Manage authorization policies and policy templates.
+
+- **policy**: create, delete, diff, get, list, update
+- **template**: delete, get, list
+
+### completion
+
+Generate or install shell completion scripts.
+
+- Supports: bash, zsh, fish, powershell
+- Can install directly into shell config or output to a file
+
+### config
+
+Manage slcli configuration and profiles.
+
+- current-profile, list-profiles, use-profile
+- view configuration
+- delete-profile
+- migrate credentials from keyring
+
+### customfield
+
+Manage DFF (custom field) configurations.
+
+- init, create, update, delete
+- list, get, export
+- edit with a local web editor
+
+### example
+
+Provision or remove example resource configurations.
+
+- list, info
+- install (provision example resources)
+- delete (cleanup in reverse order)
+
+### feed
+
+Manage NI Package Manager feeds and their packages.
+
+- Supports Windows (.nipkg) and NI Linux RT (.ipk/.deb) platforms
+- **feed**: create, delete, get, list, replicate
+- **package**: upload, list, delete
+
+### file
+
+Manage files in SystemLink File Service.
+
+- upload, download, get, list, delete
+- update-metadata
+- query for files
+- watch a folder for auto-upload
+
+### info
+
+Show current configuration and detected platform.
+
+- output format: `table` or `json`
+
+### login / logout
+
+Manage credentials and profiles.
+
+- login: set profile, url, api key, web url, default workspace
+- logout: remove current or specific profile, or all profiles
+
+### notebook
+
+Manage notebooks locally and remotely, and run executions.
+
+- init: create a local notebook skeleton
+- manage: create, update, delete, list, get, download, set-interface
+- execute: start, sync, list, get, cancel, retry (SLE only)
+
+### system
+
+Manage SystemLink systems (registered with Systems Management service).
+
+- **Filtering**: Supports Systems Management filter language (e.g.,
+  `alias.Contains("PXI")`, `connected.data.state = "CONNECTED"`)
+- **Operations**: get, list, remove, update
+- **job**: Manage system jobs (cancel, get, list, summary)
+- **report**: Generate software or hardware reports for systems
+- **summary**: Show fleet-wide system summary
+
+### tag
+
+Manage SystemLink tags.
+
+- **Operations**: create, delete, get, list, update
+- **Value operations**: get-value, set-value
+- Supports filtering when listing tags
+
+### template
+
+Manage test plan templates.
+
+- init scaffold
+- import/export
+- list, get, delete
+
+### testmonitor
+
+Manage test monitor products and results.
+
+- **product**: get, list
+- **result**: get, list
+
+### user
+
+Manage SystemLink users and service accounts.
+
+- create, update, delete
+- get, list
+
+### webapp
+
+Manage web applications locally and remotely.
+
+- init scaffold
+- pack a folder into a .nipkg
+- publish a .nipkg or folder
+- list, get, open, delete
+
+### workflow
+
+Manage workflows.
+
+- init scaffold
+- import/export
+- update
+- list, get, delete
+- preview workflow file
+
+### workspace
+
+Manage workspaces.
+
+- list, get, disable
+
+## Common patterns
+
+### Profile-based targeting
+
+- Use `--profile` to run commands against a specific SystemLink environment.
+- Use `slcli config use-profile` to switch the active profile.
+
+### CRUD consistency
+
+Most resource groups expose a consistent shape:
+
+- **Create:** `create`
+- **Read:** `get`, `list`
+- **Update:** `update`
+- **Delete:** `delete`
+
+### Scaffold → import/publish
+
+Several groups support a local-first workflow:
+
+- **init** creates a local scaffold (workflow, template, webapp, notebook).
+- **import/publish/update** pushes local artifacts to SystemLink.
+- **export** pulls remote artifacts to local JSON files.
+
+### Execution vs. management
+
+For notebooks, resource management is separated from execution:
+
+- **manage**: CRUD and metadata/interface operations
+- **execute**: run, list, cancel, retry
+
+### Output formatting
+
+Where supported (e.g., `info`), use `--format json` for script-friendly output.
+
+### Filtering and querying
+
+Many list commands support both convenience filters and advanced filter
+expressions.
+
+#### Asset filtering (`slcli asset list`)
+
+**Convenience filters** (combine with `and`):
+
+- `--model TEXT` — Filter by model name (contains match)
+- `--serial-number TEXT` — Filter by serial number (exact match)
+- `--bus-type [BUILT_IN_SYSTEM|PCI_PXI|USB|GPIB|VXI|SERIAL|TCP_IP|CRIO]` —
+  Filter by bus type
+- `--asset-type [GENERIC|DEVICE_UNDER_TEST|FIXTURE|SYSTEM]` — Filter by asset
+  type
+- `--calibration-status [OK|APPROACHING_RECOMMENDED_DUE_DATE|PAST_RECOMMENDED_DUE_DATE|OUT_FOR_CALIBRATION]`
+- `--connected` — Show only assets in connected systems (CONNECTED + PRESENT)
+- `--calibratable` — Show only calibratable assets
+- `--workspace TEXT` — Filter by workspace name or ID
+
+**Advanced filter syntax** (use with `--filter`):
+
+- Property access: `ModelName`, `SerialNumber`, `BusType`
+- String operations: `.Contains("text")`, `= "exact"`
+- Logical operators: `and`, `or`
+- Examples:
+  - `ModelName.Contains("PXI") and BusType = "PCI_PXI"`
+  - `SerialNumber = "01BB877A"`
+  - `CalibrationStatus = "OK" and ModelName.Contains("407")`
+
+#### System filtering (`slcli system list`)
+
+**Convenience filters** (combine with `and`):
+
+- `--alias TEXT` — Filter by system alias (contains match)
+- `--state [CONNECTED|DISCONNECTED|VIRTUAL|APPROVED|...]` — Filter by connection
+  state
+- `--os TEXT` — Filter by OS (kernel contains match)
+- `--host TEXT` — Filter by hostname (contains match)
+- `--has-package TEXT` — Filter for systems with specified package installed
+  (contains match, client-side)
+- `--has-keyword TEXT` — Filter systems that have this keyword (repeatable)
+- `--property TEXT` — Filter by property key=value (repeatable)
+- `--workspace TEXT` — Filter by workspace name or ID
+
+**Advanced filter syntax** (use with `--filter`):
+
+- Nested property access: `connected.data.state`, `grains.data.kernel`
+- String operations: `.Contains("text")`, `= "exact"`
+- Logical operators: `and`, `or`
+- Examples:
+  - `connected.data.state = "CONNECTED" and grains.data.kernel = "Windows"`
+  - `alias.Contains("PXI")`
+  - `connected.data.state = "CONNECTED" and grains.data.os = "Windows 10"`
+
+#### Test Monitor filtering (`slcli testmonitor result list`, `slcli testmonitor product list`)
+
+**Result convenience filters**:
+
+- `--status TEXT` — Filter by status type (e.g., PASSED, FAILED)
+- `--program-name TEXT` — Filter by program name (contains)
+- `--serial-number TEXT` — Filter by serial number (contains)
+- `--part-number TEXT` — Filter by part number (contains)
+- `--operator TEXT` — Filter by operator name (contains)
+- `--host-name TEXT` — Filter by host name (contains)
+- `--system-id TEXT` — Filter by system ID
+- `--workspace TEXT` — Filter by workspace name or ID
+
+**Product convenience filters**:
+
+- `--name TEXT` — Filter by product name (contains)
+- `--part-number TEXT` — Filter by product part number (contains)
+- `--family TEXT` — Filter by product family (contains)
+- `--workspace TEXT` — Filter by workspace name or ID
+
+**Advanced filter syntax** (use with `--filter`):
+
+- Uses Dynamic LINQ filter expressions
+- Supports `--substitution TEXT` for parameterized queries (repeatable)
+- For results: `--product-filter TEXT` with `--product-substitution TEXT` to
+  filter by associated product properties
+- Examples:
+  - `status.statusType = "FAILED"`
+  - `partNumber.Contains("ABC") and programName = "TestProgram"`
+  - `startedAt > DateTime(2026, 1, 1)`
+
+#### Common filtering features
+
+- **Order by**: Most list commands support `--order-by` with field-specific
+  options
+- **Sort direction**: Use `--descending` or `--ascending` (default varies by
+  command)
+- **Pagination**: `--take INTEGER` controls items per page (table output only)
+- **Output format**: `-f, --format [table|json]` for structured output
+- **Summary mode**: Many commands support `--summary` for aggregate statistics
+- **Group by**: Test monitor results support `--group-by` for grouping summary
+  statistics
+
+## Example workflows
+
+### Multi-environment setup
+
+1. `slcli login --profile dev --url <dev-url> --api-key <key>`
+2. `slcli login --profile prod --url <prod-url> --api-key <key>`
+3. `slcli config use-profile dev`
+
+### Asset management
+
+- `slcli asset list --filter 'ModelName.Contains("PXI")'` — Find all PXI assets
+- `slcli asset list --model "4071" --connected` — Find connected DMM assets
+- `slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE` — Assets
+  needing calibration
+- `slcli asset list --filter 'BusType = "PCI_PXI" and CalibrationStatus = "OK"'`
+  — PXI assets with valid calibration
+- `slcli asset calibration <asset-id>` — View calibration history
+- `slcli asset location-history <asset-id>` — Track where an asset has been
+- `slcli asset summary` — Get fleet-wide statistics
+
+### System management
+
+- `slcli system list --state CONNECTED` — List connected systems
+- `slcli system list --filter 'connected.data.state = "CONNECTED" and grains.data.kernel = "Windows"'`
+  — Connected Windows systems
+- `slcli system list --has-package "DAQmx"` — Systems with DAQmx installed
+- `slcli system list --alias "PXI" --os "Windows 10"` — Windows 10 PXI systems
+- `slcli system get <system-id>` — View detailed system information
+- `slcli system job list` — View all system jobs
+- `slcli system report --type SOFTWARE --output report.csv` — Generate software
+  inventory report
+- `slcli system summary` — Show fleet-wide system statistics
+
+### Test result analysis
+
+- `slcli testmonitor result list --status FAILED --part-number "ABC123"` —
+  Failed tests for specific part
+- `slcli testmonitor result list --filter 'status.statusType = "FAILED" and startedAt > DateTime(2026, 1, 1)'`
+  — Recent failures
+- `slcli testmonitor result list --program-name "Overvoltage" --serial-number "1234567"`
+  — Specific test on specific DUT
+- `slcli testmonitor result list --summary --group-by status` — Summary
+  statistics by status
+- `slcli testmonitor result get <result-id>` — Get detailed result information
+- `slcli testmonitor product list --family "Sensors"` — List products in a
+  family
+- `slcli testmonitor product list --part-number "ABC" --summary` — Product
+  summary statistics
+- `slcli testmonitor product get <product-id>` — Get product details
+
+### Tag operations
+
+- `slcli tag list` — List all tags
+- `slcli tag get-value <tag-path>` — Read current tag value
+- `slcli tag set-value <tag-path> <value>` — Write a value to a tag
+- `slcli tag create --path <path> --data-type <type>` — Create a new tag
+
+### Template and workflow lifecycle
+
+- `slcli template init` → edit JSON → `slcli template import`
+- `slcli workflow init` → edit JSON → `slcli workflow import`
+- `slcli workflow preview` for validation before update
+
+### Notebook execution
+
+- `slcli notebook manage create ...`
+- `slcli notebook execute start ...` or `slcli notebook execute sync ...`
+- `slcli notebook execute list/get/cancel` to manage runs
+
+### Web app deployment
+
+- `slcli webapp init` → edit `index.html`
+- `slcli webapp pack` → `slcli webapp publish`
+
+### Feed and package management
+
+- `slcli feed list` — List all feeds
+- `slcli feed create --name <name>` — Create a new feed
+- `slcli feed package upload --feed-id <id> --file <package.nipkg>` — Upload
+  package to feed
+- `slcli feed replicate --url <external-url>` — Replicate from external source

--- a/docs/slcli-workflow-analysis.md
+++ b/docs/slcli-workflow-analysis.md
@@ -1,0 +1,890 @@
+# slcli Workflow Analysis for AI-Assisted Queries
+
+## Executive Summary
+
+This document analyzes selected workflows from the workflow examples spreadsheet to identify the multi-step processes, data requirements, and new slcli commands needed to enable Copilot to successfully answer complex SystemLink queries. The analysis focuses on high-priority workflows that require cross-service data correlation and proposes new slcli features to support them.
+
+## Analyzed Workflows
+
+### 1. Test Results: "Show me all failed measurements on product XYZ for the last two quarters"
+
+**Priority:** High | **Complexity:** Medium | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Parse temporal range** - Convert "last two quarters" to date range
+2. **Query test results** - Filter by:
+   - Part number/product name (fuzzy match if needed)
+   - Status = FAILED
+   - Date range
+3. **Aggregate measurements** - Group by test program, step, measurement
+4. **Summarize findings** - Count failures by category
+5. **Navigate if requested** - Filter UI grid or export data
+
+#### Data Required
+
+- **From Test Monitor Service:**
+  - Results with `partNumber`, `status`, `startedAt`, `programName`
+  - Steps with `status`, `name`, `path`, `resultId`
+  - Measurements from step outputs/data
+  - Count of matching results
+
+- **From Product/Spec Service (optional):**
+  - Validate product name, get alternate names/part numbers
+
+#### API Calls Sequence
+
+```bash
+# Step 1: Query for failed results in date range
+slcli testresult query \
+  --filter 'partNumber contains "XYZ" and status.statusType = "FAILED"' \
+  --started-after "2025-08-01" \
+  --started-before "2026-01-31" \
+  --projection "id,partNumber,programName,startedAt,status" \
+  --take 1000
+
+# Step 2: For each result, get failed steps/measurements
+slcli teststep query \
+  --filter 'resultId in ["id1","id2",...] and status.statusType = "FAILED"' \
+  --projection "name,path,resultId,outputs,data"
+
+# Step 3: Get measurement paths for product (to understand structure)
+slcli testpath query \
+  --filter 'partNumber = "XYZ"' \
+  --projection "programName,path,pathNames,outputs,measurements"
+```
+
+#### Proposed New slcli Commands
+
+```bash
+# High-level result analysis command
+slcli testresult analyze \
+  --product "XYZ" \
+  --status failed \
+  --since "2 quarters ago" \
+  --group-by measurement \
+  --output summary
+
+# Simplified measurement query
+slcli testmeasurement query \
+  --product "XYZ" \
+  --status failed \
+  --since "2025-08-01" \
+  --until "2026-01-31" \
+  --format json
+
+# Combined result + step query with aggregation
+slcli testresult query-with-steps \
+  --filter 'partNumber = "XYZ" and status = "FAILED"' \
+  --date-range "2025-08-01:2026-01-31" \
+  --include-steps \
+  --aggregate-by "path,measurement"
+```
+
+---
+
+### 2. Test Results: "What was the SN of the PXI-4071 used to measure DUT SN 1234567?"
+
+**Priority:** High | **Complexity:** Hard | **Target:** (future)
+
+#### Multi-Step Analysis Process
+
+1. **Query test results by DUT serial number**
+2. **Get system ID from result** (systemId field)
+3. **Query systems service** for system details at test time
+4. **Query assets service** for assets in that system
+5. **Filter assets** by model "PXI-4071"
+6. **Cross-reference with test date** using asset location history
+7. **Return asset serial number**
+
+#### Data Required
+
+- **From Test Monitor Service:**
+  - Result with `serialNumber = "1234567"`, `systemId`, `startedAt`
+
+- **From Systems Management Service:**
+  - System with `id = systemId`, minion details
+
+- **From Asset Service:**
+  - Assets with `minionId` = system minion
+  - Asset model = "PXI-4071"
+  - Asset `locationHistory` overlapping with test date
+  - Asset serial number
+
+#### API Call Sequence
+
+```bash
+# Step 1: Find test result(s)
+slcli testresult query \
+  --filter 'serialNumber = "1234567"' \
+  --projection "id,systemId,startedAt"
+
+# Step 2: Get system information
+slcli system get <systemId> \
+  --projection "id,alias,hostname,workspaceId"
+
+# Step 3: Get assets on that system at test time
+slcli asset query \
+  --filter 'location.minionId = "<minion-id>" and model contains "PXI-4071"' \
+  --projection "id,serialNumber,model,location"
+
+# Step 4: Verify asset was there during test (location history)
+slcli asset location-history <asset-id> \
+  --from "<test-date-minus-buffer>" \
+  --to "<test-date-plus-buffer>"
+```
+
+#### Complexity Notes
+
+This is **Hard** because:
+- Requires cross-service correlation (Test → System → Asset)
+- Needs temporal correlation (asset must be at location during test)
+- Location history API may not exist or be performant
+- Asset move events may not be tracked historically if asset was removed
+
+#### Proposed New slcli Commands
+
+```bash
+# High-level asset correlation command
+slcli testresult get-assets <result-id> \
+  --filter 'model contains "PXI-4071"' \
+  --output json
+
+# Direct query with cross-service join
+slcli asset query-for-test \
+  --serial-number "1234567" \
+  --model "PXI-4071" \
+  --output table
+
+# System snapshot at time
+slcli system get-snapshot <system-id> \
+  --at-time "2025-12-01T10:30:00Z" \
+  --include assets
+
+# Unified correlation command
+slcli testresult correlate \
+  --serial-number "1234567" \
+  --show assets,system,conditions
+```
+
+---
+
+### 3. Data Spaces: "Remove the selected data points"
+
+**Priority:** High | **Complexity:** Low | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Get current data space context** - ID of active data space
+2. **Get selected data point IDs** from UI selection
+3. **Set keyword on data points** - Mark as hidden/removed
+4. **Update data space configuration** - Exclude marked points
+5. **Check for analytics** - Prompt user about updating analytics
+
+#### Data Required
+
+- **From Data Frame Service:**
+  - Data space ID
+  - Selected data point IDs or filter criteria
+  - Current data space configuration
+  - List of analytics using this data space
+
+- **From UI Context:**
+  - Active data space
+  - Selected rows/points (could be lasso selection or grid selection)
+
+#### API Call Sequence
+
+```bash
+# Step 1: Get data space details
+slcli dataspace get <dataspace-id> \
+  --include-config
+
+# Step 2: Mark data points with keyword
+slcli dataframe update-points <dataframe-id> \
+  --point-ids "id1,id2,id3" \
+  --set-keyword "hidden" \
+  --reason "outlier-removed"
+
+# Step 3: Update data space filter
+slcli dataspace update <dataspace-id> \
+  --exclude-keyword "hidden"
+
+# Step 4: List affected analytics
+slcli analytics list \
+  --using-dataspace <dataspace-id>
+```
+
+#### Proposed New slcli Commands
+
+```bash
+# High-level data point management
+slcli dataspace remove-points <dataspace-id> \
+  --point-ids "id1,id2,id3" \
+  --check-analytics \
+  --confirm
+
+# Bulk point operations
+slcli dataframe set-keyword <dataframe-id> \
+  --point-ids "id1,id2,id3" \
+  --keyword "removed" \
+  --value "true"
+
+# Interactive point management
+slcli dataspace manage-points <dataspace-id> \
+  --interactive
+```
+
+---
+
+### 4. Assets: "Find me a system that has a DMM and a scope"
+
+**Priority:** High | **Complexity:** Medium | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Query assets for DMMs** - Filter by model/capabilities
+2. **Query assets for scopes** - Filter by model/capabilities
+3. **Find common minion IDs** - Intersection of asset locations
+4. **Query systems** by minion IDs
+5. **Return available systems**
+
+#### Data Required
+
+- **From Asset Service:**
+  - Assets where `model contains "DMM"` or busType/assetType indicates DMM
+  - Assets where `model contains "scope"` or model matches known scope patterns
+  - Asset `location.minionId` for each
+  - Asset availability status
+
+- **From Systems Management Service:**
+  - Systems where `id` in minion IDs
+  - System state (connected, available)
+
+#### API Call Sequence
+
+```bash
+# Step 1: Find DMMs
+slcli asset query \
+  --filter 'model contains "DMM" or model contains "407"' \
+  --projection "id,model,location.minionId" \
+  --take 500
+
+# Step 2: Find scopes
+slcli asset query \
+  --filter 'model contains "scope" or model contains "5"' \
+  --projection "id,model,location.minionId" \
+  --take 500
+
+# Step 3: Get systems by minion IDs (intersection)
+slcli system list \
+  --filter 'id in ["minion1","minion2"]' \
+  --projection "id,alias,state"
+```
+
+#### Complexity Notes
+
+This is **Medium** because:
+- Requires correlating assets across different searches
+- Model name matching can be fuzzy (DMM vs 4071 vs PXI-4071)
+- Need to compute intersection client-side
+- Assets may not have semantic "capabilities" field
+
+#### Proposed New slcli Commands
+
+```bash
+# High-level system search by capability
+slcli system find \
+  --has-asset "DMM" \
+  --has-asset "scope" \
+  --available \
+  --output table
+
+# Asset-driven system query
+slcli system query-by-assets \
+  --requires "DMM,scope" \
+  --match-all \
+  --show-asset-details
+
+# Capability-based search
+slcli asset find-systems \
+  --with-capabilities "voltage-measurement,waveform-acquisition" \
+  --output json
+
+# Combined availability check
+slcli system find \
+  --has-instrument "DMM" \
+  --has-instrument "scope" \
+  --available-after "2026-02-10" \
+  --available-until "2026-03-10"
+```
+
+---
+
+### 5. Systems: "Find me a system with package X installed"
+
+**Priority:** High | **Complexity:** Hard | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Determine package name** - Exact or fuzzy match
+2. **Query systems** - Get all systems (potentially large)
+3. **For each system, get software packages** - May require per-system API call
+4. **Filter by package name** - Check installed packages
+5. **Return matching systems**
+
+#### Data Required
+
+- **From Systems Management Service:**
+  - System IDs and metadata
+  - System `packages` or `grains.packages` information
+  - Package names and versions installed on each system
+
+#### Current API Limitations
+
+- No single query to filter systems by installed package
+- May require:
+  - Fetching all systems, then fetching packages for each (N+1 query problem)
+  - OR new aggregated query API
+  - OR CDC/search index on packages
+
+#### API Call Sequence (Current State)
+
+```bash
+# Step 1: Get all systems
+slcli system list \
+  --projection "id,alias,workspaceId" \
+  --take 5000
+
+# Step 2: For each system, check packages (expensive!)
+for system_id in $(slcli system list --format json | jq -r '.[].id'); do
+  slcli system get $system_id --projection "packages" \
+    | jq -r '.packages | keys | .[] | select(contains("PackageX"))'
+done
+```
+
+#### Complexity Notes
+
+This is **Hard** because:
+- Performant implementation requires new query API or index
+- Package data may be nested in `grains` and not directly queryable
+- Large number of systems × packages = expensive operation
+- Would benefit from Elasticsearch/CDC index on package data
+
+#### Proposed New APIs & slcli Commands
+
+**New API Requirements:**
+- `GET /nisysmgmt/v1/systems/search` with package filter support
+- OR `POST /nisysmgmt/v1/systems/query` with packages in projection
+- OR new endpoint: `GET /nisysmgmt/v1/systems-by-software?packageName=X`
+
+**New slcli Commands:**
+
+```bash
+# High-level system search by software
+slcli system find \
+  --with-package "DAQmx" \
+  --version ">= 22.0" \
+  --output table
+
+# Software-specific query
+slcli system query-by-software \
+  --package-name "DAQmx" \
+  --output json
+
+# List systems with software
+slcli software find-systems \
+  --package "PackageX" \
+  --include-version
+
+# Fuzzy package search
+slcli system find \
+  --with-package-matching "daq.*" \
+  --regex
+```
+
+---
+
+### 6. Test Results: "Show me what type of test data exists for [Part Number]"
+
+**Priority:** High | **Complexity:** Low | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Query paths API** for part number
+2. **Get unique program names and paths**
+3. **Summarize measurement types**
+4. **Return structured summary**
+
+#### Data Required
+
+- **From Test Monitor Service (Paths API):**
+  - Paths where `partNumber = "<part-number>"`
+  - Fields: `programName`, `path`, `pathNames`, `measurements`, `outputs`
+
+#### API Call Sequence
+
+```bash
+# Step 1: Query paths for product
+slcli testpath query \
+  --filter 'partNumber = "ABC123"' \
+  --projection "programName,path,pathNames,measurements,outputs" \
+  --format json
+
+# Step 2: Summarize (client-side or server-side aggregation)
+# Group by programName, collect unique paths
+```
+
+#### Proposed New slcli Commands
+
+```bash
+# Direct summary command
+slcli testpath summary \
+  --part-number "ABC123" \
+  --output table
+
+# Product test coverage
+slcli testresult describe-product \
+  --part-number "ABC123" \
+  --show tests,measurements,programs
+
+# Structured metadata query
+slcli testmetadata get \
+  --part-number "ABC123" \
+  --format json
+```
+
+---
+
+### 7. Alarms: "Recommend a solution for this alarm"
+
+**Priority:** High | **Complexity:** Low | **Target:** Oct-26
+
+#### Multi-Step Analysis Process
+
+1. **Get alarm details** - ID, type, severity, tag, message
+2. **Use LLM knowledge** - SystemLink alarm patterns (PXI overheating, disk space, etc.)
+3. **Optionally search ni.com** or docs
+4. **Return recommendation**
+
+#### Data Required
+
+- **From Alarm Service:**
+  - Alarm `instanceId`, `alarmId`, `message`, `tagPath`
+  - Alarm metadata and recent history
+  - Related system information
+
+- **From Tag Service (optional):**
+  - Tag value and history
+
+#### API Call Sequence
+
+```bash
+# Step 1: Get alarm details
+slcli alarm get <instance-id> \
+  --format json
+
+# Step 2: Get related tag info (if applicable)
+slcli tag get "<tag-path>" \
+  --include-value
+```
+
+#### Notes
+
+This is **Low** complexity because:
+- Primarily relies on LLM's existing knowledge
+- Alarm data is already contextual
+- May benefit from page context in UI
+- No complex cross-service correlation needed
+
+#### Proposed New slcli Commands
+
+```bash
+# Alarm troubleshooting helper
+slcli alarm diagnose <instance-id> \
+  --output markdown
+
+# Get alarm with context
+slcli alarm get <instance-id> \
+  --include tag,system,history \
+  --format json
+```
+
+---
+
+## Proposed New slcli Command Groups
+
+### 1. `slcli testresult` enhancements
+
+```bash
+# Existing: query, get, list, create, update, delete
+# New:
+slcli testresult analyze <options>    # High-level analytics
+slcli testresult get-assets <id>      # Get assets used in test
+slcli testresult correlate <options>  # Cross-service correlation
+slcli testresult query-with-steps     # Combined result+step query
+slcli testresult describe-product     # Product test summary
+```
+
+### 2. `slcli teststep` (new)
+
+```bash
+slcli teststep query <options>        # Query steps with filters
+slcli teststep get <id>               # Get step details
+slcli teststep list                   # List steps for result
+```
+
+### 3. `slcli testpath` (new)
+
+```bash
+slcli testpath query <options>        # Query paths
+slcli testpath summary <options>      # Summarize test coverage
+slcli testpath get <id>               # Get path details
+```
+
+### 4. `slcli testmeasurement` (new)
+
+```bash
+slcli testmeasurement query <options> # Query measurements
+slcli testmeasurement analyze         # Analyze measurement trends
+```
+
+### 5. `slcli system` enhancements
+
+```bash
+# Existing: list, get, disable
+# New:
+slcli system find <options>           # Find systems by criteria
+slcli system get-snapshot <id>        # System state at point in time
+slcli system query-by-assets          # Find by asset requirements
+slcli system query-by-software        # Find by installed software
+```
+
+### 6. `slcli asset` enhancements
+
+```bash
+# Existing: get, list, query, create, update, delete
+# New:
+slcli asset query-for-test <id>       # Assets used in specific test
+slcli asset find-systems <options>    # Systems with specific assets
+slcli asset location-history <id>     # Location history over time
+slcli asset capability-search         # Search by capabilities
+```
+
+### 7. `slcli dataspace` (new)
+
+```bash
+slcli dataspace get <id>              # Get data space details
+slcli dataspace list                  # List data spaces
+slcli dataspace remove-points         # Remove/hide data points
+slcli dataspace update <id>           # Update configuration
+slcli dataspace manage-points         # Interactive point management
+```
+
+### 8. `slcli dataframe` (new)
+
+```bash
+slcli dataframe get <id>              # Get dataframe details
+slcli dataframe query <options>       # Query data points
+slcli dataframe set-keyword           # Set keywords on points
+slcli dataframe update-points         # Update data point metadata
+```
+
+### 9. `slcli alarm` enhancements
+
+```bash
+# Existing: (may not exist yet)
+# New:
+slcli alarm get <id>                  # Get alarm with context
+slcli alarm list                      # List alarms with filters
+slcli alarm query                     # Query alarms
+slcli alarm diagnose <id>             # Get troubleshooting recommendations
+slcli alarm history <id>              # Get alarm history
+```
+
+---
+
+## API Gaps and Requirements
+
+### Critical Gaps for High-Priority Workflows
+
+1. **Test Monitor Service:**
+   - ✅ Results query exists
+   - ✅ Steps query exists
+   - ✅ Paths query exists
+   - ❌ **Missing:** Combined result+steps+measurements query (single call)
+   - ❌ **Missing:** Aggregation/grouping support in query API
+   - ❌ **Missing:** Statistical summary endpoints
+
+2. **Systems Management Service:**
+   - ✅ Systems list/get exists
+   - ✅ Systems query/search exists
+   - ❌ **Missing:** Filter by installed packages in query
+   - ❌ **Missing:** System snapshot at historical time
+   - ❌ **Missing:** Bulk package information across systems
+
+3. **Asset Service:**
+   - ✅ Assets query exists
+   - ✅ Assets by minion/location exists
+   - ❌ **Missing:** Asset location history API
+   - ❌ **Missing:** Asset-to-test correlation endpoint
+   - ❌ **Missing:** Capability-based search
+   - ⚠️ **Limited:** Fuzzy model name matching
+
+4. **Data Frame Service:**
+   - ❓ **Unknown:** Current API capabilities
+   - ❌ **Likely Missing:** Bulk point keyword updates
+   - ❌ **Likely Missing:** Point filtering/hiding API
+   - ❌ **Missing:** Data space configuration management
+
+5. **Alarm Service:**
+   - ⚠️ **May exist:** Basic CRUD for alarms
+   - ❌ **Missing:** Alarm query with filters
+   - ❌ **Missing:** Alarm diagnostics/context enrichment
+
+### Performance Requirements
+
+1. **Pagination:** All query commands must support `--skip` and `--take`
+2. **Streaming:** Large result sets should support streaming/cursors
+3. **Aggregation:** Server-side aggregation preferred over client-side
+4. **Caching:** Consider caching for metadata queries (paths, products)
+
+---
+
+## Implementation Recommendations
+
+### Phase 1: Oct-26 Target (Low Complexity, High Priority)
+
+1. **Test Results Basic Queries:**
+   - `slcli testresult query` with comprehensive filters
+   - `slcli testpath summary` for product test coverage
+   - `slcli teststep query` for step-level analysis
+
+2. **Asset/System Discovery:**
+   - `slcli system find --has-asset` (basic implementation using client-side join)
+   - `slcli asset query` with enhanced filters
+
+3. **Data Space Management:**
+   - `slcli dataspace remove-points` (basic keyword-based hiding)
+   - `slcli dataframe set-keyword` for bulk operations
+
+4. **Alarm Context:**
+   - `slcli alarm get` with rich context
+   - `slcli alarm list` with filters
+
+### Phase 2: Future (Medium-Hard Complexity)
+
+1. **Cross-Service Correlation:**
+   - `slcli testresult get-assets` (requires new API or complex orchestration)
+   - `slcli asset query-for-test` (reverse lookup)
+
+2. **Historical State:**
+   - `slcli system get-snapshot --at-time` (requires historical data)
+   - `slcli asset location-history` (requires history tracking)
+
+3. **Advanced Search:**
+   - `slcli system query-by-software` (requires CDC/Elasticsearch index)
+   - `slcli asset capability-search` (requires capability metadata)
+
+### Phase 3: Advanced Analytics
+
+1. **Statistical Analysis:**
+   - `slcli testresult analyze` with grouping/aggregation
+   - `slcli testmeasurement analyze` for trends
+   - Built-in math/stats capabilities
+
+2. **Unified Queries:**
+   - `slcli query` command group for cross-service queries
+   - Graph-based querying (follow relationships)
+
+---
+
+## Design Patterns for slcli Commands
+
+### 1. Consistent Filtering
+
+All query commands should support:
+- `--filter` - SystemLink filter expression
+- `--format` - json, table, csv
+- `--projection` - Select specific fields
+- `--skip` / `--take` - Pagination
+- `--order-by` - Sorting
+
+Example:
+```bash
+slcli testresult query \
+  --filter 'partNumber = "ABC" and status.statusType = "FAILED"' \
+  --projection "id,startedAt,operator,systemId" \
+  --order-by "startedAt desc" \
+  --take 100 \
+  --format json
+```
+
+### 2. Context-Aware Commands
+
+Commands should infer context when possible:
+- Current workspace from profile
+- Current data space from UI context
+- Recent result IDs from command history
+
+Example:
+```bash
+# Use current data space from context
+slcli dataspace remove-points --selection "current"
+
+# Use last queried result
+slcli testresult get-assets --result "last"
+```
+
+### 3. Composition and Piping
+
+Enable Unix-style composition:
+```bash
+# Find systems, then get their assets
+slcli system find --has-asset "DMM" --format json \
+  | jq -r '.[].id' \
+  | xargs -I {} slcli asset query --filter 'location.minionId = "{}"'
+
+# Query results, extract IDs, get steps
+slcli testresult query --filter 'status.statusType = "FAILED"' --format json \
+  | jq -r '.[].id' \
+  | slcli teststep query --result-ids -
+```
+
+### 4. Smart Defaults
+
+- Default to current workspace
+- Default date ranges (e.g., "last week", "yesterday")
+- Default to interactive mode when ambiguous
+- Default output format based on terminal (table) vs pipe (json)
+
+### 5. Fuzzy Matching
+
+Support fuzzy matching where appropriate:
+- Product names: "XYZ" matches "Product-XYZ-Rev2"
+- Asset models: "DMM" matches "PXI-4071", "NI-4065"
+- Package names: "daq" matches "NI-DAQmx"
+
+Use `--exact` flag to disable fuzzy matching.
+
+---
+
+## Copilot Integration Strategy
+
+### Tool Design Principles
+
+1. **Atomic Operations:** Each slcli command does one thing well
+2. **Composable:** Commands can be chained/piped
+3. **Informative Output:** JSON output includes metadata for reasoning
+4. **Error Handling:** Clear error messages with suggestions
+5. **Dry Run:** Support `--dry-run` to show what would happen
+
+### Context Passing
+
+Copilot should maintain context across tool calls:
+- Store result IDs, system IDs from previous queries
+- Remember current workspace, profile
+- Track data spaces, products being analyzed
+
+### Multi-Step Workflows
+
+For hard queries, Copilot should:
+1. Break query into steps
+2. Execute each step with slcli
+3. Correlate results client-side when needed
+4. Summarize findings in natural language
+
+Example workflow for "asset used in test":
+```python
+# Copilot reasoning:
+# 1. Get test result by SN
+result = slcli_testresult_query(filter='serialNumber = "1234567"')
+result_id = result[0]['id']
+system_id = result[0]['systemId']
+test_date = result[0]['startedAt']
+
+# 2. Get system details
+system = slcli_system_get(system_id)
+minion_id = system['id']
+
+# 3. Get assets on system
+assets = slcli_asset_query(filter=f'location.minionId = "{minion_id}" and model contains "PXI-4071"')
+
+# 4. Verify asset was there at test time (if history API exists)
+for asset in assets:
+    history = slcli_asset_location_history(asset['id'], from=test_date_minus_day, to=test_date_plus_day)
+    if overlaps(history, test_date):
+        return asset['serialNumber']
+```
+
+---
+
+## Appendix: OpenAPI Service Coverage
+
+### Available Services (from attached docs)
+
+1. **nitestmonitor** - Test Monitor Service (v2)
+   - Results, Steps, Products, Paths
+   - Query, Get, Create, Update, Delete operations
+   - Filter, projection, pagination support
+
+2. **nisysmgmt** - Systems Management Service
+   - Systems (minions), packages, grains
+   - Query, get, update operations
+   - Limited package querying
+
+3. **nialarm** - Alarm Service
+   - Alarm instances, definitions
+   - Query, get, acknowledge, clear operations
+
+4. **nidataframe** - Data Frame Service
+   - Data frames (likely data spaces)
+   - Needs further investigation of capabilities
+
+5. **nifile** - File Service
+   - File upload, download, metadata
+   - May be used for test data files
+
+6. **ninotebook** - Notebook Service
+   - Notebook execution
+   - Could be used for analysis workflows
+
+7. **niasset** (inferred from code search)
+   - Asset query, create, update
+   - Utilization, calibration
+   - Location management
+
+### Service Gaps
+
+- **No unified query service** for cross-service joins
+- **No graph query API** for relationship traversal
+- **Limited aggregation** across services
+- **No standardized "correlate" endpoints**
+
+---
+
+## Conclusion
+
+Enabling Copilot to answer complex SystemLink queries requires:
+
+1. **New slcli command groups:** testresult, teststep, testpath, testmeasurement, dataspace, dataframe, enhanced system/asset/alarm commands
+
+2. **New API capabilities:**
+   - Cross-service correlation endpoints
+   - Historical state/snapshot APIs
+   - Software/package filtering in systems queries
+   - Asset location history
+   - Data space point management
+
+3. **Implementation phases:**
+   - **Phase 1 (Oct-26):** Low-complexity commands using existing APIs + client-side correlation
+   - **Phase 2 (Future):** Medium-complexity with new APIs for common patterns
+   - **Phase 3 (Advanced):** Hard queries with graph traversal and analytics
+
+4. **Design patterns:**
+   - Consistent filtering, pagination, output formats
+   - Context-aware defaults
+   - Composable/pipeable commands
+   - Fuzzy matching where appropriate
+
+The analysis shows that many high-priority, low-complexity workflows can be implemented immediately with existing APIs, while harder workflows requiring cross-service correlation will need new APIs or client-side orchestration in Copilot's reasoning layer.

--- a/docs/system-command-proposal.md
+++ b/docs/system-command-proposal.md
@@ -1,0 +1,1016 @@
+# System Command Proposal: Analysis & Recommendations
+
+**Date:** February 10, 2026
+**Context:** Review of slcli-workflow-analysis.md against nisysmgmt OpenAPI spec, following slcli best practices
+
+---
+
+## Executive Summary
+
+The workflow analysis proposes several granular system commands (`system find`, `system get-snapshot`, `system query-by-assets`, `system query-by-software`) that split functionality across too many specialized verbs. This doesn't align with:
+
+1. The nisysmgmt v1 REST API structure
+2. Established slcli command patterns (single `list`/`get` verbs with rich filtering)
+3. Actual user mental models
+
+**Recommendation:** Create a `slcli system` command group with standard `list`, `get`, `summary`, `update`, and `remove` commands — enhanced with targeted flags for the specific workflow requirements (package search, job management).
+
+---
+
+## API Assessment
+
+### Available Endpoints (nisysmgmt v1)
+
+#### System Endpoints
+
+- ✅ `GET /nisysmgmt/v1/systems?id=<id>` — Get system(s) by ID
+- ✅ `POST /nisysmgmt/v1/query-systems` — Query systems with filter/projection/orderBy/skip/take
+- ✅ `GET /nisysmgmt/v1/get-systems-summary` — Connected/disconnected/virtual counts
+- ✅ `GET /nisysmgmt/v1/get-pending-systems-summary` — Pending approval count
+- ✅ `POST /nisysmgmt/v1/update-systems` — Batch update system metadata
+- ✅ `PATCH /nisysmgmt/v1/systems/managed/{id}` — Update single system
+- ✅ `POST /nisysmgmt/v1/remove-systems` — Remove/unregister systems
+- ✅ `POST /nisysmgmt/v1/generate-systems-report` — Generate SOFTWARE/HARDWARE report
+
+#### Virtual System Endpoints
+
+- ✅ `POST /nisysmgmt/v1/virtual` — Create virtual system
+- ✅ `POST /nisysmgmt/v1/virtual/generate-system-apikey` — Generate API key for virtual system
+
+#### Job Endpoints
+
+- ✅ `GET /nisysmgmt/v1/jobs` — Get jobs (by systemId, jid, state, function)
+- ✅ `POST /nisysmgmt/v1/query-jobs` — Query jobs with filter/projection/orderBy/skip/take
+- ✅ `POST /nisysmgmt/v1/jobs` — Create job (run salt function on target systems)
+- ✅ `POST /nisysmgmt/v1/cancel-jobs` — Cancel jobs
+- ✅ `GET /nisysmgmt/v1/get-jobs-summary` — Active/failed/succeeded counts
+
+#### Key Management Endpoints
+
+- ✅ `GET /nisysmgmt/v1/get-systems-keys` — Get all system keys (pending/denied/approved/rejected)
+- ✅ `POST /nisysmgmt/v1/get-systems-keys` — Get keys for specific system IDs
+- ✅ `POST /nisysmgmt/v1/manage-systems-keys` — Accept/reject/delete keys
+
+### System Data Model
+
+From the API example response, a system object contains:
+
+```json
+{
+  "id": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+  "alias": "MySystem",
+  "scanCode": "e20aadfb-91fe-4596-97e8-e8cb67ff786a",
+  "createdTimestamp": "2026-02-10T20:37:48Z",
+  "lastUpdatedTimestamp": "2026-02-10T20:37:48Z",
+  "connected": {
+    "data": { "state": "CONNECTED" }
+  },
+  "grains": {
+    "data": {
+      "kernel": "Windows",
+      "osversion": "10.0.19042.928",
+      "osmanufacturer": "Microsoft Corporation",
+      "host": "MyComputer",
+      "cpuarch": "AMD64",
+      "deviceclass": "Desktop"
+    }
+  },
+  "status": {
+    "data": { "http_connected": true }
+  },
+  "packages": {
+    "data": {
+      "ni-daqmx": {
+        "arch": "windows_x64",
+        "displayname": "NI-DAQmx",
+        "displayversion": "2023 Q1",
+        "version": "23.0.0.49253-0+f101",
+        "group": "Infrastructure"
+      }
+    }
+  },
+  "feeds": {
+    "data": { ... }
+  },
+  "keywords": {
+    "data": ["Running", "InUse"]
+  },
+  "properties": {
+    "data": {
+      "RunningTestsVersion": "3.9.2",
+      "TestStandVersion": "2020"
+    }
+  },
+  "workspace": "6b70e1df-ae93-4ded-9fe0-dc775732289b",
+  "orgId": "e740733d-da55-4031-b32f-fb7cd8961810",
+  "removed": false
+}
+```
+
+### Filter Syntax (QuerySystemsRequest)
+
+The query-systems API uses the same filter syntax as the asset service:
+
+```
+Operators: =, !=, >, >=, <, <=, and/&&, or/||, .Contains(), !.Contains()
+```
+
+**Filterable system properties:**
+
+- `id` — System ID
+- `alias` — System alias
+- `createdTimestamp` / `lastUpdatedTimestamp` — ISO-8601 timestamps
+- `connected.data.state` — Connection state enum (CONNECTED, DISCONNECTED, VIRTUAL, etc.)
+- `grains.data.*` — System info (os, kernel, host, cpuarch, deviceclass, etc.)
+- `packages.data.*` — Installed packages and versions
+- `feeds.data.*` — Configured feeds
+- `keywords.data` — Keywords array (`.Contains()`)
+- `properties.data.*` — Custom properties
+- `status.data.http_connected` — HTTP connection status
+
+### Connection States
+
+```
+ACTIVATED_WITHOUT_CONNECTION | APPROVED | DISCONNECTED |
+CONNECTED_REFRESH_PENDING | CONNECTED | CONNECTED_REFRESH_FAILED | VIRTUAL
+```
+
+### Job States
+
+```
+SUCCEEDED | OUTOFQUEUE | INQUEUE | INPROGRESS | CANCELED | FAILED
+```
+
+---
+
+## Workflow Analysis Proposals vs. Recommended Implementation
+
+### Workflow 2: "What was the SN of the PXI-4071 used to measure DUT SN 1234567?"
+
+**Workflow Analysis Proposes:**
+
+```bash
+slcli system get <systemId> --projection "id,alias,hostname,workspaceId"
+slcli system get-snapshot <system-id> --at-time "2025-12-01T10:30:00Z" --include assets
+```
+
+**Recommended Implementation:**
+
+```bash
+# Simple get by ID — no snapshot API exists
+slcli system get <systemId> --format json
+```
+
+**Assessment:** ✅ `system get` covers the system lookup step
+
+- The workflow analysis's `get-snapshot` requires historical state APIs that don't exist
+- The cross-service correlation (test → system → asset) is best handled by Copilot's reasoning layer, not a single CLI command
+- `slcli system get` provides the system details needed for the next step (`slcli asset list --model "PXI-4071"`)
+
+---
+
+### Workflow 4: "Find me a system that has a DMM and a scope"
+
+**Workflow Analysis Proposes:**
+
+```bash
+slcli system find --has-asset "DMM" --has-asset "scope" --available --output table
+slcli system query-by-assets --requires "DMM,scope" --match-all --show-asset-details
+```
+
+**Recommended Implementation:**
+
+```bash
+# Step 1: Use asset commands to find minionIds (already implemented)
+slcli asset list --model "DMM" --connected true --format json \
+  | jq -r '.[].location.minionId'
+
+# Step 2: Query systems by those IDs
+slcli system list --state CONNECTED --format json
+
+# Step 3: Copilot correlates minionIds to system IDs client-side
+```
+
+**Assessment:** ⚠️ Cross-service correlation is a Copilot task
+
+- The nisysmgmt API has no asset awareness — `--has-asset` would require client-side orchestration
+- Creating a fake `find` command that hides multi-API calls is fragile and opinionated
+- Better to provide solid `system list` with rich filtering, and let Copilot compose the workflow
+- The `system list` command can filter by `connected.data.state` to find available systems
+
+---
+
+### Workflow 5: "Find me a system with package X installed"
+
+**Workflow Analysis Proposes:**
+
+```bash
+slcli system find --with-package "DAQmx" --version ">= 22.0" --output table
+slcli system query-by-software --package-name "DAQmx" --output json
+```
+
+**Recommended Implementation:**
+
+```bash
+# The query-systems API DOES support filtering by packages.data!
+slcli system list \
+  --filter 'packages.data.ni-daqmx.version != ""' \
+  --format table
+
+# Or with a convenience flag:
+slcli system list \
+  --has-package "ni-daqmx" \
+  --state CONNECTED \
+  --format table
+```
+
+**Assessment:** ✅ Achievable with existing API
+
+- The `QuerySystemsRequest` filter explicitly documents `packages.data.*` as filterable
+- A `--has-package` convenience option translates to the filter expression `packages.data.<name>.version != ""`
+- No need for a separate `query-by-software` command — it's just a filter on `system list`
+- For fuzzy package matching, client-side filtering is needed (query all systems with packages projection, then filter)
+
+---
+
+## Concrete Proposal
+
+### Keep Command Structure Simple, Follow Established Patterns
+
+#### Proposed structure:
+
+```
+slcli system
+├── list        [query systems with filters, pagination, table/JSON]
+├── get         [get detailed system info by ID]
+├── summary     [connected/disconnected/virtual/pending counts]
+├── update      [update system metadata: alias, keywords, properties, workspace]
+├── remove      [remove/unregister systems]
+├── report      [generate software/hardware report]
+├── job
+│   ├── list    [query jobs with filters]
+│   ├── get     [get job details by ID]
+│   ├── summary [active/failed/succeeded counts]
+│   └── cancel  [cancel a job]
+└── key
+    ├── list    [list system keys by state]
+    └── manage  [accept/reject/delete keys]
+```
+
+**NOT creating separate:**
+
+- ❌ `system find` (redundant with `system list` + filters)
+- ❌ `system get-snapshot` (no historical API exists)
+- ❌ `system query-by-assets` (cross-service correlation is a Copilot task)
+- ❌ `system query-by-software` (use `system list --has-package`)
+
+---
+
+## Command Specifications
+
+### Phase 1 — Core Read Operations
+
+#### 1. `slcli system list`
+
+**Purpose:** Query and list systems with comprehensive filtering.
+
+**API:** `POST /nisysmgmt/v1/query-systems`
+
+```bash
+slcli system list \
+  --alias "MySystem" \
+  --state CONNECTED \
+  --os "Windows" \
+  --has-package "ni-daqmx" \
+  --has-keyword "Running" \
+  --workspace "Production" \
+  --filter 'grains.data.deviceclass = "PXIe Chassis"' \
+  --order-by ALIAS \
+  --take 25 \
+  --format table
+```
+
+**Options:**
+
+| Option             | Type               | Description                                                        |
+| ------------------ | ------------------ | ------------------------------------------------------------------ |
+| `--alias / -a`     | `str`              | Filter by system alias (contains match)                            |
+| `--state / -s`     | `Choice`           | Filter by connection state: CONNECTED, DISCONNECTED, VIRTUAL, etc. |
+| `--os`             | `str`              | Filter by OS (grains.data.kernel contains match)                   |
+| `--host`           | `str`              | Filter by hostname (grains.data.host contains match)               |
+| `--has-package`    | `str`              | Filter for systems with specified package installed                |
+| `--has-keyword`    | `str` (repeatable) | Filter systems that have the specified keyword                     |
+| `--property`       | `str` (repeatable) | Filter by property `key=value`                                     |
+| `--workspace / -w` | `str`              | Filter by workspace ID or name                                     |
+| `--filter`         | `str`              | Custom filter expression (API-native syntax)                       |
+| `--order-by`       | `Choice`           | Order by: ALIAS, CREATED_AT, UPDATED_AT, STATE, HOST               |
+| `--take / -t`      | `int`              | Number of items per page (default: 25)                             |
+| `--format / -f`    | `Choice`           | Output format: table (default), json                               |
+
+**Table columns:**
+
+```
+┌─────────────────────────────┬──────────────────┬────────────┬──────────────┬───────────────────┐
+│ Alias                       │ Host             │ State      │ OS           │ ID                │
+├─────────────────────────────┼──────────────────┼────────────┼──────────────┼───────────────────┤
+│ PXI-TestStand-01            │ PXIE-8840-01     │ CONNECTED  │ Windows      │ HVM_domU--SN-...  │
+│ Lab-Controller-West         │ DESKTOP-CTRL     │ CONNECTED  │ Windows      │ 6b70e1df-ae93...  │
+│ Build-Server-03             │ buildsvr03       │ DISCONNECT │ Linux        │ e740733d-da55...  │
+└─────────────────────────────┴──────────────────┴────────────┴──────────────┴───────────────────┘
+```
+
+**Filter building logic:**
+
+- `--alias "MySystem"` → `alias.Contains("MySystem")`
+- `--state CONNECTED` → `connected.data.state = "CONNECTED"`
+- `--os "Windows"` → `grains.data.kernel.Contains("Windows")`
+- `--host "PXIE"` → `grains.data.host.Contains("PXIE")`
+- `--has-package "ni-daqmx"` → client-side filter (query with packages projection, match key names containing the search term)
+- `--has-keyword "Running"` → `keywords.data.Contains("Running")`
+- `--property "owner=admin"` → `properties.data.owner = "admin"`
+- `--workspace` → resolve workspace ID if name given, then `workspace = "<id>"`
+- Multiple filters combined with `and`
+
+**Implementation notes:**
+
+- `--has-package` requires special handling: the API filter `packages.data.<name>.version != ""` works for **exact** package names, but fuzzy matching needs client-side filtering. Implementation: if the package name looks like an exact match (no wildcards), use server-side filter; otherwise, fetch with packages projection and filter client-side.
+- Use skip/take pagination (max 1000 per request), same pattern as `_query_all_assets()`.
+- Projection: use `new(id,alias,connected,grains,keywords,properties,workspace,packages)` to minimize payload when not filtering by packages, or omit projection to get full data when `--has-package` is used.
+
+---
+
+#### 2. `slcli system get <system_id>`
+
+**Purpose:** Get detailed information about a single system.
+
+**API:** `GET /nisysmgmt/v1/systems?id=<system_id>`
+
+```bash
+slcli system get HVM_domU--SN-ec20418e --format json
+slcli system get HVM_domU--SN-ec20418e --include-packages --include-feeds
+```
+
+**Options:**
+
+| Option               | Type     | Description                          |
+| -------------------- | -------- | ------------------------------------ |
+| `--include-packages` | `flag`   | Include installed packages in output |
+| `--include-feeds`    | `flag`   | Include configured feeds in output   |
+| `--format / -f`      | `Choice` | Output format: table (default), json |
+
+**Table output (default — without packages/feeds):**
+
+```
+System Details
+──────────────────────────────────────
+  ID:            HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade--MAC-12-9D-96-E7-CA-51
+  Alias:         PXI-TestStand-01
+  State:         CONNECTED
+  Workspace:     6b70e1df-ae93-4ded-9fe0-dc775732289b
+
+  System Info:
+    Host:          PXIE-8840-01
+    OS:            Windows (10.0.19042.928)
+    Architecture:  AMD64
+    Device Class:  PXIe Chassis
+
+  Keywords:        Running, InUse
+
+  Properties:
+    RunningTestsVersion: 3.9.2
+    TestStandVersion:    2020
+
+  Timestamps:
+    Created:       2026-01-15 10:30:00 UTC
+    Last Updated:  2026-02-10 20:37:48 UTC
+    Last Present:  2026-02-10 20:37:48 UTC
+```
+
+**With `--include-packages`:** appends a packages table:
+
+```
+  Installed Packages (42):
+  ┌──────────────────────────────────┬──────────────┬──────────────────┐
+  │ Package                          │ Version      │ Group            │
+  ├──────────────────────────────────┼──────────────┼──────────────────┤
+  │ NI-DAQmx                         │ 2023 Q1      │ Infrastructure   │
+  │ NI Curl                          │ 21.3.0       │ Infrastructure   │
+  │ ...                              │ ...          │ ...              │
+  └──────────────────────────────────┴──────────────┴──────────────────┘
+```
+
+**Implementation notes:**
+
+- The `GET /nisysmgmt/v1/systems?id=<id>` returns an array; take the first element.
+- Grains data provides OS info: `kernel`, `osversion`, `osmanufacturer`, `host`, `cpuarch`, `deviceclass`.
+- Packages data is a dict where keys are package names and values contain `displayname`, `displayversion`, `version`, `group`, `arch`, etc.
+- Feeds data is a dict where keys are feed URLs and values are arrays of feed config objects.
+
+---
+
+#### 3. `slcli system summary`
+
+**Purpose:** Show fleet summary — connected, disconnected, virtual, and pending counts.
+
+**APIs:**
+
+- `GET /nisysmgmt/v1/get-systems-summary` → `connectedCount`, `disconnectedCount`, `virtualCount`
+- `GET /nisysmgmt/v1/get-pending-systems-summary` → `pendingCount`
+
+```bash
+slcli system summary --format table
+slcli system summary --format json
+```
+
+**Options:**
+
+| Option          | Type     | Description                          |
+| --------------- | -------- | ------------------------------------ |
+| `--format / -f` | `Choice` | Output format: table (default), json |
+
+**Table output:**
+
+```
+System Fleet Summary
+──────────────────────────────────────
+  Connected:      42
+  Disconnected:   8
+  Virtual:        3
+  Pending:        2
+  ─────────────────
+  Total:          55
+```
+
+**JSON output:**
+
+```json
+{
+  "connectedCount": 42,
+  "disconnectedCount": 8,
+  "virtualCount": 3,
+  "pendingCount": 2,
+  "totalCount": 55
+}
+```
+
+**Implementation notes:**
+
+- Two API calls (systems summary + pending summary), can be made in sequence.
+- `totalCount` is computed client-side: `connected + disconnected + virtual + pending`.
+
+---
+
+### Phase 2 — Mutation Operations & Jobs
+
+#### 4. `slcli system update <system_id>`
+
+**Purpose:** Update a system's metadata (alias, keywords, properties, workspace, location).
+
+**API:** `PATCH /nisysmgmt/v1/systems/managed/{id}`
+
+```bash
+slcli system update HVM_domU--SN-ec20418e \
+  --alias "PXI-Lab-Controller" \
+  --keyword "Production" \
+  --keyword "Calibrated" \
+  --property "owner=jsmith" \
+  --property "location=Lab-B" \
+  --workspace "33eba2fe-fe42-48a1-a47f-a6669479a8aa"
+```
+
+**Options:**
+
+| Option          | Type               | Description                                         |
+| --------------- | ------------------ | --------------------------------------------------- |
+| `--alias`       | `str`              | New alias for the system                            |
+| `--keyword`     | `str` (repeatable) | Keywords to set (replaces all keywords)             |
+| `--property`    | `str` (repeatable) | Properties as `key=value` (replaces all properties) |
+| `--workspace`   | `str`              | Workspace ID or name to move system to              |
+| `--scan-code`   | `str`              | New scan code                                       |
+| `--location-id` | `str`              | New location ID                                     |
+| `--format / -f` | `Choice`           | Output format: table (default), json                |
+
+**Implementation notes:**
+
+- Uses `PATCH /nisysmgmt/v1/systems/managed/{id}` with `SystemPatchRequest` body.
+- Only include fields that are explicitly provided (don't send nulls for unchanged fields).
+- `--keyword` is repeatable and replaces all existing keywords (API behavior).
+- `--property` is repeatable, parsed with `_parse_properties()` helper (same as asset commands).
+- Protected by `check_readonly_mode()`.
+
+---
+
+#### 5. `slcli system remove <system_id>`
+
+**Purpose:** Remove/unregister a system from SystemLink.
+
+**API:** `POST /nisysmgmt/v1/remove-systems`
+
+```bash
+slcli system remove HVM_domU--SN-ec20418e
+slcli system remove HVM_domU--SN-ec20418e --force
+```
+
+**Options:**
+
+| Option    | Type   | Description                                                                                                   |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `--force` | `flag` | Skip confirmation prompt; also controls API `force` parameter (immediate removal vs. wait for unregister job) |
+
+**Behavior:**
+
+- Without `--force`: show confirmation prompt ("Remove system 'PXI-TestStand-01' (HVM_domU--SN-...)? [y/N]"), API `force=false` (wait for unregister job).
+- With `--force`: no prompt, API `force=true` (remove from database immediately).
+- Protected by `check_readonly_mode()`.
+- Display success: `✓ System removed: HVM_domU--SN-ec20418e`
+- If API returns `failedIds`, display errors for each.
+
+---
+
+#### 6. `slcli system report`
+
+**Purpose:** Generate a software or hardware report for systems.
+
+**API:** `POST /nisysmgmt/v1/generate-systems-report`
+
+```bash
+slcli system report --type SOFTWARE --output software-report.csv
+slcli system report --type HARDWARE --filter 'connected.data.state = "CONNECTED"' --output hw-report.csv
+```
+
+**Options:**
+
+| Option          | Type     | Description                                         |
+| --------------- | -------- | --------------------------------------------------- |
+| `--type`        | `Choice` | Report type: SOFTWARE, HARDWARE (required)          |
+| `--filter`      | `str`    | Filter expression to scope which systems to include |
+| `--output / -o` | `Path`   | File path to save the report (required)             |
+
+**Implementation notes:**
+
+- API returns binary data (report file). Stream to output file.
+- The `SystemsReportRequest` takes `type` and `filter`.
+- Protected by `check_readonly_mode()` (generates a report file).
+
+---
+
+#### 7. `slcli system job list`
+
+**Purpose:** Query and list jobs.
+
+**API:** `POST /nisysmgmt/v1/query-jobs`
+
+```bash
+slcli system job list --state FAILED --format table
+slcli system job list --system-id HVM_domU--SN-ec20418e --format json
+slcli system job list --filter 'config.fun.Contains("nisysmgmt.set_blackout")' --take 10
+```
+
+**Options:**
+
+| Option          | Type     | Description                                                                       |
+| --------------- | -------- | --------------------------------------------------------------------------------- |
+| `--system-id`   | `str`    | Filter jobs by target system ID                                                   |
+| `--state`       | `Choice` | Filter by job state: SUCCEEDED, FAILED, INPROGRESS, INQUEUE, OUTOFQUEUE, CANCELED |
+| `--function`    | `str`    | Filter by salt function name                                                      |
+| `--filter`      | `str`    | Custom filter expression                                                          |
+| `--order-by`    | `Choice` | Order by: CREATED_AT (default desc), UPDATED_AT, STATE                            |
+| `--take / -t`   | `int`    | Items per page (default: 25)                                                      |
+| `--format / -f` | `Choice` | Output format: table (default), json                                              |
+
+**Table columns:**
+
+```
+┌──────────────────────────────────────┬──────────────┬──────────────────────┬──────────────────────────────┐
+│ Job ID                               │ State        │ Created              │ Target System                │
+├──────────────────────────────────────┼──────────────┼──────────────────────┼──────────────────────────────┤
+│ 54af4b95-ea89-48df-b21f-dddf5608...  │ SUCCEEDED    │ 2026-02-10 15:15:13  │ HVM_domU--SN-ec20418e...     │
+│ d762dfad-f644-4470-8ecd-6b9e0769...  │ FAILED       │ 2026-02-09 10:30:00  │ PXIE-8840-01                 │
+└──────────────────────────────────────┴──────────────┴──────────────────────┴──────────────────────────────┘
+```
+
+**Filter building logic:**
+
+- `--system-id` → `id = "<system-id>"` (Note: in job model, `id` is the target system)
+- `--state FAILED` → `state = "FAILED"`
+- `--function "set_blackout"` → `config.fun.Contains("set_blackout")`
+- Default order: `createdTimestamp descending`
+
+---
+
+#### 8. `slcli system job get <job_id>`
+
+**Purpose:** Get detailed information about a specific job.
+
+**API:** `GET /nisysmgmt/v1/jobs?jid=<job_id>`
+
+```bash
+slcli system job get 54af4b95-ea89-48df-b21f-dddf56083476 --format json
+```
+
+**Options:**
+
+| Option          | Type     | Description                          |
+| --------------- | -------- | ------------------------------------ |
+| `--format / -f` | `Choice` | Output format: table (default), json |
+
+**Table output:**
+
+```
+Job Details
+──────────────────────────────────────
+  Job ID:        54af4b95-ea89-48df-b21f-dddf56083476
+  State:         SUCCEEDED
+  Target:        HVM_domU--SN-ec20418e-d93b-2de3-b957-28e29379cade
+  Functions:     system.set_computer_desc
+
+  Timestamps:
+    Created:       2026-02-10 15:15:13 UTC
+    Updated:       2026-02-10 15:15:14 UTC
+    Dispatched:    2026-02-10 15:15:13 UTC
+
+  Result:
+    Return Code:   0
+    Return:        SUCCESS
+    Success:       true
+```
+
+---
+
+#### 9. `slcli system job summary`
+
+**Purpose:** Show job summary — active, failed, succeeded counts.
+
+**API:** `GET /nisysmgmt/v1/get-jobs-summary`
+
+```bash
+slcli system job summary --format table
+```
+
+**Table output:**
+
+```
+Job Summary
+──────────────────────────────────────
+  Active:       3
+  Succeeded:    127
+  Failed:       5
+  ─────────────────
+  Total:        135
+```
+
+---
+
+#### 10. `slcli system job cancel <job_id>`
+
+**Purpose:** Cancel a running job.
+
+**API:** `POST /nisysmgmt/v1/cancel-jobs`
+
+```bash
+slcli system job cancel 54af4b95-ea89-48df-b21f-dddf56083476
+slcli system job cancel 54af4b95-ea89-48df-b21f-dddf56083476 --system-id HVM_domU--SN-ec20418e
+```
+
+**Options:**
+
+| Option        | Type  | Description                                     |
+| ------------- | ----- | ----------------------------------------------- |
+| `--system-id` | `str` | Target system ID (optional, for disambiguation) |
+
+**Implementation notes:**
+
+- `CancelJobRequest` takes `jid` and optional `systemId`.
+- Protected by `check_readonly_mode()`.
+- Display success: `✓ Job cancelled: 54af4b95-...`
+
+---
+
+### Phase 3 — Key Management (Future)
+
+#### 11. `slcli system key list`
+
+**Purpose:** List system keys by state (pending, approved, denied, rejected).
+
+**API:** `GET /nisysmgmt/v1/get-systems-keys`
+
+```bash
+slcli system key list --state pending --format table
+slcli system key list --format json
+```
+
+**Options:**
+
+| Option          | Type     | Description                                                                               |
+| --------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `--state`       | `Choice` | Filter by key state: PENDING, APPROVED, DENIED, REJECTED (optional, shows all if omitted) |
+| `--format / -f` | `Choice` | Output format: table (default), json                                                      |
+
+---
+
+#### 12. `slcli system key manage <system_id>`
+
+**Purpose:** Accept, reject, or delete a system key.
+
+**API:** `POST /nisysmgmt/v1/manage-systems-keys`
+
+```bash
+slcli system key manage HVM_domU--SN-ec20418e --action ACCEPT
+slcli system key manage HVM_domU--SN-ec20418e --action REJECT
+slcli system key manage HVM_domU--SN-ec20418e --action DELETE --workspace "Production"
+```
+
+**Options:**
+
+| Option        | Type     | Description                               |
+| ------------- | -------- | ----------------------------------------- |
+| `--action`    | `Choice` | Action: ACCEPT, REJECT, DELETE (required) |
+| `--workspace` | `str`    | Workspace ID or name (for ACCEPT action)  |
+
+---
+
+## Addressing Specific Workflow Requirements
+
+### Workflow 2: "What was the SN of the PXI-4071 used to measure DUT SN 1234567?"
+
+**Using proposed commands:**
+
+```bash
+# Step 1: Get test result (testmonitor - already exists)
+slcli testmonitor result list \
+  --serial-number "1234567" \
+  --format json
+# → Extract systemId from result
+
+# Step 2: Get system details
+slcli system get <systemId> --format json
+# → System ID is the minionId for asset lookup
+
+# Step 3: Query assets on that system (asset - already exists)
+slcli asset list \
+  --model "PXI-4071" \
+  --connected true \
+  --format json
+# → Copilot correlates by minionId
+```
+
+**Assessment:** All steps achievable with `system get`. The cross-service correlation is handled by Copilot's reasoning layer, which is the correct architecture for multi-service workflows.
+
+---
+
+### Workflow 4: "Find me a system that has a DMM and a scope"
+
+**Using proposed commands:**
+
+```bash
+# Step 1: Find DMM assets (asset - already exists)
+slcli asset list --model "DMM" --format json
+# → Extract minionIds
+
+# Step 2: Find scope assets (asset - already exists)
+slcli asset list --model "scope" --format json
+# → Extract minionIds
+
+# Step 3: Get system details for common minionIds
+slcli system list --state CONNECTED --format json
+# → Copilot computes intersection of minionIds with system IDs
+```
+
+**Assessment:** No new API needed. Copilot performs the set intersection logic.
+
+---
+
+### Workflow 5: "Find me a system with package X installed"
+
+**Using proposed commands:**
+
+```bash
+# Direct server-side filter (exact package name)
+slcli system list --has-package "ni-daqmx" --state CONNECTED --format table
+
+# Or with custom filter
+slcli system list --filter 'packages.data.ni-daqmx.version != ""' --format table
+
+# Fuzzy package search (client-side filtering)
+slcli system list --has-package "daq" --format json
+# → Implementation: fetch systems with packages projection, filter client-side
+# → Show all systems where any package key contains "daq"
+```
+
+**Assessment:** ✅ Fully supported. The `--has-package` option makes this a single command for the most common case. For exact package names, server-side filtering is efficient. For fuzzy matching, the command fetches all systems and filters client-side.
+
+---
+
+## Rationale for Simplified Structure
+
+### 1. Aligns with API Structure
+
+The nisysmgmt API is organized around three primary entities:
+
+- **Systems** — The core entity (query, get, update, remove)
+- **Jobs** — Operations dispatched to systems (query, create, cancel)
+- **Keys** — System key management (accept, reject, delete)
+
+This maps naturally to our command hierarchy: `system`, `system job`, `system key`.
+
+### 2. Matches User Mental Model
+
+Users think in terms of:
+
+- "List all connected systems" → `system list --state CONNECTED`
+- "What packages does this system have?" → `system get <id> --include-packages`
+- "Find systems with DAQmx" → `system list --has-package "ni-daqmx"`
+- "Check fleet health" → `system summary`
+
+They don't think:
+
+- "Query by software" (it's just a filter on system list)
+- "Get snapshot at time" (no historical API exists)
+- "Find by assets" (that's a cross-service operation for Copilot)
+
+### 3. Reduces Command Explosion
+
+Workflow analysis proposes:
+
+- `system find` (new verb, overlaps with list)
+- `system get-snapshot` (no API support)
+- `system query-by-assets` (cross-service, not a system API feature)
+- `system query-by-software` (just a filter on list)
+  = **4 new specialized commands that don't generalize**
+
+Our proposal:
+
+- `system list` (with rich filtering including `--has-package`)
+- `system get` (detailed view with optional packages/feeds)
+- `system summary` (fleet overview)
+- `system update` / `system remove` (mutation operations)
+- `system report` (hardware/software reports)
+- `system job list/get/summary/cancel` (job management)
+- `system key list/manage` (key management, future)
+  = **12 commands covering ALL available API endpoints**
+
+### 4. Follows Established Patterns
+
+```bash
+# Asset commands (just implemented)
+slcli asset list       # Query with filters
+slcli asset get <id>   # Get details
+slcli asset summary    # Fleet overview
+slcli asset create     # Mutation
+slcli asset update     # Mutation
+slcli asset delete     # Mutation
+
+# System commands (proposed — same pattern!)
+slcli system list      # Query with filters
+slcli system get <id>  # Get details
+slcli system summary   # Fleet overview
+slcli system update    # Mutation
+slcli system remove    # Mutation (API says "remove", not "delete")
+slcli system report    # Unique to systems
+```
+
+---
+
+## Comparison Table
+
+| Capability                | Workflow Analysis                       | Counter-Proposal                             | Assessment                        |
+| ------------------------- | --------------------------------------- | -------------------------------------------- | --------------------------------- |
+| List systems with filters | `system list`                           | `system list`                                | ✅ Equivalent                     |
+| Get system details        | `system get`                            | `system get`                                 | ✅ Equivalent                     |
+| Find by installed package | `system find --with-package` (new verb) | `system list --has-package` (filter on list) | ✅ Simpler, no new verb           |
+| Find by assets            | `system query-by-assets`                | Copilot orchestration                        | ✅ Correct separation of concerns |
+| Historical snapshot       | `system get-snapshot --at-time`         | Not implemented (no API)                     | ✅ Honest about API limitations   |
+| Fleet summary             | Not proposed                            | `system summary`                             | ✅ Added value                    |
+| Job management            | Not proposed                            | `system job list/get/summary/cancel`         | ✅ Full API coverage              |
+| Key management            | Not proposed                            | `system key list/manage`                     | ✅ Full API coverage              |
+| System reports            | Not proposed                            | `system report`                              | ✅ Full API coverage              |
+| Update metadata           | Not proposed                            | `system update`                              | ✅ Full API coverage              |
+| Remove systems            | Not proposed                            | `system remove`                              | ✅ Full API coverage              |
+
+---
+
+## Implementation Priority
+
+### Phase 1: Core Read Operations (Immediate)
+
+- 🔨 `slcli system list` — Query systems with filters, pagination, table/JSON
+- 🔨 `slcli system get <id>` — Detailed system info with optional packages/feeds
+- 🔨 `slcli system summary` — Connected/disconnected/virtual/pending counts
+
+### Phase 2: Mutation Operations & Jobs (Short-term)
+
+- 🔨 `slcli system update <id>` — Update alias, keywords, properties, workspace
+- 🔨 `slcli system remove <id>` — Remove/unregister with confirmation
+- 🔨 `slcli system report` — Generate software/hardware reports
+- 🔨 `slcli system job list` — Query jobs with filters
+- 🔨 `slcli system job get <id>` — Job details
+- 🔨 `slcli system job summary` — Active/failed/succeeded counts
+- 🔨 `slcli system job cancel <id>` — Cancel running jobs
+
+### Phase 3: Key Management (Future)
+
+- 🔨 `slcli system key list` — List keys by state
+- 🔨 `slcli system key manage` — Accept/reject/delete keys
+
+### Phase 4: Future Enhancements
+
+- 🔨 `slcli system create-virtual` — Create virtual systems
+- 🔨 Enhanced `--has-package` with version comparison operators
+- 🔨 `system list --include-packages` for bulk package inventory
+- 🔨 Cross-reference with assets (if unified query API becomes available)
+
+---
+
+## API Requirements
+
+### Existing APIs (All Available Now)
+
+**System APIs:**
+
+- ✅ `POST /nisysmgmt/v1/query-systems` — Full query with filter, projection, orderBy, skip, take
+- ✅ `GET /nisysmgmt/v1/systems?id=<id>` — Get single system with all data
+- ✅ `GET /nisysmgmt/v1/get-systems-summary` — Connected/disconnected/virtual counts
+- ✅ `GET /nisysmgmt/v1/get-pending-systems-summary` — Pending count
+- ✅ `POST /nisysmgmt/v1/update-systems` — Batch update system metadata
+- ✅ `PATCH /nisysmgmt/v1/systems/managed/{id}` — Update single system
+- ✅ `POST /nisysmgmt/v1/remove-systems` — Remove systems
+- ✅ `POST /nisysmgmt/v1/generate-systems-report` — Generate reports
+
+**Job APIs:**
+
+- ✅ `GET /nisysmgmt/v1/jobs` — Get jobs by systemId/jid/state/function
+- ✅ `POST /nisysmgmt/v1/query-jobs` — Query jobs with filter/projection/orderBy/skip/take
+- ✅ `POST /nisysmgmt/v1/jobs` — Create jobs
+- ✅ `POST /nisysmgmt/v1/cancel-jobs` — Cancel jobs
+- ✅ `GET /nisysmgmt/v1/get-jobs-summary` — Job summary
+
+**Key APIs:**
+
+- ✅ `GET /nisysmgmt/v1/get-systems-keys` — Get all keys
+- ✅ `POST /nisysmgmt/v1/get-systems-keys` — Get keys for specific systems
+- ✅ `POST /nisysmgmt/v1/manage-systems-keys` — Manage keys (accept/reject/delete)
+
+### No New APIs Required
+
+All proposed commands can be implemented using existing nisysmgmt v1 APIs through:
+
+- **Query API:** Full filter/projection/pagination on systems and jobs
+- **Package filtering:** Server-side via `packages.data.<name>` filters, or client-side for fuzzy matching
+- **System metadata:** PATCH API for individual updates, POST for batch updates
+- **Reports:** Existing report generation endpoint
+
+### Implementation Notes
+
+**For `system list --has-package`:**
+
+- Exact name: server-side filter `packages.data.<name>.version != ""`
+- Fuzzy name: query all systems with packages in projection, client-side filter by matching package key names containing the search term
+- Performance consideration: fuzzy package search over many systems may require pagination through all results. Add `_warn_if_large_dataset()` similar to asset commands.
+
+**For `system list` pagination:**
+
+- Use `QuerySystemsRequest` with `skip`/`take` (max 1000 per request)
+- Implement `_query_all_systems()` helper matching the `_query_all_assets()` pattern
+- Enable interactive pagination in table mode (25 items/page, Y/n prompt)
+
+**For `system get --include-packages`:**
+
+- The `GET /nisysmgmt/v1/systems?id=<id>` returns packages by default
+- Parse `packages.data` dict: keys are package names, values contain `displayname`, `displayversion`, `version`, `group`, `arch`, etc.
+- Sort packages alphabetically by display name for table output
+
+**For `system report`:**
+
+- API returns binary data (likely CSV)
+- Stream response to output file
+- Show progress indicator for large reports
+
+---
+
+## Testing Strategy
+
+### Unit Tests (tests/unit/test_system_click.py)
+
+```python
+# Test classes matching the pattern from test_asset_click.py:
+class TestBuildSystemFilter:           # Filter construction from CLI options
+class TestListSystems:                  # system list command variations
+class TestGetSystem:                    # system get with/without packages/feeds
+class TestSystemSummary:                # system summary response handling
+class TestUpdateSystem:                 # system update with various options
+class TestRemoveSystem:                 # system remove with/without --force
+class TestSystemReport:                 # system report generation
+class TestJobList:                      # system job list with filters
+class TestJobGet:                       # system job get details
+class TestJobSummary:                   # system job summary
+class TestJobCancel:                    # system job cancel
+```
+
+### Coverage targets:
+
+- ≥80% coverage for new code
+- All filter combinations tested
+- Error paths tested (404, 401, network errors)
+- `--has-package` tested with exact and fuzzy matching
+- Pagination tested (single page, multi-page, empty results)
+- Mutation commands tested with readonly mode

--- a/docs/testmonitor-command-proposal.md
+++ b/docs/testmonitor-command-proposal.md
@@ -1,0 +1,592 @@
+# Test Monitor Command Proposal: Analysis & Recommendations
+
+**Date:** February 6, 2026  
+**Context:** Review of slcli-workflow-analysis.md against current testmonitor implementation
+
+---
+
+## Executive Summary
+
+The current `testmonitor` implementation provides **solid foundational capabilities** that address many workflow requirements. However, the workflow analysis proposes a more granular command structure that doesn't align well with:
+1. Current SystemLink API structure
+2. Established slcli patterns
+3. Actual user workflows
+
+**Recommendation:** Enhance the existing `testmonitor` commands rather than creating separate `testresult`, `teststep`, `testpath`, `testmeasurement` groups.
+
+---
+
+## Current Implementation Assessment
+
+### What We Have (Just Implemented)
+
+#### `slcli testmonitor product list`
+**Capabilities:**
+- ✅ Filter by name, part-number, family, workspace
+- ✅ Dynamic LINQ filter expressions with substitutions
+- ✅ Ordering by: ID, PART_NUMBER, NAME, FAMILY, UPDATED_AT
+- ✅ Interactive pagination (25 items/page)
+- ✅ Table and JSON output formats
+- ✅ Workspace resolution (by ID or name)
+
+**Example:**
+```bash
+slcli testmonitor product list \
+  --name "XYZ" \
+  --family "TestFamily" \
+  --filter "updatedAt > @0" \
+  --substitution "2025-08-01" \
+  --format json
+```
+
+#### `slcli testmonitor result list`
+**Capabilities:**
+- ✅ Filter by: status, program-name, serial-number, part-number, operator, host-name, system-id, workspace
+- ✅ Product filtering via `--product-filter` and `--product-substitution`
+- ✅ Dynamic LINQ expressions with full substitution support
+- ✅ Ordering by 11 fields (ID, STARTED_AT, UPDATED_AT, PROGRAM_NAME, etc.)
+- ✅ Interactive pagination
+- ✅ Table and JSON output
+- ✅ Status normalization (e.g., "passed" → "PASSED")
+
+**Example:**
+```bash
+slcli testmonitor result list \
+  --status FAILED \
+  --part-number "XYZ" \
+  --started-after "2025-08-01" \
+  --started-before "2026-01-31" \
+  --format json
+```
+
+---
+
+## Workflow Analysis Proposals vs. Current Implementation
+
+### Workflow 1: "Show me all failed measurements on product XYZ for the last two quarters"
+
+**Workflow Analysis Proposes:**
+```bash
+# Multiple separate command groups
+slcli testresult query --filter '...' --started-after --started-before
+slcli teststep query --filter 'resultId in [...]'
+slcli testpath query --filter 'partNumber = "XYZ"'
+slcli testresult analyze --product "XYZ" --status failed
+slcli testmeasurement query --product "XYZ" --status failed
+```
+
+**Current Implementation Can Do:**
+```bash
+# Single, focused command
+slcli testmonitor result list \
+  --part-number "XYZ" \
+  --status FAILED \
+  --started-after "2025-08-01" \
+  --started-before "2026-01-31" \
+  --format json
+
+# For step-level data (proposed enhancement):
+slcli testmonitor result list \
+  --part-number "XYZ" \
+  --status FAILED \
+  --started-after "2025-08-01" \
+  --include-steps \
+  --format json
+```
+
+**Assessment:** ✅ Current structure is BETTER
+- Fewer commands to learn
+- Aligns with API structure (results are primary entity)
+- Natural temporal filtering with `--started-after/before`
+- Can be enhanced with `--include-steps` flag
+
+---
+
+### Workflow 6: "Show me what type of test data exists for [Part Number]"
+
+**Workflow Analysis Proposes:**
+```bash
+slcli testpath query --filter 'partNumber = "ABC123"'
+slcli testpath summary --part-number "ABC123"
+slcli testmetadata get --part-number "ABC123"
+```
+
+**Current Implementation Can Do:**
+```bash
+# Query results to understand test coverage
+slcli testmonitor result list \
+  --part-number "ABC123" \
+  --format json \
+  | jq -r '[.[] | {program: .programName, started: .startedAt, status: .status.statusType}] | unique_by(.program)'
+
+# Better: Add a summary flag
+slcli testmonitor result list \
+  --part-number "ABC123" \
+  --summary \
+  --format table
+```
+
+**Assessment:** ⚠️ Needs enhancement
+- Current: Can list results, but no built-in summary
+- Proposed: Add `--summary` flag to product/result list
+- Don't need separate `testpath` command group
+
+---
+
+## Concrete Counter-Proposal
+
+### Keep Current Structure, Add Enhancements
+
+#### 1. Enhance `testmonitor product list`
+
+**Add flags:**
+```bash
+slcli testmonitor product list \
+  --name "XYZ" \
+  --summary              # Show test coverage summary (programs, result counts)
+  --show-paths           # Include test paths in output
+  --format json
+```
+
+**Implementation:** Use POST `/nitestmonitor/v2/query-paths` to get paths matching product criteria, then aggregate data client-side
+
+---
+
+#### 2. Enhance `testmonitor result list`
+
+**Add flags:**
+```bash
+slcli testmonitor result list \
+  --part-number "XYZ" \
+  --status FAILED \
+  --started-after "2025-08-01" \
+  --started-before "2026-01-31" \
+  --include-steps        # Include step data in response
+  --include-measurements # Include measurement data
+  --group-by program     # Group results by program name
+  --summary              # Show aggregated summary
+  --format json
+```
+
+**Additional temporal filters:**
+```bash
+# Natural language date support
+--since "2 quarters ago"
+--since "last week"
+--since "yesterday"
+```
+
+**Implementation:**
+- `--include-steps`: Use POST `/nitestmonitor/v2/query-steps` with filter `resultId == @0` for each result
+- `--include-measurements`: Parse measurements from step `outputs` field (part of step data)
+- `--group-by`: Client-side grouping of results using POST `/nitestmonitor/v2/query-result-values` for efficient distinct value queries
+- `--summary`: Aggregate counts by status, program, etc. using client-side processing
+
+---
+
+#### 3. Add `testmonitor product get` command
+
+**Purpose:** Get detailed product information including test coverage
+
+```bash
+slcli testmonitor product get <id> \
+  --show-results         # Include recent results
+  --show-coverage        # Include test coverage stats
+  --format json
+```
+
+**Output example:**
+```json
+{
+  "id": "prod-123",
+  "name": "Product XYZ",
+  "partNumber": "XYZ-001",
+  "family": "TestFamily",
+  "workspace": "ws-456",
+  "coverage": {
+    "programs": ["Calibration", "Functional Test"],
+    "totalResults": 1250,
+    "passRate": 0.95,
+    "lastTested": "2026-02-05T10:30:00Z"
+  },
+  "recentResults": [...]
+}
+```
+
+---
+
+#### 4. Add `testmonitor result get` command
+
+**Purpose:** Get detailed result with steps and measurements
+
+```bash
+slcli testmonitor result get <id> \
+  --include-steps \
+  --include-measurements \
+  --format json
+```
+
+**Output example:**
+```json
+{
+  "id": "result-789",
+  "status": {"statusType": "PASSED", "statusName": "Passed"},
+  "programName": "Calibration",
+  "partNumber": "XYZ-001",
+  "serialNumber": "SN123456",
+  "startedAt": "2026-02-05T10:30:00Z",
+  "updatedAt": "2026-02-05T10:35:42Z",
+  "systemId": "sys-abc",
+  "hostName": "test-station-01",
+  "operator": "engineer@company.com",
+  "totalTimeInSeconds": 342.5,
+  "workspace": "f94b178e-288c-4101-afb1-833992413aa7",
+  "steps": [
+    {
+      "name": "DMM Voltage Test",
+      "stepType": "NumericLimitTest",
+      "stepId": "step-001",
+      "resultId": "result-789",
+      "path": ["Setup", "DMM Tests", "Voltage"],
+      "status": {"statusType": "PASSED", "statusName": "Passed"},
+      "totalTimeInSeconds": 5.2,
+      "outputs": [
+        {"name": "Voltage", "value": 5.01}
+      ],
+      "dataModel": "TestStand"
+    }
+  ]
+}
+```
+
+**Note:** Measurements are stored in the `outputs` array of each step, not as a separate entity.
+
+---
+
+#### 5. Keep Command Structure Simple
+
+**Proposed structure:**
+```
+slcli testmonitor
+├── product
+│   ├── list [current, enhanced with --summary, --show-paths]
+│   └── get [new: detailed product info]
+└── result
+    ├── list [current, enhanced with --include-steps, --group-by, --summary]
+    └── get [new: detailed result with steps/measurements]
+```
+
+**NOT creating separate:**
+- ❌ `testresult` (redundant with `testmonitor result`)
+- ❌ `teststep` (accessed via `result get --include-steps`)
+- ❌ `testpath` (accessed via `product list --show-paths`)
+- ❌ `testmeasurement` (accessed via `result get --include-measurements`)
+
+---
+
+## Rationale for Simplified Structure
+
+### 1. Aligns with API Structure
+The SystemLink Test Monitor API v2 is organized around four primary entities:
+- **Products** - Test specifications and metadata (part numbers, families, properties)
+- **Results** - Individual test executions (status, timestamps, system info)
+- **Steps** - Test execution steps within results (measurements, status, hierarchy)
+- **Paths** - Unique measurement paths across test programs
+
+While steps and paths have their own query endpoints, they are **conceptually nested**:
+- Steps belong to results (accessed via `resultId` filter)
+- Paths are derived from products (accessed via `partNumber` filter)
+- Measurements are stored in step `outputs` field (not a separate entity)
+
+This supports our simplified CLI structure where steps are accessed via `result get --include-steps`
+
+### 2. Matches User Mental Model
+Users think in terms of:
+- "List all failed tests for this product" → `result list`
+- "What products do we test?" → `product list`
+- "Show me details of this test run" → `result get`
+
+They don't think:
+- "Query test steps" (steps are part of results)
+- "Query test paths" (paths are product metadata)
+- "Query measurements" (measurements are in steps)
+
+### 3. Reduces Command Explosion
+Workflow analysis proposes:
+- `testresult` (7 subcommands)
+- `teststep` (3 subcommands)
+- `testpath` (3 subcommands)
+- `testmeasurement` (2 subcommands)
+= **15 new commands**
+
+Our proposal:
+- Enhance `testmonitor product list`
+- Enhance `testmonitor result list`
+- Add `testmonitor product get`
+- Add `testmonitor result get`
+= **2 new commands + enhancements to existing 2**
+
+### 4. Follows Established Patterns
+
+Similar commands in slcli:
+```bash
+# File service - single group, simple verbs
+slcli file list
+slcli file get <id>
+slcli file upload
+
+# Tag service - single group
+slcli tag list
+slcli tag get <path>
+slcli tag create
+
+# Notebook service - single group
+slcli notebook list
+slcli notebook get <id>
+slcli notebook execute
+```
+
+We should follow this pattern:
+```bash
+slcli testmonitor product list
+slcli testmonitor product get <id>
+slcli testmonitor result list
+slcli testmonitor result get <id>
+```
+
+---
+
+## Addressing Specific Workflow Requirements
+
+### Workflow 1: Failed measurements on product XYZ
+
+**Using enhanced commands:**
+```bash
+# Get all failed results with steps
+slcli testmonitor result list \
+  --part-number "XYZ" \
+  --status FAILED \
+  --started-after "2025-08-01" \
+  --include-steps \
+  --format json \
+  > failed-results.json
+
+# Analyze measurements (Copilot can parse JSON)
+# Or add summary flag:
+slcli testmonitor result list \
+  --part-number "XYZ" \
+  --status FAILED \
+  --started-after "2025-08-01" \
+  --summary \
+  --format table
+```
+
+**Summary output example:**
+```
+Product: XYZ
+Period: 2025-08-01 to 2026-01-31
+Failed Results: 45
+
+Top Failed Steps:
+  DMM Voltage Test: 23 failures
+  Frequency Response: 15 failures
+  Power Supply Test: 7 failures
+
+Programs:
+  Calibration: 30 failures
+  Functional Test: 15 failures
+```
+
+---
+
+### Workflow 6: Test data types for product
+
+**Using enhanced commands:**
+```bash
+# Product summary with test coverage
+slcli testmonitor product list \
+  --name "ABC123" \
+  --summary \
+  --show-paths \
+  --format table
+
+# Or get specific product
+slcli testmonitor product get <id> \
+  --show-coverage \
+  --format json
+```
+
+**Output example:**
+```
+Product: ABC123 (Part: ABC123-REV2)
+Workspace: Production
+
+Test Coverage:
+  Programs: Calibration, Functional Test, Burn-In
+  Paths: 156 unique measurement paths
+  Results: 2,340 total (95% pass rate)
+  Last Tested: 2026-02-05
+
+Common Measurements:
+  - Voltage (DC, AC)
+  - Current
+  - Resistance
+  - Frequency Response
+  - Power Consumption
+```
+
+---
+
+## Implementation Priority
+
+### Phase 1: Immediate (with current PR)
+- ✅ `testmonitor product list` (done)
+- ✅ `testmonitor result list` (done)
+- ✅ Comprehensive filtering (done)
+- ✅ Dynamic LINQ support (done)
+
+### Phase 2: Short-term (next sprint)
+- 🔨 Add `testmonitor product get <id>`
+- 🔨 Add `testmonitor result get <id>`
+- 🔨 Add `--include-steps` flag to `result get`
+- 🔨 Add `--include-measurements` flag to `result get`
+
+### Phase 3: Medium-term
+- 🔨 Add `--summary` flag to `product list` and `result list`
+- 🔨 Add `--group-by` flag to `result list`
+- 🔨 Add `--show-paths` flag to `product list`
+- 🔨 Add `--show-coverage` flag to `product get`
+- 🔨 Natural language date parsing ("2 quarters ago", "last week")
+
+### Phase 4: Future Enhancements
+- 🔨 Client-side aggregation and analytics
+- 🔨 Export capabilities (CSV, Excel)
+- 🔨 Statistical analysis (pass rates, trends)
+- 🔨 Cross-reference with assets/systems (when APIs available)
+
+---
+
+## API Requirements
+
+### Existing APIs (Available Now)
+
+**Product APIs:**
+- ✅ POST `/nitestmonitor/v2/query-products` - Query products with filters
+- ✅ GET `/nitestmonitor/v2/products/{productId}` - Get single product by ID
+- ✅ POST `/nitestmonitor/v2/products` - Create/update products
+- ✅ POST `/nitestmonitor/v2/update-products` - Batch update products
+- ✅ POST `/nitestmonitor/v2/delete-products` - Batch delete products
+- ✅ POST `/nitestmonitor/v2/query-product-values` - Query distinct field values
+
+**Result APIs:**
+- ✅ POST `/nitestmonitor/v2/query-results` - Query results with filters (supports continuation tokens)
+- ✅ GET `/nitestmonitor/v2/results/{resultId}` - Get single result by ID
+- ✅ POST `/nitestmonitor/v2/results` - Create results
+- ✅ POST `/nitestmonitor/v2/update-results` - Batch update results
+- ✅ POST `/nitestmonitor/v2/delete-results` - Batch delete results
+- ✅ POST `/nitestmonitor/v2/query-result-values` - Query distinct field values
+
+**Step APIs:**
+- ✅ POST `/nitestmonitor/v2/query-steps` - Query steps with filters (supports continuation tokens)
+- ✅ GET `/nitestmonitor/v2/results/{resultId}/steps/{stepId}` - Get single step
+- ✅ POST `/nitestmonitor/v2/steps` - Create steps
+- ✅ POST `/nitestmonitor/v2/update-steps` - Batch update steps
+- ✅ POST `/nitestmonitor/v2/delete-steps` - Batch delete steps
+- ✅ POST `/nitestmonitor/v2/query-step-values` - Query distinct field values
+
+**Path APIs:**
+- ✅ GET `/nitestmonitor/v2/paths` - List paths with query parameters
+- ✅ GET `/nitestmonitor/v2/paths/{pathId}` - Get single path by ID
+- ✅ POST `/nitestmonitor/v2/query-paths` - Query paths with filters
+
+### Implementation Notes
+
+**For `testmonitor result get --include-steps`:**
+- Use POST `/nitestmonitor/v2/query-steps` with filter: `resultId == @0`
+- All steps for a result can be retrieved in a single query
+- Steps support filtering by: name, stepType, stepId, parentId, path, totalTimeInSeconds, status, etc.
+
+**For `testmonitor product get --show-coverage`:**
+- Use POST `/nitestmonitor/v2/query-paths` with filter: `partNumber == @0`
+- Use POST `/nitestmonitor/v2/query-results` with product filter to get result counts
+- Client-side aggregation of pass rates, program names, and statistics
+
+**For `testmonitor result list --summary`:**
+- Query results normally
+- Client-side aggregation by status, program name, etc.
+- Use POST `/nitestmonitor/v2/query-result-values` to get distinct values for grouping
+
+**For `testmonitor product list --show-paths`:**
+- Use POST `/nitestmonitor/v2/query-paths` after product query
+- Match products to paths by partNumber field
+- Display common measurement paths
+
+### No New APIs Required
+
+All proposed enhancements can be implemented using existing Test Monitor v2 APIs through:
+- **Query APIs:** Full Dynamic LINQ filtering with continuation token pagination
+- **Value query APIs:** Efficient distinct value queries for grouping/summary
+- **Client-side processing:** Aggregation, grouping, and statistical analysis
+- **Multiple queries:** Combine product, result, step, and path queries as needed
+
+---
+
+## Comparison Table
+
+| Capability | Workflow Analysis | Counter-Proposal | Assessment |
+|-----------|------------------|------------------|------------|
+| List products | `testresult query` + `testpath query` | `testmonitor product list` | ✅ Simpler |
+| List results | `testresult query` | `testmonitor result list` | ✅ Equivalent |
+| Get result details | `testresult get <id>` | `testmonitor result get <id>` | ✅ Equivalent |
+| Include steps | `teststep query --filter resultId` | `result get --include-steps` | ✅ More intuitive |
+| Product summary | `testpath summary` + `testmetadata get` | `product get --show-coverage` | ✅ Simpler |
+| Measurements | `testmeasurement query` | `result get --include-measurements` | ✅ Logical grouping |
+| Failed analysis | `testresult analyze` | `result list --summary` | ✅ Integrated |
+| Cross-service | `testresult get-assets` | Future enhancement | ⚠️ API gap |
+
+---
+
+## Recommendation Summary
+
+### ✅ Accept Current Implementation
+The current `testmonitor` structure is **well-designed** and aligns with:
+- SystemLink API organization
+- User mental models
+- Established slcli patterns
+
+### 🔨 Enhance with Flags
+Add capabilities through **flags** rather than new command groups:
+- `--summary` for aggregated views
+- `--include-steps` for nested data
+- `--include-measurements` for measurement data
+- `--show-coverage` for test coverage
+- `--group-by` for organization
+
+### ❌ Reject Command Explosion
+Do NOT create separate:
+- `testresult` (redundant)
+- `teststep` (nested entity)
+- `testpath` (product metadata)
+- `testmeasurement` (nested entity)
+
+### 🎯 Focus on User Workflows
+Design commands around:
+1. **Discovery:** "What products/results exist?"
+2. **Filtering:** "Show me failed tests for product X"
+3. **Detail:** "Show me everything about this result"
+4. **Analysis:** "Summarize results by program/status"
+
+---
+
+## Conclusion
+
+The current `testmonitor` implementation provides a **strong foundation** that can be enhanced to meet all workflow requirements **without creating command bloat**. By adding flags like `--include-steps`, `--summary`, and `--show-coverage`, we can provide the same capabilities with a much simpler, more intuitive command structure.
+
+**Next Steps:**
+1. ✅ Merge current PR with `product list` and `result list`
+2. 🔨 Implement `product get` and `result get` commands
+3. 🔨 Add enhancement flags (`--include-steps`, `--summary`, etc.)
+4. 🔨 Add natural language date parsing
+5. 📊 Gather user feedback on command structure
+
+This approach keeps the CLI **simple, powerful, and maintainable** while fully satisfying the workflow analysis requirements.

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,53 @@
+## Summary
+
+Performance improvements, bug fixes, and a new Agent Skills definition for `slcli`.
+
+---
+
+### 🚀 Test Monitor performance improvements (`slcli/testmonitor_click.py`)
+
+- **Count-only queries for `--summary`**: Added `_query_counts_by_status()` which uses `returnCount: true` and `take: 0` per status type instead of fetching all results and aggregating client-side. Dramatically reduces data transfer for summary commands.
+- **Increased batch size**: Changed `_query_all_results()` page size from 100 → 1000 (API max) for faster full-result queries.
+- **Fixed `TIMEDOUT` enum**: API expects `TIMEDOUT` (no underscore), not `TIMED_OUT` as documented. Updated status type list accordingly.
+
+### 🖥️ System list improvements (`slcli/system_click.py`)
+
+- **Default `--take` changed to 100**: More useful default for fleet-level queries.
+- **`--take` now applies to JSON output**: Previously JSON ignored the take parameter; now it respects it.
+- **Conservative page size (100)**: Reduced internal `_query_all_items()` batch size from 1000 → 100 to avoid HTTP 500 errors from the Systems Management API.
+
+### 🔧 Asset create error handling (`slcli/asset_click.py`)
+
+- **Improved create response parsing**: Now inspects both `assets` and `failed` arrays from the API response.
+- **Non-zero exit on failure**: JSON output exits with `GENERAL_ERROR` when the `failed` array is non-empty and no assets were created.
+- **User-friendly error messages**: Table output now shows the server-provided error message on creation failure.
+
+### 📘 Agent Skills definition (`skills/slcli/`)
+
+New [Agent Skills](https://agentskills.io/specification) skill definition so AI agents can discover and effectively use `slcli`:
+
+- `skills/slcli/SKILL.md` — Frontmatter + full command reference with quick start, all filter options, and key rules
+- `skills/slcli/references/analysis-recipes.md` — 10 step-by-step recipes with `jq` post-processing for common data analysis questions
+- `skills/slcli/references/filtering.md` — Comprehensive filtering reference covering LINQ, Asset API expressions, System Management filters, sorting, enums
+
+### 🧪 Test updates
+
+- `tests/unit/test_testmonitor_click.py` — Updated mocks for count-only query approach
+- `tests/unit/test_system_click.py` — Updated expectations for new default take (100)
+- `tests/e2e/test_asset_e2e.py` — Added `--vendor-name` to create test to satisfy API validation
+
+---
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `slcli/testmonitor_click.py` | Count-only queries, batch size increase, TIMEDOUT fix |
+| `slcli/system_click.py` | Default take → 100, JSON take support, page size → 100 |
+| `slcli/asset_click.py` | Improved create error handling |
+| `skills/slcli/SKILL.md` | New Agent Skills definition |
+| `skills/slcli/references/analysis-recipes.md` | Analysis recipes for 10 common questions |
+| `skills/slcli/references/filtering.md` | Filtering reference guide |
+| `tests/unit/test_testmonitor_click.py` | Updated mocks |
+| `tests/unit/test_system_click.py` | Updated default take expectations |
+| `tests/e2e/test_asset_e2e.py` | Added vendor-name to create test |

--- a/skills/slcli/SKILL.md
+++ b/skills/slcli/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: slcli
+description: >-
+  Query and manage NI SystemLink resources including test results, assets, systems,
+  products, tags, feeds, and workspaces using the slcli command-line interface.
+  Use when the user asks about test data analysis, asset management, calibration status,
+  system fleet health, operator performance, failure analysis, production metrics,
+  equipment utilization, or any SystemLink resource operations. Supports filtering,
+  aggregation, summary statistics, and JSON output for programmatic processing.
+compatibility: >-
+  Requires slcli installed and authenticated (slcli login). Python 3.10+.
+  Requires network access to a SystemLink server instance.
+metadata:
+  author: ni-kismet
+  version: "1.0"
+---
+
+# SystemLink CLI (slcli)
+
+## Quick start
+
+```bash
+# check current connection
+slcli info
+
+# list test results (table output, paginated)
+slcli testmonitor result list --take 25
+
+# list test results (JSON output, all results)
+slcli testmonitor result list --take 100 -f json
+
+# summarize test results by status
+slcli testmonitor result list --summary --group-by status -f json
+
+# list assets needing calibration
+slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE
+
+# list connected systems
+slcli system list --state CONNECTED
+```
+
+## Output formats
+
+All list and get commands support `-f, --format` with `table` (default) or `json`.
+
+- **Table**: Paginated (default 25 rows), human-readable with box-drawing.
+- **JSON**: Returns all matching results as a JSON array — ideal for piping to `jq`.
+
+Always use `-f json` when you need to process, filter, or aggregate output programmatically.
+
+## Commands
+
+### testmonitor — Test data analysis
+
+The primary command group for test result queries and product analysis.
+
+```bash
+# List results with filters
+slcli testmonitor result list [OPTIONS]
+
+# Convenience filters (combine freely)
+  --status TEXT              # PASSED, FAILED, RUNNING, ERRORED, TERMINATED, TIMEDOUT, etc.
+  --program-name TEXT        # Filter by test program name (contains)
+  --serial-number TEXT       # Filter by DUT serial number (contains)
+  --part-number TEXT         # Filter by part number (contains)
+  --operator TEXT            # Filter by operator name (contains)
+  --host-name TEXT           # Filter by test host (contains)
+  --system-id TEXT           # Filter by system ID (exact)
+  --workspace, -w TEXT       # Filter by workspace name or ID
+
+# Advanced filtering
+  --filter TEXT              # Dynamic LINQ expression
+  --substitution TEXT        # Parameterized value for --filter (repeatable)
+  --product-filter TEXT      # LINQ filter on associated products
+  --product-substitution TEXT # Parameterized value for --product-filter (repeatable)
+
+# Sorting
+  --order-by CHOICE          # ID, STARTED_AT, UPDATED_AT, PROGRAM_NAME, SYSTEM_ID,
+                             # HOST_NAME, OPERATOR, SERIAL_NUMBER, PART_NUMBER,
+                             # TOTAL_TIME_IN_SECONDS, PROPERTIES
+  --descending / --ascending # Default: descending
+
+# Aggregation
+  --summary                  # Show summary statistics instead of individual results
+  --group-by CHOICE          # status, programName, serialNumber, operator, hostName, systemId
+
+# Pagination & output
+  --take, -t INTEGER         # Items per page (default 25)
+  --format, -f [table|json]  # Output format (default: table)
+
+# Get a single result
+slcli testmonitor result get <RESULT_ID> [--include-steps] [-f json]
+
+# List products
+slcli testmonitor product list [OPTIONS]
+  --name TEXT                # Filter by product name (contains)
+  --part-number TEXT         # Filter by part number (contains)
+  --family TEXT              # Filter by product family (contains)
+  --workspace, -w TEXT       # Filter by workspace name or ID
+  --summary                  # Show summary statistics
+  --take, -t INTEGER         # Items per page (default 25)
+  -f [table|json]
+
+# Get a single product
+slcli testmonitor product get <PRODUCT_ID> [-f json]
+```
+
+### asset — Asset and calibration management
+
+```bash
+# List assets with filters
+slcli asset list [OPTIONS]
+
+# Convenience filters
+  --model TEXT               # Filter by model name (contains)
+  --serial-number TEXT       # Filter by serial number (exact)
+  --bus-type CHOICE          # BUILT_IN_SYSTEM, PCI_PXI, USB, GPIB, VXI, SERIAL, TCP_IP, CRIO
+  --asset-type CHOICE        # GENERIC, DEVICE_UNDER_TEST, FIXTURE, SYSTEM
+  --calibration-status CHOICE # OK, APPROACHING_RECOMMENDED_DUE_DATE,
+                              # PAST_RECOMMENDED_DUE_DATE, OUT_FOR_CALIBRATION
+  --connected                # Only assets in connected systems
+  --calibratable             # Only calibratable assets
+  --workspace, -w TEXT       # Filter by workspace name or ID
+
+# Advanced filtering
+  --filter TEXT              # Asset API expression (e.g., 'ModelName.Contains("PXI")')
+
+# Sorting & output
+  --order-by CHOICE          # Sort field
+  --descending / --ascending
+  --take, -t INTEGER         # Default 25
+  -f [table|json]
+
+# Other asset commands
+slcli asset get <ASSET_ID> [-f json]
+slcli asset summary [-f json]                       # Fleet-wide statistics
+slcli asset calibration <ASSET_ID> [-f json]        # Calibration history
+slcli asset location-history <ASSET_ID> [-f json]   # Location/connection history
+slcli asset create --model-name TEXT [OPTIONS]       # Create an asset
+slcli asset update <ASSET_ID> [OPTIONS]              # Update an asset
+slcli asset delete <ASSET_ID>                        # Delete an asset
+```
+
+### system — System fleet management
+
+```bash
+# List systems with filters
+slcli system list [OPTIONS]
+
+# Convenience filters
+  --alias, -a TEXT           # Filter by alias (contains)
+  --state CHOICE             # CONNECTED, DISCONNECTED, VIRTUAL, APPROVED, etc.
+  --os TEXT                  # Filter by OS/kernel (contains)
+  --host TEXT                # Filter by hostname (contains)
+  --has-package TEXT         # Systems with installed package (contains, client-side)
+  --has-keyword TEXT         # Systems with keyword (repeatable)
+  --property TEXT            # Property key=value filter (repeatable)
+  --workspace, -w TEXT       # Filter by workspace name or ID
+
+# Advanced filtering
+  --filter TEXT              # Systems Management filter expression
+                             # e.g., 'connected.data.state = "CONNECTED"'
+
+# Output
+  --take, -t INTEGER         # Default 100
+  -f [table|json]
+
+# Other system commands
+slcli system get <SYSTEM_ID> [-f json]
+slcli system summary [-f json]                      # Fleet-wide statistics
+slcli system report --type [SOFTWARE|HARDWARE] -o FILE  # Generate CSV report
+slcli system update <SYSTEM_ID> [OPTIONS]            # Update system metadata
+slcli system remove <SYSTEM_ID>                      # Remove a system
+
+# System jobs
+slcli system job list [OPTIONS]
+slcli system job get <JOB_ID>
+slcli system job summary [-f json]
+slcli system job cancel <JOB_ID>
+```
+
+### tag — Tag operations
+
+```bash
+slcli tag list [OPTIONS]
+slcli tag get-value <TAG_PATH>
+slcli tag set-value <TAG_PATH> <VALUE>
+slcli tag create --path <PATH> --data-type <TYPE>
+slcli tag delete <TAG_PATH>
+```
+
+### workspace — Workspace management
+
+```bash
+slcli workspace list [-f json]
+slcli workspace get <WORKSPACE_ID> [-f json]
+```
+
+## Recipes: answering analysis questions
+
+See [references/analysis-recipes.md](references/analysis-recipes.md) for detailed
+multi-step recipes covering operator performance, calibration tracking, capacity
+planning, yield analysis, and failure pattern investigation.
+
+## Filtering guide
+
+See [references/filtering.md](references/filtering.md) for detailed filtering
+syntax, advanced LINQ expressions, and parameterized query examples.
+
+## Key rules
+
+1. **Always use `-f json`** when piping output to `jq` or doing programmatic analysis.
+2. **Use `--summary --group-by`** for aggregation instead of fetching all records and counting.
+3. **Use convenience filters first** (e.g., `--status FAILED`), fall back to `--filter` for complex queries.
+4. **Parameterize `--filter` queries** — use `--substitution` instead of string interpolation.
+5. **Combine filters** — convenience filters are ANDed together automatically.
+6. **Use `--take`** to control result volume; JSON returns all matching up to `--take`.
+7. **Status enum values**: `PASSED`, `FAILED`, `RUNNING`, `ERRORED`, `TERMINATED`, `TIMEDOUT`, `WAITING`, `SKIPPED`, `CUSTOM`.
+8. **Exit codes**: 0 = success, 1 = general error, 2 = invalid input, 3 = not found, 4 = permission denied, 5 = network error.

--- a/skills/slcli/references/analysis-recipes.md
+++ b/skills/slcli/references/analysis-recipes.md
@@ -1,0 +1,350 @@
+# Analysis Recipes
+
+Step-by-step recipes for answering common data analysis questions with `slcli`.
+Each recipe maps to a real-world scenario and shows the exact commands needed.
+
+---
+
+## Recipe 1: Operator failure rate analysis
+
+**Question:** Which operators have the highest failure rates and what should they
+focus on?
+
+**Steps:**
+
+```bash
+# Step 1: Get summary by operator to see total counts per operator
+slcli testmonitor result list --summary --group-by operator -f json
+
+# Step 2: Get failed counts per operator
+slcli testmonitor result list --status FAILED --summary --group-by operator -f json
+
+# Step 3: Deep-dive into a specific operator's failures
+slcli testmonitor result list --operator "xli" --status FAILED -f json --take 500
+
+# Step 4: See which programs the operator fails on most
+slcli testmonitor result list --operator "xli" --status FAILED --summary --group-by programName -f json
+```
+
+**Post-processing with jq:**
+
+```bash
+# Calculate failure rate per operator (combine step 1 and 2 outputs)
+slcli testmonitor result list --operator "xli" -f json --take 500 | \
+  jq '[group_by(.status.statusType) | .[] | {status: .[0].status.statusType, count: length}]'
+```
+
+---
+
+## Recipe 2: Calibration overdue tracking
+
+**Question:** Which assets are most overdue for calibration and what test
+capacity is at risk?
+
+**Steps:**
+
+```bash
+# Step 1: List all assets past calibration due date
+slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE -f json --take 100
+
+# Step 2: Get the fleet-wide calibration summary
+slcli asset summary -f json
+
+# Step 3: Check assets approaching due date (proactive)
+slcli asset list --calibration-status APPROACHING_RECOMMENDED_DUE_DATE -f json
+
+# Step 4: Get calibration history for a specific overdue asset
+slcli asset calibration <ASSET_ID> -f json
+
+# Step 5: Check which system the asset belongs to
+slcli asset location-history <ASSET_ID> -f json
+```
+
+**Post-processing with jq:**
+
+```bash
+# Group overdue assets by model
+slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE -f json --take 200 | \
+  jq '[group_by(.modelName) | .[] | {model: .[0].modelName, count: length}] | sort_by(-.count)'
+
+# Find overdue assets in connected systems (blocking test execution)
+slcli asset list --calibration-status PAST_RECOMMENDED_DUE_DATE --connected -f json --take 200 | \
+  jq 'length'
+```
+
+---
+
+## Recipe 3: Test time distribution and bottleneck identification
+
+**Question:** What is the test time distribution across stations and where are
+bottlenecks?
+
+**Steps:**
+
+```bash
+# Step 1: Get results with execution time, grouped by host
+slcli testmonitor result list -f json --take 500 --order-by TOTAL_TIME_IN_SECONDS --descending
+
+# Step 2: Summarize by host to find busiest stations
+slcli testmonitor result list --summary --group-by hostName -f json
+
+# Step 3: Drill into slowest host
+slcli testmonitor result list --host-name "station-01" -f json --take 200 \
+  --order-by TOTAL_TIME_IN_SECONDS --descending
+```
+
+**Post-processing with jq:**
+
+```bash
+# Calculate average test duration per host
+slcli testmonitor result list -f json --take 1000 | \
+  jq '[group_by(.hostName) | .[] | {
+    host: .[0].hostName,
+    count: length,
+    avg_seconds: ([.[].totalTimeInSeconds] | add / length),
+    max_seconds: ([.[].totalTimeInSeconds] | max)
+  }] | sort_by(-.avg_seconds)'
+
+# Find outlier tests (> 2x average duration)
+slcli testmonitor result list -f json --take 1000 | \
+  jq '(([.[].totalTimeInSeconds] | add / length) * 2) as $threshold |
+      [.[] | select(.totalTimeInSeconds > $threshold)] | length'
+```
+
+---
+
+## Recipe 4: System capability discovery
+
+**Question:** Which connected systems lack specific measurement capabilities?
+
+**Steps:**
+
+```bash
+# Step 1: List all connected systems
+slcli system list --state CONNECTED -f json --take 200
+
+# Step 2: Get assets for a specific system
+slcli asset list --filter 'ParentId = @0' --substitution "<SYSTEM_ID>" -f json
+
+# Step 3: Generate a hardware report
+slcli system report --type HARDWARE -o hardware_report.csv
+
+# Step 4: Check systems with specific packages
+slcli system list --has-package "DAQmx" --state CONNECTED -f json
+```
+
+**Post-processing with jq:**
+
+```bash
+# List connected systems and their OS
+slcli system list --state CONNECTED -f json --take 500 | \
+  jq '[.[] | {alias, id, os: .grains.kernel}]'
+```
+
+---
+
+## Recipe 5: Product yield analysis
+
+**Question:** How many units per product variant are past their first-pass yield
+expectations?
+
+**Steps:**
+
+```bash
+# Step 1: List products with battery part numbers
+slcli testmonitor product list --part-number "BATT" -f json
+
+# Step 2: Get summary for a specific product
+slcli testmonitor product list --part-number "BATT-8" --summary -f json
+
+# Step 3: Get pass/fail breakdown for a product
+slcli testmonitor result list --part-number "BATT-8" --summary --group-by status -f json
+
+# Step 4: Compare across all battery products
+for i in $(seq 0 14); do
+  echo "BATT-$i:"
+  slcli testmonitor result list --part-number "BATT-$i" --summary --group-by status -f json
+done
+```
+
+**Post-processing with jq:**
+
+```bash
+# Calculate yield rate for a part number
+slcli testmonitor result list --part-number "BATT-8" -f json --take 1000 | \
+  jq '{
+    total: length,
+    passed: [.[] | select(.status.statusType == "PASSED")] | length,
+    failed: [.[] | select(.status.statusType == "FAILED")] | length
+  } | . + {yield_pct: (100 * .passed / .total | round)}'
+```
+
+---
+
+## Recipe 6: Test program runtime analysis
+
+**Question:** Which test programs have the longest runtimes?
+
+**Steps:**
+
+```bash
+# Step 1: Summarize by program name
+slcli testmonitor result list --summary --group-by programName -f json
+
+# Step 2: Get detailed results for the longest program
+slcli testmonitor result list --program-name "SOH_SCT_HPPC" -f json --take 200 \
+  --order-by TOTAL_TIME_IN_SECONDS --descending
+
+# Step 3: Compare program variants
+slcli testmonitor result list --program-name "SOH_SCT_HPPC_0" -f json --take 100
+slcli testmonitor result list --program-name "SOH_SCT_HPPC_5" -f json --take 100
+```
+
+**Post-processing with jq:**
+
+```bash
+# Top 5 programs by average runtime
+slcli testmonitor result list -f json --take 2000 | \
+  jq '[group_by(.programName) | .[] | {
+    program: .[0].programName,
+    count: length,
+    avg_seconds: ([.[].totalTimeInSeconds] | add / length | . * 100 | round / 100),
+    total_hours: ([.[].totalTimeInSeconds] | add / 3600 | . * 100 | round / 100)
+  }] | sort_by(-.avg_seconds) | .[:5]'
+```
+
+---
+
+## Recipe 7: Location-based failure analysis
+
+**Question:** Are there facility-specific issues causing higher failure rates?
+
+**Steps:**
+
+```bash
+# Step 1: List all systems to understand location naming conventions
+slcli system list -f json --take 200 | jq '[.[].alias] | unique'
+
+# Step 2: Get failure counts per system
+slcli testmonitor result list --status FAILED --summary --group-by systemId -f json
+
+# Step 3: Get total counts per system for rate calculation
+slcli testmonitor result list --summary --group-by systemId -f json
+
+# Step 4: Drill into a system with high failure rate
+slcli testmonitor result list --system-id "<SYSTEM_ID>" --status FAILED -f json --take 100
+```
+
+---
+
+## Recipe 8: Fixture calibration and capacity planning
+
+**Question:** Which PAtools fixtures need recalibration soon and what capacity
+would we lose?
+
+**Steps:**
+
+```bash
+# Step 1: List all PAtools fixtures
+slcli asset list --filter 'VendorName.Contains("PAtools")' --asset-type FIXTURE -f json
+
+# Step 2: Filter for those approaching calibration due date
+slcli asset list --filter 'VendorName.Contains("PAtools")' --asset-type FIXTURE \
+  --calibration-status APPROACHING_RECOMMENDED_DUE_DATE -f json
+
+# Step 3: Get overall fixture summary
+slcli asset summary -f json
+```
+
+**Post-processing with jq:**
+
+```bash
+# Count fixtures by calibration status
+slcli asset list --filter 'VendorName.Contains("PAtools")' --asset-type FIXTURE -f json --take 100 | \
+  jq '[group_by(.calibrationStatus) | .[] | {status: .[0].calibrationStatus, count: length}]'
+```
+
+---
+
+## Recipe 9: Product family workload distribution
+
+**Question:** How is test execution distributed across product families?
+
+**Steps:**
+
+```bash
+# Step 1: List all products to see families
+slcli testmonitor product list -f json --take 100
+
+# Step 2: Summarize by product family
+slcli testmonitor product list --summary -f json
+
+# Step 3: Get result volume per part number
+slcli testmonitor result list --summary --group-by programName -f json
+```
+
+**Post-processing with jq:**
+
+```bash
+# Group products by family prefix
+slcli testmonitor product list -f json --take 100 | \
+  jq '[group_by(.family) | .[] | {family: .[0].family, products: length}] | sort_by(-.products)'
+
+# Get execution volume grouped by part-number prefix
+slcli testmonitor result list -f json --take 2000 | \
+  jq '[group_by(.partNumber | split("-")[0]) | .[] | {
+    family: .[0].partNumber | split("-")[0],
+    executions: length,
+    total_hours: ([.[].totalTimeInSeconds] | add / 3600 | . * 10 | round / 10)
+  }] | sort_by(-.executions)'
+```
+
+---
+
+## Recipe 10: Environmental condition failure patterns
+
+**Question:** Are failures concentrated in specific operating condition ranges?
+
+**Steps:**
+
+```bash
+# Step 1: Get failed results with properties
+slcli testmonitor result list --status FAILED -f json --take 500
+
+# Step 2: Get detailed result with step data for environmental readings
+slcli testmonitor result get <RESULT_ID> --include-steps -f json
+
+# Step 3: Compare passed vs. failed property distributions
+slcli testmonitor result list --status PASSED -f json --take 500
+slcli testmonitor result list --status FAILED -f json --take 500
+```
+
+**Post-processing with jq:**
+
+```bash
+# Extract temperature and voltage from failed results
+slcli testmonitor result list --status FAILED -f json --take 500 | \
+  jq '[.[] | select(.properties != null) | {
+    partNumber,
+    programName,
+    properties: (.properties | to_entries | map(select(.key | test("Temp|Volt|Capacity"; "i"))))
+  }] | [.[] | select(.properties | length > 0)]'
+
+# Compare property distributions between passed and failed
+slcli testmonitor result list --status FAILED --part-number "BATT-8" -f json --take 200 | \
+  jq '[.[].totalTimeInSeconds] | {min: min, max: max, avg: (add / length | round)}'
+```
+
+---
+
+## General tips
+
+- **Start with `--summary`** to understand data shape before fetching raw records.
+- **Use `--group-by`** with `--summary` for aggregation: `status`, `programName`,
+  `serialNumber`, `operator`, `hostName`, `systemId`.
+- **Chain with `jq`** for complex transformations — always use `-f json`.
+- **Use `--take` wisely** — start small (100-500), increase if needed.
+- **For rate calculations**, query total count and filtered count separately, then divide.
+- **Use `--order-by TOTAL_TIME_IN_SECONDS --descending`** to find slowest tests quickly.
+- **Asset `--connected` flag** limits to assets in currently connected systems.
+- **System `--has-package`** filter is client-side — use with `--state CONNECTED` to reduce volume.

--- a/skills/slcli/references/filtering.md
+++ b/skills/slcli/references/filtering.md
@@ -69,10 +69,10 @@ Test Monitor uses Dynamic LINQ filter expressions.
 
 ```bash
 # Status filter
---filter 'status.statusType = "FAILED"'
+--filter 'status.statusType == "FAILED"'
 
 # Combined filters
---filter 'partNumber.Contains("ABC") and programName = "TestProgram"'
+--filter 'partNumber.Contains("ABC") and programName == "TestProgram"'
 
 # Date-based filtering
 --filter 'startedAt > DateTime(2026, 1, 1)'
@@ -85,7 +85,7 @@ Test Monitor uses Dynamic LINQ filter expressions.
 
 ```bash
 # Good — parameterized
---filter 'programName = @0' --substitution "SOH_SCT_HPPC_0"
+--filter 'programName == @0' --substitution "SOH_SCT_HPPC_0"
 
 # Bad — string interpolation (security risk)
 --filter "programName = '${PROGRAM}'"
@@ -94,7 +94,7 @@ Test Monitor uses Dynamic LINQ filter expressions.
 Multiple substitutions are positional:
 
 ```bash
---filter 'programName = @0 and operator = @1' \
+--filter 'programName == @0 and operator == @1' \
   --substitution "SOH_SCT_HPPC_0" \
   --substitution "xli"
 ```
@@ -105,7 +105,7 @@ Filter results by properties of their associated product:
 
 ```bash
 slcli testmonitor result list \
-  --product-filter 'family = @0' \
+  --product-filter 'family == @0' \
   --product-substitution "Battery"
 ```
 
@@ -118,10 +118,10 @@ Asset filtering uses the Asset API expression language:
 --filter 'ModelName.Contains("PXI")'
 
 # Exact match
---filter 'SerialNumber = "01BB877A"'
+--filter 'SerialNumber == "01BB877A"'
 
 # Combined with logical operators
---filter 'BusType = "PCI_PXI" and CalibrationStatus = "OK"'
+--filter 'BusType == "PCI_PXI" and CalibrationStatus == "OK"'
 
 # Vendor filtering
 --filter 'VendorName.Contains("PAtools")'
@@ -136,13 +136,13 @@ System filtering uses nested property access:
 
 ```bash
 # Connection state (nested property)
---filter 'connected.data.state = "CONNECTED"'
+--filter 'connected.data.state == "CONNECTED"'
 
 # OS filtering
---filter 'grains.data.kernel = "Windows"'
+--filter 'grains.data.kernel == "Windows"'
 
 # Combined
---filter 'connected.data.state = "CONNECTED" and grains.data.kernel = "Windows"'
+--filter 'connected.data.state == "CONNECTED" and grains.data.kernel == "Windows"'
 
 # Alias matching
 --filter 'alias.Contains("PXI")'

--- a/skills/slcli/references/filtering.md
+++ b/skills/slcli/references/filtering.md
@@ -1,0 +1,236 @@
+# Filtering Reference
+
+Detailed guide to filtering syntax across slcli command groups.
+
+---
+
+## Convenience filters
+
+Convenience filters are named options that map to common query patterns. When
+multiple convenience filters are specified, they are combined with AND logic.
+
+### Test Monitor results
+
+| Flag                   | Match type | Example                    |
+| ---------------------- | ---------- | -------------------------- |
+| `--status TEXT`        | Exact      | `--status FAILED`          |
+| `--program-name TEXT`  | Contains   | `--program-name "SOH_SCT"` |
+| `--serial-number TEXT` | Contains   | `--serial-number "1234"`   |
+| `--part-number TEXT`   | Contains   | `--part-number "BATT-8"`   |
+| `--operator TEXT`      | Contains   | `--operator "xli"`         |
+| `--host-name TEXT`     | Contains   | `--host-name "station-01"` |
+| `--system-id TEXT`     | Exact      | `--system-id "abc-123"`    |
+| `--workspace, -w TEXT` | Name or ID | `--workspace "Production"` |
+
+### Test Monitor products
+
+| Flag                   | Match type | Example                    |
+| ---------------------- | ---------- | -------------------------- |
+| `--name TEXT`          | Contains   | `--name "Battery"`         |
+| `--part-number TEXT`   | Contains   | `--part-number "BATT"`     |
+| `--family TEXT`        | Contains   | `--family "Sensors"`       |
+| `--workspace, -w TEXT` | Name or ID | `--workspace "Production"` |
+
+### Assets
+
+| Flag                          | Match type     | Example                                          |
+| ----------------------------- | -------------- | ------------------------------------------------ |
+| `--model TEXT`                | Contains       | `--model "4071"`                                 |
+| `--serial-number TEXT`        | Exact          | `--serial-number "01BB877A"`                     |
+| `--bus-type CHOICE`           | Exact enum     | `--bus-type PCI_PXI`                             |
+| `--asset-type CHOICE`         | Exact enum     | `--asset-type FIXTURE`                           |
+| `--calibration-status CHOICE` | Exact enum     | `--calibration-status PAST_RECOMMENDED_DUE_DATE` |
+| `--connected`                 | Flag (boolean) | `--connected`                                    |
+| `--calibratable`              | Flag (boolean) | `--calibratable`                                 |
+| `--workspace, -w TEXT`        | Name or ID     | `--workspace "Production"`                       |
+
+### Systems
+
+| Flag                   | Match type             | Example                        |
+| ---------------------- | ---------------------- | ------------------------------ |
+| `--alias, -a TEXT`     | Contains               | `--alias "PXI"`                |
+| `--state CHOICE`       | Exact enum             | `--state CONNECTED`            |
+| `--os TEXT`            | Contains               | `--os "Windows"`               |
+| `--host TEXT`          | Contains               | `--host "lab-01"`              |
+| `--has-package TEXT`   | Contains (client-side) | `--has-package "DAQmx"`        |
+| `--has-keyword TEXT`   | Exact (repeatable)     | `--has-keyword "production"`   |
+| `--property TEXT`      | key=value (repeatable) | `--property "location=Austin"` |
+| `--workspace, -w TEXT` | Name or ID             | `--workspace "Production"`     |
+
+---
+
+## Advanced filter expressions
+
+Use `--filter` for complex queries that go beyond convenience filters.
+
+### Test Monitor LINQ syntax
+
+Test Monitor uses Dynamic LINQ filter expressions.
+
+```bash
+# Status filter
+--filter 'status.statusType = "FAILED"'
+
+# Combined filters
+--filter 'partNumber.Contains("ABC") and programName = "TestProgram"'
+
+# Date-based filtering
+--filter 'startedAt > DateTime(2026, 1, 1)'
+
+# Numeric comparison
+--filter 'totalTimeInSeconds > 300'
+```
+
+**Important:** Always use parameterized queries with `--substitution`:
+
+```bash
+# Good — parameterized
+--filter 'programName = @0' --substitution "SOH_SCT_HPPC_0"
+
+# Bad — string interpolation (security risk)
+--filter "programName = '${PROGRAM}'"
+```
+
+Multiple substitutions are positional:
+
+```bash
+--filter 'programName = @0 and operator = @1' \
+  --substitution "SOH_SCT_HPPC_0" \
+  --substitution "xli"
+```
+
+### Product filtering with `--product-filter`
+
+Filter results by properties of their associated product:
+
+```bash
+slcli testmonitor result list \
+  --product-filter 'family = @0' \
+  --product-substitution "Battery"
+```
+
+### Asset API expression syntax
+
+Asset filtering uses the Asset API expression language:
+
+```bash
+# Property access with methods
+--filter 'ModelName.Contains("PXI")'
+
+# Exact match
+--filter 'SerialNumber = "01BB877A"'
+
+# Combined with logical operators
+--filter 'BusType = "PCI_PXI" and CalibrationStatus = "OK"'
+
+# Vendor filtering
+--filter 'VendorName.Contains("PAtools")'
+
+# Combined with convenience filters
+slcli asset list --asset-type FIXTURE --filter 'VendorName.Contains("PAtools")'
+```
+
+### Systems Management filter syntax
+
+System filtering uses nested property access:
+
+```bash
+# Connection state (nested property)
+--filter 'connected.data.state = "CONNECTED"'
+
+# OS filtering
+--filter 'grains.data.kernel = "Windows"'
+
+# Combined
+--filter 'connected.data.state = "CONNECTED" and grains.data.kernel = "Windows"'
+
+# Alias matching
+--filter 'alias.Contains("PXI")'
+```
+
+---
+
+## Sorting
+
+Most list commands support `--order-by` and `--descending / --ascending`.
+
+### Test Monitor result sort fields
+
+`ID`, `STARTED_AT`, `UPDATED_AT`, `PROGRAM_NAME`, `SYSTEM_ID`, `HOST_NAME`,
+`OPERATOR`, `SERIAL_NUMBER`, `PART_NUMBER`, `TOTAL_TIME_IN_SECONDS`, `PROPERTIES`
+
+Default: `STARTED_AT` descending.
+
+```bash
+# Slowest tests first
+slcli testmonitor result list --order-by TOTAL_TIME_IN_SECONDS --descending
+
+# Oldest first
+slcli testmonitor result list --order-by STARTED_AT --ascending
+```
+
+---
+
+## Aggregation with --summary
+
+The `--summary` flag returns aggregate counts instead of individual records.
+Combine with `--group-by` for grouped aggregation.
+
+```bash
+# Total counts by status
+slcli testmonitor result list --summary --group-by status -f json
+
+# Counts by operator
+slcli testmonitor result list --summary --group-by operator -f json
+
+# Filtered summary — failures by program
+slcli testmonitor result list --status FAILED --summary --group-by programName -f json
+
+# Product summary
+slcli testmonitor product list --summary -f json
+```
+
+Available `--group-by` values: `status`, `programName`, `serialNumber`,
+`operator`, `hostName`, `systemId`.
+
+---
+
+## Pagination
+
+- **Table output**: Paginated interactively (default 25 rows, Y/n prompt for next page).
+- **JSON output**: Returns all results up to `--take` limit in a single array.
+- **`--take, -t`**: Controls maximum items. Default 25 for most commands, 100 for systems.
+
+```bash
+# Get exactly 500 results as JSON
+slcli testmonitor result list -f json --take 500
+
+# Get first 10 in table
+slcli testmonitor result list --take 10
+```
+
+---
+
+## Enum values reference
+
+### Status types (Test Monitor)
+
+`PASSED`, `FAILED`, `RUNNING`, `ERRORED`, `TERMINATED`, `TIMEDOUT`, `WAITING`,
+`SKIPPED`, `CUSTOM`
+
+### Calibration status (Assets)
+
+`OK`, `APPROACHING_RECOMMENDED_DUE_DATE`, `PAST_RECOMMENDED_DUE_DATE`,
+`OUT_FOR_CALIBRATION`
+
+### Asset types
+
+`GENERIC`, `DEVICE_UNDER_TEST`, `FIXTURE`, `SYSTEM`
+
+### Bus types (Assets)
+
+`BUILT_IN_SYSTEM`, `PCI_PXI`, `USB`, `GPIB`, `VXI`, `SERIAL`, `TCP_IP`, `CRIO`
+
+### System states
+
+`CONNECTED`, `DISCONNECTED`, `VIRTUAL`, `APPROVED`

--- a/slcli/asset_click.py
+++ b/slcli/asset_click.py
@@ -1074,22 +1074,34 @@ def register_asset_commands(cli: Any) -> None:
 
             if format_output.lower() == "json":
                 click.echo(json.dumps(result_data, indent=2))
-                # Exit with error if asset creation failed
-                if failed and not assets:
+                # Exit with error if any assets failed (complete or partial failure)
+                if failed:
                     sys.exit(ExitCodes.GENERAL_ERROR)
             else:
-                if assets:
+                if assets and failed:
+                    # Partial success: show success but warn about failures
+                    format_success(
+                        "Asset created",
+                        {"Model": model_name, "Serial": serial_number or "N/A"},
+                    )
+                    error_info = failed[0] if failed else {}
+                    error_msg = error_info.get("error", {}).get("message", "Unknown error")
+                    click.echo(f"⚠ Warning: Some assets failed to create: {error_msg}", err=True)
+                    sys.exit(ExitCodes.GENERAL_ERROR)
+                elif assets:
+                    # Complete success
                     format_success(
                         "Asset created",
                         {"Model": model_name, "Serial": serial_number or "N/A"},
                     )
                 elif failed:
-                    # Asset creation failed
+                    # Complete failure
                     error_info = failed[0] if failed else {}
                     error_msg = error_info.get("error", {}).get("message", "Unknown error")
                     click.echo(f"✗ Asset creation failed: {error_msg}", err=True)
                     sys.exit(ExitCodes.GENERAL_ERROR)
                 else:
+                    # Edge case: empty response
                     format_success(
                         "Asset created",
                         {"Model": model_name, "Serial": serial_number or "N/A"},

--- a/slcli/system_click.py
+++ b/slcli/system_click.py
@@ -421,8 +421,9 @@ def _handle_interactive_pagination(
 
     skip = 0
     shown_count = 0
-    # When using client-side filtering we fetch larger batches
-    fetch_size = 1000 if client_filter else take
+    # When using client-side filtering we fetch larger batches, but use
+    # conservative size (100) to avoid HTTP 500 errors from the Systems API
+    fetch_size = 100 if client_filter else take
 
     while True:
         page_items = _fetch_page(
@@ -829,7 +830,10 @@ def register_system_commands(cli: Any) -> None:
         type=int,
         default=100,
         show_default=True,
-        help="Maximum number of items to return",
+        help=(
+            "Number of items per page for table output; maximum number of items "
+            "to return for JSON"
+        ),
     )
     @click.option("--alias", "-a", help="Filter by system alias (contains match)")
     @click.option(

--- a/slcli/system_click.py
+++ b/slcli/system_click.py
@@ -301,7 +301,7 @@ def _query_all_items(
         List of item objects (up to ``take`` count).
     """
     all_items: List[Dict[str, Any]] = []
-    page_size = 1000  # API max per request
+    page_size = 100  # Use conservative batch size to avoid 500 errors
     skip = 0
 
     while True:
@@ -827,9 +827,9 @@ def register_system_commands(cli: Any) -> None:
         "--take",
         "-t",
         type=int,
-        default=25,
+        default=100,
         show_default=True,
-        help="Items per page (table output only)",
+        help="Maximum number of items to return",
     )
     @click.option("--alias", "-a", help="Filter by system alias (contains match)")
     @click.option(
@@ -974,6 +974,7 @@ def register_system_commands(cli: Any) -> None:
                     api_order_by,
                     _parse_systems_response,
                     projection=_LIST_PROJECTION,
+                    take=take,
                 )
                 if has_package:
                     systems = _filter_by_package(systems, has_package)

--- a/slcli/testmonitor_click.py
+++ b/slcli/testmonitor_click.py
@@ -527,6 +527,8 @@ def _query_counts_by_status(
     # Fall back to client-side for other fields
     if group_by and group_by != "status":
         # Fall back to fetching all results for non-status grouping
+        # Default max is 10,000 to prevent performance issues
+        max_items = 10000
         results = _query_all_results(
             filter_expr,
             substitutions,
@@ -534,8 +536,9 @@ def _query_counts_by_status(
             product_substitutions,
             None,
             False,
+            take=max_items,
         )
-        return _summarize_results(results, group_by)
+        return _summarize_results(results, group_by, max_items=max_items)
 
     # All possible status types from the API
     # Note: API uses "TIMEDOUT" (no underscore), not "TIMED_OUT" as documented
@@ -578,6 +581,7 @@ def _query_counts_by_status(
             "substitutions": combined_subs,
             "take": 0,  # Don't fetch any data
             "returnCount": True,  # Just get the count
+            "descending": True,  # Match request shape used by other query-results calls
         }
 
         if product_filter:
@@ -1131,6 +1135,7 @@ def register_testmonitor_commands(cli: Any) -> None:
                         product_subs,
                         order_by,
                         descending,
+                        take=take,
                     )
 
                     mock_resp: Any = FilteredResponse({"results": results})

--- a/tests/e2e/test_asset_e2e.py
+++ b/tests/e2e/test_asset_e2e.py
@@ -342,6 +342,8 @@ class TestAssetLifecycleE2E:
                     model,
                     "--serial-number",
                     serial,
+                    "--vendor-name",
+                    "E2E Test Vendor",
                     "--asset-type",
                     "DEVICE_UNDER_TEST",
                     "--property",

--- a/tests/unit/test_asset_click.py
+++ b/tests/unit/test_asset_click.py
@@ -1190,7 +1190,9 @@ class TestCreateAsset:
         ) -> Any:
             if payload:
                 captured_payloads.append(payload)
-            return MockResponse([{"id": "new-asset-1", "modelName": "PXI-4071"}])
+            return MockResponse(
+                {"assets": [{"id": "new-asset-1", "modelName": "PXI-4071"}], "failed": []}
+            )
 
         monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
         monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
@@ -1229,7 +1231,7 @@ class TestCreateAsset:
             payload: Any = None,
             **_: Any,
         ) -> Any:
-            return MockResponse([{"id": "new-1", "modelName": "DMM"}])
+            return MockResponse({"assets": [{"id": "new-1", "modelName": "DMM"}], "failed": []})
 
         monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
         monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})
@@ -1242,7 +1244,7 @@ class TestCreateAsset:
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data[0]["id"] == "new-1"
+        assert data["assets"][0]["id"] == "new-1"
 
     def test_create_asset_with_keywords_and_properties(
         self, monkeypatch: Any, runner: CliRunner
@@ -1260,7 +1262,7 @@ class TestCreateAsset:
         ) -> Any:
             if payload:
                 captured_payloads.append(payload)
-            return MockResponse([{"id": "new-2"}])
+            return MockResponse({"assets": [{"id": "new-2"}], "failed": []})
 
         monkeypatch.setattr("slcli.asset_click.make_api_request", mock_request)
         monkeypatch.setattr("slcli.asset_click.get_workspace_map", lambda: {})

--- a/tests/unit/test_system_click.py
+++ b/tests/unit/test_system_click.py
@@ -851,8 +851,8 @@ class TestListSystems:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # Return exactly take (25) items so pagination triggers
-                return MockResponse({"data": [SAMPLE_SYSTEM] * 25})
+                # Return exactly take (100) items so pagination triggers
+                return MockResponse({"data": [SAMPLE_SYSTEM] * 100})
             return MockResponse({"data": []})
 
         monkeypatch.setattr("slcli.system_click.make_api_request", mock_post)
@@ -861,7 +861,7 @@ class TestListSystems:
         cli = make_cli()
         result = runner.invoke(cli, ["system", "list", "-f", "table"], input="n\n")
         assert result.exit_code == 0
-        assert "Showing 25 systems" in result.output
+        assert "Showing 100 systems" in result.output
         assert "More results may be available" in result.output
 
 


### PR DESCRIPTION
## Summary

Performance improvements, bug fixes, and a new Agent Skills definition for `slcli`.

---

### 🚀 Test Monitor performance improvements (`slcli/testmonitor_click.py`)

- **Count-only queries for `--summary`**: Added `_query_counts_by_status()` which uses `returnCount: true` and `take: 0` per status type instead of fetching all results and aggregating client-side. Dramatically reduces data transfer for summary commands.
- **Increased batch size**: Changed `_query_all_results()` page size from 100 → 1000 (API max) for faster full-result queries.
- **Fixed `TIMEDOUT` enum**: API expects `TIMEDOUT` (no underscore), not `TIMED_OUT` as documented. Updated status type list accordingly.

### 🖥️ System list improvements (`slcli/system_click.py`)

- **Default `--take` changed to 100**: More useful default for fleet-level queries.
- **`--take` now applies to JSON output**: Previously JSON ignored the take parameter; now it respects it.
- **Conservative page size (100)**: Reduced internal `_query_all_items()` batch size from 1000 → 100 to avoid HTTP 500 errors from the Systems Management API.

### 🔧 Asset create error handling (`slcli/asset_click.py`)

- **Improved create response parsing**: Now inspects both `assets` and `failed` arrays from the API response.
- **Non-zero exit on failure**: JSON output exits with `GENERAL_ERROR` when the `failed` array is non-empty and no assets were created.
- **User-friendly error messages**: Table output now shows the server-provided error message on creation failure.

### 📘 Agent Skills definition (`skills/slcli/`)

New [Agent Skills](https://agentskills.io/specification) skill definition so AI agents can discover and effectively use `slcli`:

- `skills/slcli/SKILL.md` — Frontmatter + full command reference with quick start, all filter options, and key rules
- `skills/slcli/references/analysis-recipes.md` — 10 step-by-step recipes with `jq` post-processing for common data analysis questions
- `skills/slcli/references/filtering.md` — Comprehensive filtering reference covering LINQ, Asset API expressions, System Management filters, sorting, enums

### 🧪 Test updates

- `tests/unit/test_testmonitor_click.py` — Updated mocks for count-only query approach
- `tests/unit/test_system_click.py` — Updated expectations for new default take (100)
- `tests/e2e/test_asset_e2e.py` — Added `--vendor-name` to create test to satisfy API validation

---

### Files changed

| File | Change |
|------|--------|
| `slcli/testmonitor_click.py` | Count-only queries, batch size increase, TIMEDOUT fix |
| `slcli/system_click.py` | Default take → 100, JSON take support, page size → 100 |
| `slcli/asset_click.py` | Improved create error handling |
| `skills/slcli/SKILL.md` | New Agent Skills definition |
| `skills/slcli/references/analysis-recipes.md` | Analysis recipes for 10 common questions |
| `skills/slcli/references/filtering.md` | Filtering reference guide |
| `tests/unit/test_testmonitor_click.py` | Updated mocks |
| `tests/unit/test_system_click.py` | Updated default take expectations |
| `tests/e2e/test_asset_e2e.py` | Added vendor-name to create test |