### PR TITLE
Fix Homebrew install layout for slcli

### DIFF
--- a/newsfragments/134.patch.md
+++ b/newsfragments/134.patch.md
@@ -1,0 +1,1 @@
+Fix the Homebrew formula to install the staged slcli archive contents correctly.

--- a/scripts/homebrew-slcli.rb.j2
+++ b/scripts/homebrew-slcli.rb.j2
@@ -22,7 +22,7 @@ class Slcli < Formula
   end
 
   def install
-    libexec.install Dir["slcli/*"]
+    libexec.install Dir["*"]
     bin.install_symlink libexec/"slcli"
   end
 

--- a/tests/unit/test_release_packaging.py
+++ b/tests/unit/test_release_packaging.py
@@ -8,7 +8,7 @@ from scripts import build_homebrew, build_scoop
 
 
 def test_render_formula_installs_binary_contents(tmp_path: Path, monkeypatch: Any) -> None:
-    """The Homebrew formula should install the extracted binary contents, not the directory."""
+    """The Homebrew formula should install the staged archive contents into libexec."""
     output_path = tmp_path / "homebrew-slcli.rb"
     monkeypatch.setattr(build_homebrew, "DIST_FORMULA", output_path)
 
@@ -28,7 +28,7 @@ def test_render_formula_installs_binary_contents(tmp_path: Path, monkeypatch: An
         'url "https://github.com/ni-kismet/systemlink-cli/releases/download/v1.2.3/slcli-macos-15-intel.tar.gz"'
         in rendered
     )
-    assert 'libexec.install Dir["slcli/*"]' in rendered
+    assert 'libexec.install Dir["*"]' in rendered
     assert 'bin.install_symlink libexec/"slcli"' in rendered
 
 


### PR DESCRIPTION
## Summary
- align the Homebrew formula with Homebrew's staged archive layout by installing the extracted top-level contents into `libexec`
- update the packaging regression test to match the actual Homebrew extraction behavior observed during install

## Testing
- `poetry run pytest tests/unit/test_release_packaging.py -q`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- Added `134.patch.md` to note the Homebrew formula install-layout fix.