### PR TITLE
Add slash prompt for concise PR creation

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -30,13 +30,20 @@
    /slcli-pr-review e2e                # E2E testing focus
    /slcli-pr-review standard coverage  # With optional focus area
    ```
-3. **Follow the checklist** provided by the slash command
-4. **Run the commands** listed in the review prompt
-5. **Provide detailed feedback** to the developer
+3. **Use the `/slcli-pr-create` slash command** to publish the current changes as a concise pull request:
+  ```bash
+  /slcli-pr-create
+  /slcli-pr-create Add semantic release changelog asset
+  ```
+4. **Follow the checklist** provided by the slash command
+5. **Run the commands** listed in the review prompt
+6. **Provide detailed feedback** to the developer
 
 ### Slash Command Location
 
 File: [`.github/prompts/pr-review.prompt.md`](.github/prompts/pr-review.prompt.md)
+
+File: [`.github/prompts/pr-create.prompt.md`](.github/prompts/pr-create.prompt.md)
 
 ---
 
@@ -48,6 +55,7 @@ In **Copilot Chat**, type:
 
 ```
 /slcli-pr-review [type] [focus]
+/slcli-pr-create [title] [base] [draft] [context]
 ```
 
 ### Arguments
@@ -64,6 +72,8 @@ In **Copilot Chat**, type:
 /slcli-pr-review refactor           # Refactoring-focused review
 /slcli-pr-review e2e                # E2E testing-focused review
 /slcli-pr-review standard coverage  # Standard review with coverage focus
+/slcli-pr-create                    # Open a concise PR for current branch
+/slcli-pr-create Fix release changelog commit
 ```
 
 ---

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -31,10 +31,10 @@
    /slcli-pr-review standard coverage  # With optional focus area
    ```
 3. **Use the `/slcli-pr-create` slash command** to publish the current changes as a concise pull request:
-  ```bash
-  /slcli-pr-create
-  /slcli-pr-create Add semantic release changelog asset
-  ```
+   ```bash
+   /slcli-pr-create
+   /slcli-pr-create title="Add semantic release changelog asset"
+   ```
 4. **Follow the checklist** provided by the slash command
 5. **Run the commands** listed in the review prompt
 6. **Provide detailed feedback** to the developer
@@ -55,7 +55,7 @@ In **Copilot Chat**, type:
 
 ```
 /slcli-pr-review [type] [focus]
-/slcli-pr-create [title] [base] [draft] [context]
+/slcli-pr-create [title="..."] [base=...] [draft=true|false] [context="..."]
 ```
 
 ### Arguments
@@ -73,7 +73,7 @@ In **Copilot Chat**, type:
 /slcli-pr-review e2e                # E2E testing-focused review
 /slcli-pr-review standard coverage  # Standard review with coverage focus
 /slcli-pr-create                    # Open a concise PR for current branch
-/slcli-pr-create Fix release changelog commit
+/slcli-pr-create title="Fix release changelog commit"
 ```
 
 ---

--- a/.github/prompts/pr-create.prompt.md
+++ b/.github/prompts/pr-create.prompt.md
@@ -1,0 +1,46 @@
+---
+name: slcli-pr-create
+description: Create a concise GitHub pull request for the current changes. Ensures the work is on a feature branch, pushes it, and opens the PR.
+argument-hint: Optional title, base branch, draft, or extra reviewer context
+agent: agent
+---
+
+## Summary
+
+Create and post a concise pull request for the current work. Before opening the PR, make sure the changes are on a non-default feature branch and pushed to GitHub.
+
+## Arguments
+
+- `title` (optional): Preferred PR title
+- `base` (optional): Target branch. Default to the repository default branch.
+- `draft` (optional): Create the PR as a draft when explicitly requested.
+- `context` (optional): Extra reviewer context to include in the PR description.
+
+## Procedure
+
+1. Inspect the git working tree, current branch, upstream status, and commits ahead of the base branch.
+2. If the current branch is the default branch, create a new descriptive feature branch and switch to it before proceeding.
+3. If there are uncommitted changes, commit them with a concise commit message that matches the repo's commit style.
+4. Push the branch to `origin` if it is not already published there.
+5. Draft a concise PR title from the branch name, commits, and diff unless one was provided.
+6. Draft a concise PR description with these sections:
+   - `## Summary`
+   - `## Testing`
+   - `## Notes` only when needed for reviewer context
+7. Open the PR on GitHub against the requested base branch or the repository default branch.
+8. Report the branch name, commit range, PR number, and PR URL back to the user.
+
+## Constraints
+
+- Keep the PR title specific and under 72 characters when practical.
+- Keep the PR description short and reviewer-oriented.
+- Do not leave the changes on `main` or another shared protected branch.
+- Do not create a draft PR unless the user asked for one or the branch is clearly not ready for review.
+
+## Example
+
+```bash
+/slcli-pr-create
+/slcli-pr-create Update semantic release changelog handling
+/slcli-pr-create draft base=release/1.x include the Python Semantic Release v10 regression details
+```

