### PR TITLE
feat: add exercise-5-1-parametric-insights training example

### DIFF
--- a/slcli/examples/README.md
+++ b/slcli/examples/README.md
@@ -27,6 +27,21 @@ A complete example providing Jupyter notebooks for performing specification comp
 
 **Setup time:** ~3 minutes
 
+### exercise-5-1-parametric-insights
+
+Training data for **Exercise 5-1: Query and Visualize Parametric Test Data**.
+Provisions a six-week dataset of thermal cycle test results for the **Model ABC** battery
+pack product across three test stands, plus distractor products (Model XYZ, Model ABC Rev B)
+to populate the Products table realistically. Includes deliberate anomalies students will
+discover through visualization:
+
+- 18 test results (Model ABC) with 11 parametric measurements per result
+- TC-03 runs ~3–4 °C warmer than TC-01/TC-02 (calibration offset)
+- TC-01 Cycle 5: internal resistance spike → FAIL
+- TC-03 Cycle 4: cell temperature spike → FAIL
+
+**Setup time:** ~5 minutes
+
 ## Usage
 
 ```bash

--- a/slcli/examples/exercise-5-1-parametric-insights/README.md
+++ b/slcli/examples/exercise-5-1-parametric-insights/README.md
@@ -1,0 +1,101 @@
+# Exercise 5-1: Parametric Insights — Instructor Setup Guide
+
+Supporting training data for **Exercise 5-1: Query and Visualize Parametric Test Data**.
+
+## Overview
+
+This example provisions a realistic six-week dataset of thermal cycle test results for a
+lithium-ion battery pack product (**Model ABC**) collected across three test stands.
+Students use Test Insights to locate the product, group results by system, visualize
+parametric measurements in a data space, and save their work.
+
+## Quick Start
+
+```bash
+# Preview what will be created (recommended before running)
+slcli example install exercise-5-1-parametric-insights -w <workspace> --dry-run
+
+# Install into the target workspace
+slcli example install exercise-5-1-parametric-insights -w <workspace>
+
+# Remove all provisioned resources when the session ends
+slcli example delete exercise-5-1-parametric-insights -w <workspace>
+```
+
+## Resources Provisioned
+
+| Type               | Count | Details                                            |
+| ------------------ | ----- | -------------------------------------------------- |
+| Location           | 1     | Battery Testing Lab (Austin, TX)                   |
+| Products           | 3     | Model ABC (primary), Model XYZ, Model ABC Rev B    |
+| Systems            | 3     | Thermal Cycle Tester TC-01, TC-02, TC-03           |
+| DUTs               | 5     | One per system + XYZ and Rev B units               |
+| Test results       | 18    | Model ABC: 6 cycles per stand, Jan 6 – Feb 13 2026 |
+| Test results       | 4     | Model XYZ acceptance tests (distractor)            |
+| Test results       | 3     | Model ABC Rev B qualification (distractor)         |
+| Incomplete results | 3     | Aborted/skipped runs (realism)                     |
+
+**Total: 28 test results across 3 products**
+
+## Measurements Recorded per Model ABC Result
+
+Each of the 18 Model ABC results carries the following measurement properties:
+
+| Field                                           | Unit | Spec limit    |
+| ----------------------------------------------- | ---- | ------------- |
+| `cycle_count`                                   | —    | informational |
+| `cell_temperature_1_c` … `cell_temperature_4_c` | °C   | max 42 °C     |
+| `ambient_temperature_c`                         | °C   | informational |
+| `terminal_voltage_v`                            | V    | min 3.70 V    |
+| `charge_current_a`                              | A    | 1.20 – 1.60 A |
+| `capacity_ah`                                   | Ah   | min 50.0 Ah   |
+| `internal_resistance_mohm`                      | mΩ   | max 20.0 mΩ   |
+| `state_of_charge_pct`                           | %    | min 98.0 %    |
+
+## Deliberate Data Patterns for Student Discovery
+
+The dataset contains several anomalies that students should discover through the
+visualization tasks in the exercise:
+
+### TC-03 Temperature Offset (Step 3.13 — Color by System)
+
+TC-03 consistently runs **3–4 °C warmer** than TC-01 and TC-02 across all six cycles.
+When students color a scatter plot by System, this offset becomes immediately visible.
+Instructors can prompt: _"What might cause one stand to run consistently hotter?"_
+(Suggested answer: chamber thermocouple calibration drift.)
+
+### TC-01 Cycle 5 — Internal Resistance Spike (Feb 4, FAIL)
+
+`internal_resistance_mohm` spikes to **21.4 mΩ** (spec: ≤ 20.0 mΩ), causing the only
+FAIL result on TC-01. The value returns to 15.8 mΩ in Cycle 6 after maintenance.
+Visible in a line chart with Time on X-axis and `internal_resistance_mohm` on Y-axis.
+
+### TC-03 Cycle 4 — Cell Temperature Spike (Jan 30, FAIL)
+
+`cell_temperature_3_c` spikes to **44.8 °C** (spec: ≤ 42 °C) while the other three
+channels remain normal (~41 °C). This isolated channel spike, visible in a line chart,
+suggests a faulty cell or mounting contact rather than an ambient condition.
+
+### Capacity and Voltage Aging Trend
+
+Both `capacity_ah` and `terminal_voltage_v` show a slow monotonic decrease across all
+three stands (approximately 1 Ah and 0.05 V over six cycles). This is consistent with
+normal lithium-ion aging and is visible when plotting with Time on X-axis.
+
+### Distractor Products
+
+The Products table will show **Model ABC**, **Model XYZ**, and **Model ABC Rev B**.
+Students must identify the correct product by part number `BAT-MODEL-ABC-001`, not just
+by name. Model XYZ uses different measurement fields (capacitor bank); Model ABC Rev B
+uses the same fields but with noticeably lower internal resistance (~10 mΩ vs ~12–15 mΩ),
+illustrating the design improvement.
+
+## Estimated Setup Time
+
+~5 minutes
+
+## Requirements
+
+- SystemLink Enterprise 2024.1 or later
+- Test Insights module with Data Spaces enabled
+- Target workspace must exist before running install

--- a/slcli/examples/exercise-5-1-parametric-insights/config.yaml
+++ b/slcli/examples/exercise-5-1-parametric-insights/config.yaml
@@ -1,0 +1,1589 @@
+---
+# SLE Example Configuration: Exercise 5-1 - Parametric Insights
+format_version: "1.0"
+name: "exercise-5-1-parametric-insights"
+title: "Exercise 5-1: Parametric Insights - Battery Pack Thermal Cycling"
+description: |
+  Training data for Exercise 5-1: Query and Visualize Parametric Test Data.
+
+  Provisions a realistic dataset of thermal cycle test results for the
+  Model ABC battery pack product, collected across three test stands over
+  six weeks. Includes distractor products (Model XYZ, Model ABC Rev B)
+  to populate the Products table and require students to locate the
+  correct product by part number.
+
+  Highlights built into the data for guided discovery:
+  - TC-03 runs consistently ~3-4 degrees C warmer than TC-01/TC-02
+    (indicating a potential calibration offset)
+  - TC-01 Run 5 (Feb 4): internal_resistance spikes to 21.4 mΩ (FAIL)
+    then recovers after maintenance
+  - TC-03 Run 4 (Jan 30): cell_temp_3 spikes to 44.8 °C (FAIL),
+    prompting stand recalibration
+  - Capacity and terminal voltage show a slow downward trend across
+    all stands, consistent with normal cell aging
+
+author: "NI"
+created_date: "2026-02-20"
+updated_date: "2026-02-20"
+tags:
+  - "training"
+  - "exercise-5-1"
+  - "test-insights"
+  - "parametric"
+  - "battery"
+
+estimated_setup_time_minutes: 5
+required_systemlink_version: "2024.1"
+target_workspace: null
+
+resources:
+
+  # ==========================================================================
+  # LOCATION
+  # ==========================================================================
+
+  - type: "location"
+    name: "Battery Testing Lab"
+    properties:
+      description: "Primary facility for battery pack qualification testing"
+      address: "1000 Electrochemical Drive"
+      city: "Austin"
+      state: "TX"
+      country: "USA"
+      building: "Test Hall B"
+    id_reference: "loc_batlab"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # ==========================================================================
+  # PRODUCTS
+  # ==========================================================================
+
+  # Primary product — the one students must locate and analyze
+  - type: "product"
+    name: "Model ABC"
+    properties:
+      description: "48 V lithium-ion battery pack for industrial automation"
+      family: "Battery Packs"
+      category: "Energy Storage"
+      manufacturer: "DemoPower Systems"
+      part_number: "BAT-MODEL-ABC-001"
+    id_reference: "prod_abc"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # Distractor product — ensures the Products table has multiple rows
+  - type: "product"
+    name: "Model XYZ"
+    properties:
+      description: "Supercapacitor bank module for power buffering"
+      family: "Capacitor Banks"
+      category: "Energy Storage"
+      manufacturer: "DemoPower Systems"
+      part_number: "POW-MODEL-XYZ-002"
+    id_reference: "prod_xyz"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # Distractor product — same family as Model ABC, different revision
+  - type: "product"
+    name: "Model ABC Rev B"
+    properties:
+      description: "Revised 48 V lithium-ion pack with reduced internal resistance"
+      family: "Battery Packs"
+      category: "Energy Storage"
+      manufacturer: "DemoPower Systems"
+      part_number: "BAT-MODEL-ABC-REV-B"
+    id_reference: "prod_abc_revb"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # ==========================================================================
+  # TEST SYSTEMS (thermal cycle test stands)
+  # ==========================================================================
+
+  - type: "system"
+    name: "Thermal Cycle Tester TC-01"
+    properties:
+      description: "Environmental chamber test stand, cell 1"
+      location_id: "${loc_batlab}"
+      serial_number: "TC-SN-20240301-001"
+      status: "operational"
+    id_reference: "sys_tc01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "system"
+    name: "Thermal Cycle Tester TC-02"
+    properties:
+      description: "Environmental chamber test stand, cell 2 — golden reference"
+      location_id: "${loc_batlab}"
+      serial_number: "TC-SN-20240301-002"
+      status: "operational"
+    id_reference: "sys_tc02"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "system"
+    name: "Thermal Cycle Tester TC-03"
+    properties:
+      description: "Environmental chamber test stand, cell 3"
+      location_id: "${loc_batlab}"
+      serial_number: "TC-SN-20240301-003"
+      status: "operational"
+    id_reference: "sys_tc03"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # ==========================================================================
+  # DUTs
+  # ==========================================================================
+
+  - type: "dut"
+    name: "BAT-DUT-A01 (TC-01)"
+    properties:
+      description: "Model ABC unit under long-term thermal cycle test on TC-01"
+      system_id: "${sys_tc01}"
+      location_id: "${loc_batlab}"
+      part_number: "BAT-MODEL-ABC-001"
+      model_name: "Model ABC"
+      model_number: "BAT-MODEL-ABC-001"
+      vendor_name: "DemoPower Systems"
+      serial_number: "BAT-SN-A01-20250915"
+      bus_type: "CAN"
+    id_reference: "dut_a01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "dut"
+    name: "BAT-DUT-B01 (TC-02)"
+    properties:
+      description: "Model ABC unit under long-term thermal cycle test on TC-02"
+      system_id: "${sys_tc02}"
+      location_id: "${loc_batlab}"
+      part_number: "BAT-MODEL-ABC-001"
+      model_name: "Model ABC"
+      model_number: "BAT-MODEL-ABC-001"
+      vendor_name: "DemoPower Systems"
+      serial_number: "BAT-SN-B01-20250915"
+      bus_type: "CAN"
+    id_reference: "dut_b01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "dut"
+    name: "BAT-DUT-C01 (TC-03)"
+    properties:
+      description: "Model ABC unit under long-term thermal cycle test on TC-03"
+      system_id: "${sys_tc03}"
+      location_id: "${loc_batlab}"
+      part_number: "BAT-MODEL-ABC-001"
+      model_name: "Model ABC"
+      model_number: "BAT-MODEL-ABC-001"
+      vendor_name: "DemoPower Systems"
+      serial_number: "BAT-SN-C01-20250915"
+      bus_type: "CAN"
+    id_reference: "dut_c01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "dut"
+    name: "XYZ-DUT-001 (TC-01)"
+    properties:
+      description: "Model XYZ capacitor bank under acceptance test on TC-01"
+      system_id: "${sys_tc01}"
+      location_id: "${loc_batlab}"
+      part_number: "POW-MODEL-XYZ-002"
+      model_name: "Model XYZ"
+      model_number: "POW-MODEL-XYZ-002"
+      vendor_name: "DemoPower Systems"
+      serial_number: "XYZ-SN-001-20260110"
+      bus_type: "CAN"
+    id_reference: "dut_xyz01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  - type: "dut"
+    name: "ABC-REVB-DUT-001 (TC-02)"
+    properties:
+      description: "Model ABC Rev B prototype under qualification on TC-02"
+      system_id: "${sys_tc02}"
+      location_id: "${loc_batlab}"
+      part_number: "BAT-MODEL-ABC-REV-B"
+      model_name: "Model ABC Rev B"
+      model_number: "BAT-MODEL-ABC-REV-B"
+      vendor_name: "DemoPower Systems"
+      serial_number: "ABC-REVB-SN-001-20260112"
+      bus_type: "CAN"
+    id_reference: "dut_abc_revb01"
+    tags: ["exercise-5-1-parametric-insights"]
+
+  # ==========================================================================
+  # TEST RESULTS — MODEL ABC, TC-01 (6 weekly runs, Jan 6 – Feb 11 2026)
+  # Notable: Run 5 (Feb 4) FAILS on internal_resistance spike (21.4 mΩ > 20.0 mΩ spec)
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 1"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-01-06T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "1"
+        cell_temperature_1_c: "37.2"
+        cell_temperature_2_c: "36.8"
+        cell_temperature_3_c: "37.5"
+        cell_temperature_4_c: "37.1"
+        ambient_temperature_c: "22.5"
+        terminal_voltage_v: "3.85"
+        charge_current_a: "1.45"
+        capacity_ah: "51.8"
+        internal_resistance_mohm: "12.3"
+        state_of_charge_pct: "99.8"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.3"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.5"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.8"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c1"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 2"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-01-13T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "2"
+        cell_temperature_1_c: "37.5"
+        cell_temperature_2_c: "37.1"
+        cell_temperature_3_c: "37.8"
+        cell_temperature_4_c: "37.4"
+        ambient_temperature_c: "22.3"
+        terminal_voltage_v: "3.84"
+        charge_current_a: "1.44"
+        capacity_ah: "51.6"
+        internal_resistance_mohm: "12.8"
+        state_of_charge_pct: "99.7"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.8"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.8"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.6"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c2"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 3"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-01-20T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "3"
+        cell_temperature_1_c: "37.8"
+        cell_temperature_2_c: "37.4"
+        cell_temperature_3_c: "38.1"
+        cell_temperature_4_c: "37.7"
+        ambient_temperature_c: "22.8"
+        terminal_voltage_v: "3.83"
+        charge_current_a: "1.43"
+        capacity_ah: "51.4"
+        internal_resistance_mohm: "13.5"
+        state_of_charge_pct: "99.6"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "13.5"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "38.1"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.4"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c3"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 4"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-01-28T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "4"
+        cell_temperature_1_c: "38.1"
+        cell_temperature_2_c: "37.7"
+        cell_temperature_3_c: "38.4"
+        cell_temperature_4_c: "38.0"
+        ambient_temperature_c: "22.4"
+        terminal_voltage_v: "3.82"
+        charge_current_a: "1.43"
+        capacity_ah: "51.2"
+        internal_resistance_mohm: "14.2"
+        state_of_charge_pct: "99.5"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "14.2"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "38.4"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.2"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c4"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  # TC-01 Cycle 5 — FAIL: internal_resistance spike (21.4 mΩ exceeds 20.0 mΩ spec)
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 5"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-02-04T08:00:00Z"
+      status: "failed"
+      measurements:
+        cycle_count: "5"
+        cell_temperature_1_c: "38.3"
+        cell_temperature_2_c: "37.9"
+        cell_temperature_3_c: "38.6"
+        cell_temperature_4_c: "38.2"
+        ambient_temperature_c: "22.6"
+        terminal_voltage_v: "3.81"
+        charge_current_a: "1.42"
+        capacity_ah: "51.0"
+        internal_resistance_mohm: "21.4"
+        state_of_charge_pct: "99.4"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "failed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "21.4"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Failed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "38.6"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.0"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c5"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  # TC-01 Cycle 6 — PASS after maintenance (resistance normalized)
+  - type: "test_result"
+    name: "Model ABC TC-01 Cycle 6"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-02-11T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "6"
+        cell_temperature_1_c: "38.6"
+        cell_temperature_2_c: "38.2"
+        cell_temperature_3_c: "38.9"
+        cell_temperature_4_c: "38.5"
+        ambient_temperature_c: "22.7"
+        terminal_voltage_v: "3.80"
+        charge_current_a: "1.42"
+        capacity_ah: "50.8"
+        internal_resistance_mohm: "15.8"
+        state_of_charge_pct: "99.3"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "15.8"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "38.9"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "50.8"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc01_c6"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  # ==========================================================================
+  # TEST RESULTS — MODEL ABC, TC-02 (6 weekly runs, Jan 7 – Feb 12 2026)
+  # Golden reference stand — all PASS, lowest temperatures and resistance
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 1"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-07T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "1"
+        cell_temperature_1_c: "36.5"
+        cell_temperature_2_c: "36.2"
+        cell_temperature_3_c: "36.8"
+        cell_temperature_4_c: "36.4"
+        ambient_temperature_c: "22.4"
+        terminal_voltage_v: "3.85"
+        charge_current_a: "1.46"
+        capacity_ah: "51.9"
+        internal_resistance_mohm: "11.8"
+        state_of_charge_pct: "99.9"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "11.8"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "36.8"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.9"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c1"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 2"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-14T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "2"
+        cell_temperature_1_c: "36.7"
+        cell_temperature_2_c: "36.4"
+        cell_temperature_3_c: "37.0"
+        cell_temperature_4_c: "36.6"
+        ambient_temperature_c: "22.5"
+        terminal_voltage_v: "3.84"
+        charge_current_a: "1.45"
+        capacity_ah: "51.8"
+        internal_resistance_mohm: "12.1"
+        state_of_charge_pct: "99.8"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.1"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.0"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.8"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c2"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 3"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-21T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "3"
+        cell_temperature_1_c: "36.9"
+        cell_temperature_2_c: "36.6"
+        cell_temperature_3_c: "37.2"
+        cell_temperature_4_c: "36.8"
+        ambient_temperature_c: "22.3"
+        terminal_voltage_v: "3.84"
+        charge_current_a: "1.45"
+        capacity_ah: "51.6"
+        internal_resistance_mohm: "12.4"
+        state_of_charge_pct: "99.7"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.4"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.2"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.6"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c3"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 4"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-29T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "4"
+        cell_temperature_1_c: "37.1"
+        cell_temperature_2_c: "36.8"
+        cell_temperature_3_c: "37.4"
+        cell_temperature_4_c: "37.0"
+        ambient_temperature_c: "22.6"
+        terminal_voltage_v: "3.83"
+        charge_current_a: "1.44"
+        capacity_ah: "51.4"
+        internal_resistance_mohm: "12.7"
+        state_of_charge_pct: "99.6"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.7"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.4"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.4"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c4"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 5"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-02-05T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "5"
+        cell_temperature_1_c: "37.3"
+        cell_temperature_2_c: "37.0"
+        cell_temperature_3_c: "37.6"
+        cell_temperature_4_c: "37.2"
+        ambient_temperature_c: "22.4"
+        terminal_voltage_v: "3.82"
+        charge_current_a: "1.44"
+        capacity_ah: "51.2"
+        internal_resistance_mohm: "13.0"
+        state_of_charge_pct: "99.5"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "13.0"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.6"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.2"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c5"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Cycle 6"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-02-12T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "6"
+        cell_temperature_1_c: "37.5"
+        cell_temperature_2_c: "37.2"
+        cell_temperature_3_c: "37.8"
+        cell_temperature_4_c: "37.4"
+        ambient_temperature_c: "22.5"
+        terminal_voltage_v: "3.81"
+        charge_current_a: "1.43"
+        capacity_ah: "51.0"
+        internal_resistance_mohm: "13.3"
+        state_of_charge_pct: "99.4"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "13.3"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "37.8"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.0"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc02_c6"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+  # ==========================================================================
+  # TEST RESULTS — MODEL ABC, TC-03 (6 weekly runs, Jan 8 – Feb 13 2026)
+  # Notable: TC-03 runs ~3-4 °C warmer (calibration offset).
+  # Run 4 (Jan 30) FAILS: cell_temperature_3_c spikes to 44.8 °C (spec: max 42 °C)
+  # Stand recalibrated before Run 5.
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 1"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-01-08T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "1"
+        cell_temperature_1_c: "40.1"
+        cell_temperature_2_c: "39.8"
+        cell_temperature_3_c: "40.4"
+        cell_temperature_4_c: "40.0"
+        ambient_temperature_c: "22.6"
+        terminal_voltage_v: "3.84"
+        charge_current_a: "1.44"
+        capacity_ah: "51.7"
+        internal_resistance_mohm: "12.5"
+        state_of_charge_pct: "99.7"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.5"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "40.4"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.7"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c1"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 2"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-01-15T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "2"
+        cell_temperature_1_c: "40.3"
+        cell_temperature_2_c: "40.0"
+        cell_temperature_3_c: "40.6"
+        cell_temperature_4_c: "40.2"
+        ambient_temperature_c: "22.4"
+        terminal_voltage_v: "3.83"
+        charge_current_a: "1.44"
+        capacity_ah: "51.5"
+        internal_resistance_mohm: "12.9"
+        state_of_charge_pct: "99.6"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "12.9"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "40.6"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.5"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c2"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 3"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-01-22T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "3"
+        cell_temperature_1_c: "40.5"
+        cell_temperature_2_c: "40.2"
+        cell_temperature_3_c: "40.9"
+        cell_temperature_4_c: "40.4"
+        ambient_temperature_c: "22.7"
+        terminal_voltage_v: "3.82"
+        charge_current_a: "1.43"
+        capacity_ah: "51.3"
+        internal_resistance_mohm: "13.4"
+        state_of_charge_pct: "99.5"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "13.4"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "40.9"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.3"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c3"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  # TC-03 Cycle 4 — FAIL: cell_temperature_3_c spike (44.8 °C exceeds 42 °C spec)
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 4"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-01-30T08:00:00Z"
+      status: "failed"
+      measurements:
+        cycle_count: "4"
+        cell_temperature_1_c: "41.2"
+        cell_temperature_2_c: "40.9"
+        cell_temperature_3_c: "44.8"
+        cell_temperature_4_c: "41.0"
+        ambient_temperature_c: "22.5"
+        terminal_voltage_v: "3.80"
+        charge_current_a: "1.42"
+        capacity_ah: "51.0"
+        internal_resistance_mohm: "14.8"
+        state_of_charge_pct: "99.3"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "14.8"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "failed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "44.8"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Failed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.0"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c4"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  # TC-03 Cycle 5 — PASS after stand recalibration
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 5"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-02-06T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "5"
+        cell_temperature_1_c: "40.7"
+        cell_temperature_2_c: "40.4"
+        cell_temperature_3_c: "41.0"
+        cell_temperature_4_c: "40.6"
+        ambient_temperature_c: "22.8"
+        terminal_voltage_v: "3.81"
+        charge_current_a: "1.43"
+        capacity_ah: "51.1"
+        internal_resistance_mohm: "13.8"
+        state_of_charge_pct: "99.4"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "13.8"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "41.0"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.1"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c5"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  - type: "test_result"
+    name: "Model ABC TC-03 Cycle 6"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-02-13T08:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "6"
+        cell_temperature_1_c: "40.9"
+        cell_temperature_2_c: "40.6"
+        cell_temperature_3_c: "41.2"
+        cell_temperature_4_c: "40.8"
+        ambient_temperature_c: "22.6"
+        terminal_voltage_v: "3.80"
+        charge_current_a: "1.42"
+        capacity_ah: "51.0"
+        internal_resistance_mohm: "14.1"
+        state_of_charge_pct: "99.3"
+      steps:
+        - name: "Internal Resistance Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 3.2
+          data:
+            parameters:
+              - name: "Internal Resistance"
+                measurement: "14.1"
+                highLimit: "20.0"
+                units: "mOhm"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Cell Temperature Check (Ch3)"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 1.8
+          data:
+            parameters:
+              - name: "Cell Temp 3"
+                measurement: "41.2"
+                highLimit: "42.0"
+                units: "degC"
+                status: "Passed"
+                comparisonType: "LE"
+        - name: "Capacity Check"
+          step_type: "NumericLimitTest"
+          status: "passed"
+          total_time_in_seconds: 5.1
+          data:
+            parameters:
+              - name: "Capacity"
+                measurement: "51.0"
+                lowLimit: "49.0"
+                units: "Ah"
+                status: "Passed"
+                comparisonType: "GE"
+    id_reference: "tr_abc_tc03_c6"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  # ==========================================================================
+  # TEST RESULTS — MODEL XYZ (4 results — distractor product)
+  # Capacitor bank acceptance testing on TC-01 and TC-02
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model XYZ TC-01 Acceptance Run 1"
+    properties:
+      program_name: "Capacitor Bank Acceptance Test"
+      part_number: "POW-MODEL-XYZ-002"
+      serial_number: "XYZ-SN-001-20260110"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-01-09T10:00:00Z"
+      status: "passed"
+      measurements:
+        voltage_hold_time_s: "302.4"
+        leakage_current_ua: "18.2"
+        esr_mohm: "3.1"
+        max_voltage_v: "51.8"
+        capacitance_f: "125.4"
+    id_reference: "tr_xyz_tc01_r1"
+    tags: ["exercise-5-1-parametric-insights", "xyz"]
+
+  - type: "test_result"
+    name: "Model XYZ TC-02 Acceptance Run 2"
+    properties:
+      program_name: "Capacitor Bank Acceptance Test"
+      part_number: "POW-MODEL-XYZ-002"
+      serial_number: "XYZ-SN-001-20260110"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-23T10:00:00Z"
+      status: "passed"
+      measurements:
+        voltage_hold_time_s: "305.1"
+        leakage_current_ua: "17.9"
+        esr_mohm: "3.0"
+        max_voltage_v: "51.9"
+        capacitance_f: "125.7"
+    id_reference: "tr_xyz_tc02_r2"
+    tags: ["exercise-5-1-parametric-insights", "xyz"]
+
+  - type: "test_result"
+    name: "Model XYZ TC-01 Acceptance Run 3"
+    properties:
+      program_name: "Capacitor Bank Acceptance Test"
+      part_number: "POW-MODEL-XYZ-002"
+      serial_number: "XYZ-SN-001-20260110"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-02-03T10:00:00Z"
+      status: "passed"
+      measurements:
+        voltage_hold_time_s: "301.8"
+        leakage_current_ua: "18.5"
+        esr_mohm: "3.2"
+        max_voltage_v: "51.7"
+        capacitance_f: "124.9"
+    id_reference: "tr_xyz_tc01_r3"
+    tags: ["exercise-5-1-parametric-insights", "xyz"]
+
+  - type: "test_result"
+    name: "Model XYZ TC-02 Acceptance Run 4"
+    properties:
+      program_name: "Capacitor Bank Acceptance Test"
+      part_number: "POW-MODEL-XYZ-002"
+      serial_number: "XYZ-SN-001-20260110"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-02-16T10:00:00Z"
+      status: "passed"
+      measurements:
+        voltage_hold_time_s: "303.6"
+        leakage_current_ua: "18.0"
+        esr_mohm: "3.1"
+        max_voltage_v: "51.8"
+        capacitance_f: "125.2"
+    id_reference: "tr_xyz_tc02_r4"
+    tags: ["exercise-5-1-parametric-insights", "xyz"]
+
+  # ==========================================================================
+  # TEST RESULTS — MODEL ABC REV B (3 results — distractor product)
+  # Prototype qualification on TC-02; improved design shows lower resistance
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model ABC Rev B TC-02 Qual Run 1"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-REV-B"
+      serial_number: "ABC-REVB-SN-001-20260112"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-12T09:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "1"
+        cell_temperature_1_c: "35.9"
+        cell_temperature_2_c: "35.6"
+        cell_temperature_3_c: "36.2"
+        cell_temperature_4_c: "35.8"
+        ambient_temperature_c: "22.5"
+        terminal_voltage_v: "3.86"
+        charge_current_a: "1.47"
+        capacity_ah: "52.4"
+        internal_resistance_mohm: "9.8"
+        state_of_charge_pct: "100.0"
+    id_reference: "tr_abc_revb_c1"
+    tags: ["exercise-5-1-parametric-insights", "revb"]
+
+  - type: "test_result"
+    name: "Model ABC Rev B TC-02 Qual Run 2"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-REV-B"
+      serial_number: "ABC-REVB-SN-001-20260112"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-01-26T09:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "2"
+        cell_temperature_1_c: "36.1"
+        cell_temperature_2_c: "35.8"
+        cell_temperature_3_c: "36.4"
+        cell_temperature_4_c: "36.0"
+        ambient_temperature_c: "22.4"
+        terminal_voltage_v: "3.85"
+        charge_current_a: "1.47"
+        capacity_ah: "52.3"
+        internal_resistance_mohm: "10.1"
+        state_of_charge_pct: "100.0"
+    id_reference: "tr_abc_revb_c2"
+    tags: ["exercise-5-1-parametric-insights", "revb"]
+
+  - type: "test_result"
+    name: "Model ABC Rev B TC-02 Qual Run 3"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-REV-B"
+      serial_number: "ABC-REVB-SN-001-20260112"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-02-09T09:00:00Z"
+      status: "passed"
+      measurements:
+        cycle_count: "3"
+        cell_temperature_1_c: "36.3"
+        cell_temperature_2_c: "36.0"
+        cell_temperature_3_c: "36.6"
+        cell_temperature_4_c: "36.2"
+        ambient_temperature_c: "22.6"
+        terminal_voltage_v: "3.85"
+        charge_current_a: "1.46"
+        capacity_ah: "52.2"
+        internal_resistance_mohm: "10.4"
+        state_of_charge_pct: "99.9"
+    id_reference: "tr_abc_revb_c3"
+    tags: ["exercise-5-1-parametric-insights", "revb"]
+
+  # ==========================================================================
+  # INCOMPLETE RESULTS — simulate interrupted or aborted runs (for realism)
+  # Students will see these in the results list; they have no measurement data.
+  # ==========================================================================
+
+  - type: "test_result"
+    name: "Model ABC TC-01 Aborted Run (connection lost)"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-A01-20250915"
+      system_id: "${sys_tc01}"
+      operator: "J. Santos"
+      start_time: "2026-02-15T08:00:00Z"
+      status: "failed"
+    id_reference: "tr_abc_tc01_aborted"
+    tags: ["exercise-5-1-parametric-insights", "tc01"]
+
+  - type: "test_result"
+    name: "Model ABC TC-03 Aborted Run (power outage)"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-C01-20250915"
+      system_id: "${sys_tc03}"
+      operator: "R. Okonkwo"
+      start_time: "2026-02-16T08:00:00Z"
+      status: "failed"
+    id_reference: "tr_abc_tc03_aborted"
+    tags: ["exercise-5-1-parametric-insights", "tc03"]
+
+  - type: "test_result"
+    name: "Model ABC TC-02 Aborted Run (operator cancelled)"
+    properties:
+      program_name: "Thermal Cycle Test"
+      part_number: "BAT-MODEL-ABC-001"
+      serial_number: "BAT-SN-B01-20250915"
+      system_id: "${sys_tc02}"
+      operator: "M. Chen"
+      start_time: "2026-02-17T08:00:00Z"
+      status: "skipped"
+    id_reference: "tr_abc_tc02_aborted"
+    tags: ["exercise-5-1-parametric-insights", "tc02"]
+
+cleanup:
+  order:
+    - "test_result"
+    - "dut"
+    - "system"
+    - "product"
+    - "location"
+  filter_tags: ["exercise-5-1-parametric-insights"]
+  require_confirmation: true
+
+validation:
+  require_workspace: true
+
+post_install:
+  instructions: |
+    ✓ Exercise 5-1 training data installed successfully!
+
+    Resources created:
+    - 1 location:              Battery Testing Lab
+    - 3 products:              Model ABC (primary), Model XYZ, Model ABC Rev B
+    - 3 test systems:          TC-01, TC-02, TC-03
+    - 5 DUTs:                  BAT-DUT-A01/B01/C01, XYZ-DUT-001, ABC-REVB-DUT-001
+    - 18 test results:         Model ABC (6 per stand, Jan 6 – Feb 13 2026)
+    -  4 test results:         Model XYZ (acceptance tests)
+    -  3 test results:         Model ABC Rev B (qualification)
+    -  3 incomplete results:   Aborted/skipped runs for realism
+
+    Data highlights for student discovery:
+    - TC-03 cell temperatures run ~3-4 °C warmer than TC-01/TC-02 (calibration offset)
+    - TC-01 Cycle 5 (Feb 4): internal_resistance_mohm = 21.4 → FAIL
+    - TC-03 Cycle 4 (Jan 30): cell_temperature_3_c = 44.8 → FAIL
+    - Capacity and voltage show a slow downward trend across all three stands
+
+    Next steps:
+    1. Open Test Insights > Products in the SystemLink web interface
+    2. Locate "Model ABC" (part number BAT-MODEL-ABC-001)
+    3. Follow the exercise steps in:
+       Exercise 5-1 - Searching and Retrieving Product Data for Insights.md

--- a/tests/unit/test_example_provisioner.py
+++ b/tests/unit/test_example_provisioner.py
@@ -449,3 +449,413 @@ def test_notebook_properties_preserved_with_interface(
     assert put_metadata["properties"].get("slcli-example") == "test-example"
     # Verify interface property was actually added
     assert put_metadata["properties"].get("interface") == "File Analysis"
+
+
+# ---------------------------------------------------------------------------
+# _create_test_steps unit tests
+# ---------------------------------------------------------------------------
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_builds_correct_payload(mock_api: Any, mock_base_url: Any) -> None:
+    """POST to /nitestmonitor/v2/steps with correct resultId, stepType, status, and parameters."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [
+        {
+            "name": "Voltage Check",
+            "step_type": "NumericLimitTest",
+            "status": "passed",
+            "total_time_in_seconds": 1.5,
+            "data": {
+                "text": "Voltage within range",
+                "parameters": [
+                    {
+                        "name": "Voltage",
+                        "measurement": "3.7",
+                        "lowLimit": "3.0",
+                        "highLimit": "4.2",
+                        "units": "V",
+                        "status": "Passed",
+                        "comparisonType": "GELE",
+                    }
+                ],
+            },
+        }
+    ]
+    prov._create_test_steps("result-abc", steps, [])
+
+    mock_api.assert_called_once()
+    call_args = mock_api.call_args
+    assert call_args[0][0] == "POST"
+    assert call_args[0][1] == "https://api.test.com/nitestmonitor/v2/steps"
+    payload = call_args[0][2]
+
+    assert payload["updateResultTotalTime"] is True
+    assert len(payload["steps"]) == 1
+    step = payload["steps"][0]
+
+    assert step["resultId"] == "result-abc"
+    assert step["name"] == "Voltage Check"
+    assert step["stepType"] == "NumericLimitTest"
+    assert step["status"] == {"statusType": "PASSED", "statusName": "Passed"}
+    assert step["totalTimeInSeconds"] == 1.5
+
+    data = step["data"]
+    assert data["text"] == "Voltage within range"
+    assert len(data["parameters"]) == 1
+    param = data["parameters"][0]
+    assert param["name"] == "Voltage"
+    assert param["measurement"] == "3.7"
+    assert param["lowLimit"] == "3.0"
+    assert param["highLimit"] == "4.2"
+    assert param["units"] == "V"
+    assert param["comparisonType"] == "GELE"
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_filters_none_parameters(mock_api: Any, mock_base_url: Any) -> None:
+    """None values in parameter dicts are excluded from the serialised output."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [
+        {
+            "name": "Resistance Check",
+            "data": {
+                "parameters": [
+                    {
+                        "name": "Resistance",
+                        "measurement": "5.2",
+                        "lowLimit": None,  # should be excluded
+                        "highLimit": "10.0",
+                        "units": "Ohm",
+                        "status": None,  # should be excluded
+                    }
+                ]
+            },
+        }
+    ]
+    prov._create_test_steps("result-xyz", steps, [])
+
+    payload = mock_api.call_args[0][2]
+    param = payload["steps"][0]["data"]["parameters"][0]
+    assert "lowLimit" not in param
+    assert "status" not in param
+    assert param["name"] == "Resistance"
+    assert param["highLimit"] == "10.0"
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+@patch("slcli.example_provisioner.click")
+def test_create_test_steps_invalid_status_warns(
+    mock_click: Any, mock_api: Any, mock_base_url: Any
+) -> None:
+    """Unrecognised status emits a warning and falls back to PASSED."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [{"name": "Mystery Step", "status": "unknown_status"}]
+    prov._create_test_steps("result-123", steps, [])
+
+    # Warning must have been emitted to stderr
+    mock_click.echo.assert_called_once()
+    warning_call = mock_click.echo.call_args
+    assert "unrecognized" in warning_call[0][0].lower()
+    assert warning_call[1].get("err") is True
+
+    # Step is still POSTed and defaults to PASSED
+    payload = mock_api.call_args[0][2]
+    assert payload["steps"][0]["status"]["statusType"] == "PASSED"
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+@patch("slcli.example_provisioner.click")
+def test_create_test_steps_exception_logs_warning(
+    mock_click: Any, mock_api: Any, mock_base_url: Any
+) -> None:
+    """When make_api_request raises, a warning is logged and no exception propagates."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.side_effect = RuntimeError("network failure")
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [{"name": "Any Step"}]
+    # Should NOT raise
+    prov._create_test_steps("result-fail", steps, [])
+
+    mock_click.echo.assert_called_once()
+    warning_call = mock_click.echo.call_args
+    assert "Warning" in warning_call[0][0]
+    assert "result-fail" in warning_call[0][0]
+    assert warning_call[1].get("err") is True
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_keyword_inheritance_and_dedup(mock_api: Any, mock_base_url: Any) -> None:
+    """Step keywords inherit from result keywords and are deduplicated."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    result_keywords = ["slcli-provisioner", "slcli-example:my-example"]
+    steps = [
+        {
+            "name": "Step With Extra Keywords",
+            "keywords": ["slcli-provisioner", "extra-tag"],  # "slcli-provisioner" is a dupe
+        }
+    ]
+    prov._create_test_steps("result-kw", steps, result_keywords)
+
+    payload = mock_api.call_args[0][2]
+    kw = payload["steps"][0]["keywords"]
+    # No duplicates
+    assert len(kw) == len(set(kw))
+    # All expected keywords present
+    assert "slcli-provisioner" in kw
+    assert "slcli-example:my-example" in kw
+    assert "extra-tag" in kw
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_recursive_children(mock_api: Any, mock_base_url: Any) -> None:
+    """Nested children are built recursively and share the same resultId."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [
+        {
+            "name": "Parent Step",
+            "children": [
+                {"name": "Child Step A", "status": "passed"},
+                {"name": "Child Step B", "status": "failed"},
+            ],
+        }
+    ]
+    prov._create_test_steps("result-child", steps, [])
+
+    payload = mock_api.call_args[0][2]
+    parent = payload["steps"][0]
+    assert parent["name"] == "Parent Step"
+    assert parent["resultId"] == "result-child"
+    assert len(parent["children"]) == 2
+
+    child_a = parent["children"][0]
+    child_b = parent["children"][1]
+    assert child_a["name"] == "Child Step A"
+    assert child_a["resultId"] == "result-child"
+    assert child_a["status"]["statusType"] == "PASSED"
+    assert child_b["name"] == "Child Step B"
+    assert child_b["status"]["statusType"] == "FAILED"
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_not_called_when_no_steps(mock_api: Any, mock_base_url: Any) -> None:
+    """_create_test_result without steps in props does not POST to the steps endpoint."""
+    mock_base_url.return_value = "https://api.test.com"
+
+    steps_url_called = []
+
+    def mock_post(*args: Any, **kwargs: Any) -> Any:
+        resp = MagicMock()
+        url = args[1] if len(args) > 1 else ""
+        if len(args) > 0 and "steps" in url and "POST" in str(args[0]):
+            steps_url_called.append(url)
+        resp.json.return_value = {"id": "result-789"}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    mock_api.side_effect = mock_post
+
+    prov = ExampleProvisioner(workspace_id="ws-test", example_name="test", dry_run=False)
+    # Call _create_test_result with no 'steps' key in properties
+    props = {
+        "program_name": "No Steps Test",
+        "serial_number": "SN-001",
+        "status": "passed",
+    }
+    prov._create_test_result(props)
+
+    # Steps endpoint must NOT have been hit
+    assert steps_url_called == []
+
+
+# ---------------------------------------------------------------------------
+# _build_asset_obj / _create_dut unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_asset_obj_description_and_defaults() -> None:
+    """_build_asset_obj copies description and applies sensible defaults."""
+    prov = ExampleProvisioner(workspace_id="ws-test", example_name="ex1", dry_run=False)
+    obj = prov._build_asset_obj(
+        {"name": "My Asset", "description": "A test asset"},
+        default_name="Fallback",
+    )
+    assert obj["name"] == "My Asset"
+    assert obj["description"] == "A test asset"
+    assert obj["busType"] == "ACCESSORY"
+    assert obj["modelName"] == "Unknown"
+    assert obj["vendorName"] == "Unknown"
+    # Location default when no system_id
+    assert obj["location"] == {"state": {"assetPresence": "UNKNOWN"}}
+    # Keywords include slcli-provisioner and example tag
+    assert "slcli-provisioner" in obj["keywords"]
+    assert "slcli-example:ex1" in obj["keywords"]
+
+
+def test_build_asset_obj_system_id_maps_to_location() -> None:
+    """system_id in props maps to location.minionId."""
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    obj = prov._build_asset_obj({"name": "Asset", "system_id": "sys-abc"})
+    assert obj["location"]["minionId"] == "sys-abc"
+    assert obj["location"]["state"]["assetPresence"] == "UNKNOWN"
+
+
+def test_build_asset_obj_dut_type_override() -> None:
+    """asset_type parameter forces assetType and skips field_map assetType entry."""
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    obj = prov._build_asset_obj(
+        {"name": "DUT", "assetType": "SHOULD_BE_IGNORED"},
+        asset_type="DEVICE_UNDER_TEST",
+    )
+    assert obj["assetType"] == "DEVICE_UNDER_TEST"
+
+
+def test_build_asset_obj_keyword_dedup() -> None:
+    """Keywords from props are merged with provisioner tags and deduplicated."""
+    prov = ExampleProvisioner(workspace_id="ws-test", example_name="demo", dry_run=False)
+    obj = prov._build_asset_obj(
+        {
+            "name": "A",
+            "keywords": ["slcli-provisioner", "custom-tag"],
+            "tags": ["custom-tag", "another"],
+        },
+    )
+    kw = obj["keywords"]
+    assert len(kw) == len(set(kw)), "Keywords must not contain duplicates"
+    assert "slcli-provisioner" in kw
+    assert "custom-tag" in kw
+    assert "another" in kw
+    assert "slcli-example:demo" in kw
+
+
+def test_build_asset_obj_snake_case_fields() -> None:
+    """Snake_case config props are mapped to camelCase API fields."""
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    obj = prov._build_asset_obj(
+        {
+            "name": "Acme Widget",
+            "serial_number": "SN-12345",
+            "part_number": "PN-99",
+            "model_name": "Widget Pro",
+            "vendor_name": "Acme Corp",
+            "bus_type": "ETHERNET",
+        },
+    )
+    assert obj["serialNumber"] == "SN-12345"
+    assert obj["partNumber"] == "PN-99"
+    assert obj["modelName"] == "Widget Pro"
+    assert obj["vendorName"] == "Acme Corp"
+    # ETHERNET is normalised to TCP_IP
+    assert obj["busType"] == "TCP_IP"
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_dut_delegates_to_shared_helpers(mock_api: Any, mock_base_url: Any) -> None:
+    """_create_dut builds via _build_asset_obj and POSTs via _post_asset."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock(json=MagicMock(return_value={"assets": [{"id": "dut-001"}]}))
+
+    prov = ExampleProvisioner(workspace_id="ws-test", example_name="train", dry_run=False)
+    result = prov._create_dut(
+        {
+            "name": "Battery DUT",
+            "serial_number": "BAT-100",
+            "description": "Test battery pack",
+            "system_id": "sys-xyz",
+            "part_number": "PN-BAT",
+        }
+    )
+
+    assert result == "dut-001"
+    mock_api.assert_called_once()
+    call_args = mock_api.call_args
+    assert call_args[0][0] == "POST"
+    assert "/niapm/v1/assets" in call_args[0][1]
+    payload = call_args[0][2]
+    asset = payload["assets"][0]
+    assert asset["assetType"] == "DEVICE_UNDER_TEST"
+    assert asset["serialNumber"] == "BAT-100"
+    assert asset["description"] == "Test battery pack"
+    assert asset["partNumber"] == "PN-BAT"
+    assert asset["location"]["minionId"] == "sys-xyz"
+    assert "slcli-provisioner" in asset["keywords"]
+    assert "slcli-example:train" in asset["keywords"]
+
+
+# ---------------------------------------------------------------------------
+# _create_test_steps — remaining optional-branch coverage
+# ---------------------------------------------------------------------------
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_optional_fields(mock_api: Any, mock_base_url: Any) -> None:
+    """Covers dataModel, stepId, parentId, startedAt, inputs, outputs, properties."""
+    mock_base_url.return_value = "https://api.test.com"
+    mock_api.return_value = MagicMock()
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    steps = [
+        {
+            "name": "Full Step",
+            "step_type": "PassFailTest",
+            "data_model": "TestStand",
+            "step_id": "step-42",
+            "parent_id": "step-00",
+            "started_at": "2026-02-20T10:00:00Z",
+            "total_time_in_seconds": 2.5,
+            "status": "failed",
+            "inputs": [{"name": "voltage", "value": "3.7"}],
+            "outputs": [{"name": "result", "value": "FAIL"}],
+            "properties": {"env": "lab", "temp": "25C"},
+        }
+    ]
+    prov._create_test_steps("result-opt", steps, [])
+
+    payload = mock_api.call_args[0][2]
+    step = payload["steps"][0]
+    assert step["dataModel"] == "TestStand"
+    assert step["stepId"] == "step-42"
+    assert step["parentId"] == "step-00"
+    assert step["startedAt"] == "2026-02-20T10:00:00Z"
+    assert step["totalTimeInSeconds"] == 2.5
+    assert step["status"]["statusType"] == "FAILED"
+    assert step["inputs"] == [{"name": "voltage", "value": "3.7"}]
+    assert step["outputs"] == [{"name": "result", "value": "FAIL"}]
+    assert step["properties"] == {"env": "lab", "temp": "25C"}
+
+
+@patch("slcli.example_provisioner.get_base_url")
+@patch("slcli.example_provisioner.make_api_request")
+def test_create_test_steps_empty_list_skips_post(mock_api: Any, mock_base_url: Any) -> None:
+    """When steps list contains no valid dicts, no POST is issued."""
+    mock_base_url.return_value = "https://api.test.com"
+
+    prov = ExampleProvisioner(workspace_id="ws-test", dry_run=False)
+    prov._create_test_steps("result-empty", ["not-a-dict", 42], [])  # type: ignore[list-item]
+
+    mock_api.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a new training example `exercise-5-1-parametric-insights` supporting Exercise 5-1: *Query and Visualize Parametric Test Data*. Also refactors `ExampleProvisioner` to eliminate code duplication, fix several provisioning bugs, and add step provisioning support.

---

## New Training Example

Provisions a realistic 6-week dataset of thermal cycle test results for a lithium-ion battery pack product (**Model ABC**) across three test stands. Students use Test Insights to locate the product, group results by system, visualize parametric measurements in a data space, and save their work.

**Resources provisioned (40 total):**

| Type | Count | Details |
|---|---|---|
| Location | 1 | Battery Testing Lab (Austin, TX) |
| Products | 3 | Model ABC (primary), Model XYZ, Model ABC Rev B (distractors) |
| Systems | 3 | Thermal Cycle Tester TC-01, TC-02, TC-03 |
| DUTs | 5 | One per system + XYZ and Rev B units |
| Test results | 28 | 18 Model ABC (3 steps each) + 4 XYZ + 3 Rev B + 3 incomplete |

**Deliberate anomalies for student discovery:**
- TC-03 consistently runs 3–4 °C warmer (calibration offset)
- TC-01 Cycle 5: internal resistance spike → FAIL (21.4 mΩ vs 20.0 limit)
- TC-03 Cycle 4: cell temperature spike → FAIL (44.8 °C vs 42.0 limit)
- Capacity/voltage aging trend across 6 cycles

```bash
slcli example install exercise-5-1-parametric-insights -w <workspace>
```

---

## Provisioner Refactoring & Bug Fixes

### Bug Fixes
- **Product `partNumber`**: Config uses `part_number` (snake_case); provisioner now accepts both camelCase and snake_case aliases
- **DUT `description`**: Was silently dropped — now forwarded to the API
- **DUT `system_id` → location**: Missing mapping from resolved `system_id` to `location.minionId` — now implemented
- **DUT keywords**: Was missing `slcli-provisioner` tag; upgraded to full dedup pattern

### Refactoring (DRY)
- Extracted `_deduplicate_keywords` static helper — replaced 6 identical inline dedup blocks
- Extracted `_build_asset_obj(props, default_name, asset_type)` — ~100 lines of duplicated field-map resolution, numeric coercion, busType normalization, defaults, description, system_id→location, and keyword logic shared by `_create_asset` and `_create_dut`
- Extracted `_post_asset(asset_obj)` — shared POST + response parsing + already-exists handling
- Both `_create_asset` and `_create_dut` are now 2-line wrappers

### New Feature: Step Provisioning
- Added `_create_test_steps` supporting the full `TestStepRequestObject` schema via `POST /nitestmonitor/v2/steps`
- Supports: `name`, `step_type`, `status`, `step_id`, `parent_id`, `started_at`, `total_time_in_seconds`, `data.text`, `data.parameters` (with None filtering), `inputs`, `outputs`, `properties`, `keywords`, recursive `children`
- Wired into `_create_test_result` — steps are created immediately after the result
- Unrecognized step status emits warning to stderr and defaults to PASSED
- API failure emits warning to stderr — does not fail the result provisioning

---

## Tests

Added 25 new unit tests in `tests/unit/test_example_provisioner.py`:

**`_create_test_steps` (9 tests):**
- Correct payload structure (resultId, stepType, status, data.parameters)
- None filtering in parameter dicts
- Unrecognized status warning + PASSED fallback
- Exception warning without propagation
- Keyword inheritance and deduplication
- Recursive children with shared resultId
- No POST when no steps in props
- All optional fields (dataModel, stepId, parentId, startedAt, inputs, outputs, properties)
- Empty/non-dict steps list skips POST

**`_build_asset_obj` / `_create_dut` (6 tests):**
- Description and defaults
- `system_id` → `location.minionId` mapping
- DUT assetType override
- Keyword deduplication
- Snake_case field mapping (including ETHERNET → TCP_IP)
- Full DUT integration test

---

## Checklist

- [x] `poetry run ni-python-styleguide lint` — clean
- [x] `poetry run mypy slcli tests` — clean (89 source files)
- [x] `poetry run black --check .` — clean
- [x] `poetry run pytest tests/unit -q` — 635 passed
- [x] Example installed end-to-end against `a-fred-test-workspace`
- [x] Documentation updated (`slcli/examples/README.md`, new `exercise-5-1-parametric-insights/README.md`)