--- a/.github/prompts/pr-create.prompt.md
+++ b/.github/prompts/pr-create.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slcli-pr-create
 description: Create a concise GitHub pull request for the current changes. Ensures the work is on a feature branch, pushes it, and opens the PR.
-argument-hint: Optional title, base branch, draft, or extra reviewer context
+argument-hint: Optional key=value args such as title="..." base=main draft=true context="..."
 agent: agent
 ---
 
@@ -11,24 +11,27 @@ Create and post a concise pull request for the current work. Before opening the 
 
 ## Arguments
 
-- `title` (optional): Preferred PR title
-- `base` (optional): Target branch. Default to the repository default branch.
-- `draft` (optional): Create the PR as a draft when explicitly requested.
-- `context` (optional): Extra reviewer context to include in the PR description.
+Use `key=value` arguments. Quote values that contain spaces, for example `title="Add retry handling"` or `context="Call out follow-up work"`.
+
+- `title` (optional): Preferred PR title, passed as `title="..."`
+- `base` (optional): Target branch, passed as `base=main`. Default to the repository default branch.
+- `draft` (optional): Create the PR as a draft when explicitly requested, passed as `draft=true` or `draft=false`.
+- `context` (optional): Extra reviewer context to include in the PR description, passed as `context="..."`.
 
 ## Procedure
 
 1. Inspect the git working tree, current branch, upstream status, and commits ahead of the base branch.
-2. If the current branch is the default branch, create a new descriptive feature branch and switch to it before proceeding.
-3. If there are uncommitted changes, commit them with a concise commit message that matches the repo's commit style.
-4. Push the branch to `origin` if it is not already published there.
-5. Draft a concise PR title from the branch name, commits, and diff unless one was provided.
-6. Draft a concise PR description with these sections:
+2. Summarize the planned git and PR operations for the user and ask for confirmation before creating a branch, committing, pushing, or opening the PR. Include the proposed branch name, commit message if needed, push target, base branch, and draft status.
+3. If the current branch is the default branch, create a new descriptive feature branch and switch to it before proceeding.
+4. If there are uncommitted changes, commit them with a concise commit message that matches the repo's commit style.
+5. Push the branch to `origin` if it is not already published there.
+6. Draft a concise PR title from the branch name, commits, and diff unless one was provided.
+7. Draft a concise PR description with these sections:
    - `## Summary`
    - `## Testing`
    - `## Notes` only when needed for reviewer context
-7. Open the PR on GitHub against the requested base branch or the repository default branch.
-8. Report the branch name, commit range, PR number, and PR URL back to the user.
+8. Open the PR on GitHub against the requested base branch or the repository default branch.
+9. Report the branch name, commit range, PR number, and PR URL back to the user.
 
 ## Constraints
 
@@ -41,6 +44,6 @@ Create and post a concise pull request for the current work. Before opening the 
 
 ```bash
 /slcli-pr-create
-/slcli-pr-create Update semantic release changelog handling
-/slcli-pr-create draft base=release/1.x include the Python Semantic Release v10 regression details
+/slcli-pr-create title="Update semantic release changelog handling"
+/slcli-pr-create base=release/1.x draft=true context="Include the Python Semantic Release v10 regression details"
 ```


### PR DESCRIPTION
## Summary
- add a new `/slcli-pr-create` workspace prompt for creating concise pull requests
- ensure the prompt workflow checks branch state, moves work off the default branch when needed, pushes to origin, and opens the PR
- document the new slash command in `.github/AGENTS.md` alongside the existing PR review guidance

## Testing
- not run (prompt and documentation changes only)