### PR TITLE
Add dataframe CLI command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SystemLink CLI (`slcli`) is a cross-platform Python CLI for SystemLink integrato
 ## Features
 
 - **20+ resource types** — test results, assets, systems, specifications, work items, notebooks, feeds, tags, files, users, policies, webapps, and more
+- **DataFrame tables** — inspect schema, query rows, export CSV, append data, and manage DataFrame table metadata
 - **Multi-platform** — supports SystemLink Enterprise (SLE) and SystemLink Server (SLS) with automatic detection
 - **Multi-profile** — manage dev, staging, and prod environments with named profiles
 - **AI agent skills** — installable skills for most AI agents (Copilot, Codex, etc.) and Claude — including a webapp skill for building Nimble Angular dashboards
@@ -65,6 +66,11 @@ slcli spec import --file docs/examples/specifications/import-specs.json
 slcli system compare "PXI Controller A" "PXI Controller B"
 slcli system compare sys-id-1 sys-id-2 -f json
 
+# Inspect DataFrame table shape and query rows
+slcli dataframe schema <table-id>
+slcli dataframe query <table-id> --columns Time,Voltage --where Voltage,GREATER_THAN,4.8 -f json
+slcli dataframe export <table-id> --output rows.csv
+
 # Scaffold the SystemLink Angular starter (AI skills auto-installed)
 slcli webapp init ./my-dashboard
 # Open the project and follow START_HERE.md or PROMPTS.md
@@ -94,6 +100,30 @@ slcli auto-detects terminal color support for tables, status lines, and JSON out
 - `SLCLI_COLOR=always` forces color when you want ANSI output even through wrappers or pseudo-terminals.
 - `SLCLI_COLOR=never` disables Rich color output explicitly.
 - `NO_COLOR=1` also disables color output and takes precedence over auto-detection.
+
+## DataFrames
+
+The `dataframe` command group manages tables hosted by the SystemLink DataFrame service.
+
+```bash
+# Discover tables and inspect schema
+slcli dataframe list --workspace all
+slcli dataframe get <table-id>
+slcli dataframe schema <table-id>
+
+# Query or decimate row data
+slcli dataframe query <table-id> --where State,EQUALS,FAIL --order-by Time:desc
+slcli dataframe decimate <table-id> --x-column Time --y-column Voltage --method MAX_MIN
+
+# Export and append data
+slcli dataframe export <table-id> --output rows.csv
+slcli dataframe append <table-id> --input append.json
+
+# Manage table metadata
+slcli dataframe create --definition table.json
+slcli dataframe update <table-id> --property owner=qa --column-property Voltage:units=V
+slcli dataframe delete <table-id>
+```
 
 ## Documentation
 

--- a/docs/dataframe-command-proposal.md
+++ b/docs/dataframe-command-proposal.md
@@ -1,0 +1,498 @@
+# DataFrame Command Proposal: Analysis & Recommendations
+
+**Date:** April 27, 2026  
+**Context:** Planning a new `slcli dataframe` command group against the `nidataframe` v1 OpenAPI
+
+---
+
+## Executive Summary
+
+The `nidataframe` API is a good fit for a new `slcli dataframe` command group, but the CLI should be designed around the actual service model:
+
+1. The resource is a **table**, not a generic mutable dataframe object.
+2. The primary value for CLI users is **schema discovery** and **scriptable row access**.
+3. Row writes are **append-only**. The API supports appending rows, but it does **not** expose arbitrary row update or delete operations.
+4. Table metadata is fully manageable: create, list, get, update metadata, and delete are all supported.
+
+**Recommendation:** Add a focused `slcli dataframe` group with standard metadata commands plus dedicated data access commands:
+
+```bash
+slcli dataframe list
+slcli dataframe get <table-id>
+slcli dataframe schema <table-id>
+slcli dataframe query <table-id>
+slcli dataframe export <table-id>
+slcli dataframe append <table-id>
+slcli dataframe create
+slcli dataframe update <table-id>
+slcli dataframe delete <table-id>
+```
+
+This gives users the three things they actually need:
+
+- discover table shape quickly
+- read/query/export rows in script-friendly formats
+- create tables and append new data without promising unsupported row-mutation behavior
+
+---
+
+## API Assessment
+
+### Available Endpoints
+
+#### Table metadata
+
+- `GET /nidataframe/v1/tables` — list tables
+- `POST /nidataframe/v1/query-tables` — query tables with filter, projection, ordering, pagination
+- `POST /nidataframe/v1/tables` — create table
+- `GET /nidataframe/v1/tables/{id}` — get table metadata and columns
+- `PATCH /nidataframe/v1/tables/{id}` — modify table metadata and column properties
+- `DELETE /nidataframe/v1/tables/{id}` — delete single table
+- `POST /nidataframe/v1/delete-tables` — delete multiple tables
+- `POST /nidataframe/v1/modify-tables` — modify multiple tables
+
+#### Row data
+
+- `GET /nidataframe/v1/tables/{id}/data` — read rows with basic column selection and ordering
+- `POST /nidataframe/v1/tables/{id}/query-data` — query rows with structured filters, ordering, pagination
+- `POST /nidataframe/v1/tables/{id}/export-data` — export rows, currently as CSV
+- `POST /nidataframe/v1/tables/{id}/data` — append rows using JSON or Arrow stream
+- `POST /nidataframe/v1/tables/{id}/query-decimated-data` — decimated reads for large numeric/timeseries tables
+
+### Data Model Shape
+
+The service already provides the information that matters most for scripting:
+
+- table-level metadata: `id`, `name`, `workspace`, `rowCount`, `supportsAppend`, `properties`, timestamps
+- column-level schema: `name`, `dataType`, `columnType`, `properties`
+- row data in split-oriented dataframe form:
+
+```json
+{
+  "frame": {
+    "columns": ["Time", "Voltage", "State"],
+    "data": [
+      ["2026-04-27T10:00:00.000Z", "5.01", "PASS"],
+      ["2026-04-27T10:00:01.000Z", "5.02", "PASS"]
+    ]
+  },
+  "totalRowCount": 2,
+  "continuationToken": null
+}
+```
+
+This is already script-friendly and should be preserved in `--format json` output instead of flattening it into a lossy custom shape.
+
+### Important Constraints
+
+#### 1. Row writes are append-only
+
+There is no API for updating or deleting existing rows. The CLI should expose this honestly as `append`, not `write` or `update-row`.
+
+#### 2. Exactly one index column is required at create time
+
+Each table must have exactly one `INDEX` column, and its type must be `INT32`, `INT64`, or `TIMESTAMP`.
+
+#### 3. Query filtering is structured, not Dynamic LINQ
+
+Unlike several existing services in `slcli`, row queries use structured filters like:
+
+```json
+{
+  "filters": [
+    {
+      "column": "Time",
+      "operation": "GREATER_THAN_EQUALS",
+      "value": "2026-04-01T00:00:00.000Z"
+    },
+    { "column": "State", "operation": "EQUALS", "value": "FAIL" }
+  ]
+}
+```
+
+That means the CLI should offer both:
+
+- convenience flags for common shell usage
+- a raw request-file option for complex queries
+
+#### 4. Export is CSV-only today
+
+The export endpoint supports `CSV`, either inline or via download link. The first CLI version should not invent unsupported export formats.
+
+---
+
+## Recommended CLI Structure
+
+### Core Metadata Commands
+
+#### `slcli dataframe list`
+
+Purpose: discover available tables.
+
+Recommended options:
+
+- `--name TEXT` — contains match on table name
+- `--workspace, -w TEXT` — workspace name or ID
+- `--test-result-id TEXT` — filter associated test result
+- `--supports-append / --no-supports-append`
+- `--filter TEXT` — raw `query-tables` filter expression
+- `--substitution TEXT` — repeatable substitutions for `--filter`
+- `--order-by [CREATED_AT|METADATA_MODIFIED_AT|NAME|NUMBER_OF_ROWS|ROWS_MODIFIED_AT]`
+- `--descending / --ascending`
+- `--take, -t INTEGER` — default 25 for table output
+- `--format, -f [table|json]`
+
+Implementation notes:
+
+- Use `POST /query-tables` instead of `GET /tables` for consistency and better filtering.
+- Default table output should show: `Name`, `ID`, `Workspace`, `Rows`, `Append`, `Modified`.
+- Default JSON output should return the service response shape or a minimal wrapper that still includes `continuationToken`.
+
+#### `slcli dataframe get <table-id>`
+
+Purpose: show one table's metadata summary.
+
+Recommended output:
+
+- summary fields: `id`, `name`, `workspace`, `rowCount`, `supportsAppend`, `testResultId`, timestamps
+- column count
+- properties count or selected properties
+
+Recommended options:
+
+- `--format, -f [table|json]`
+
+Implementation notes:
+
+- Use `GET /tables/{id}`.
+- Table output should be concise and lead with schema facts, not just dump properties.
+
+#### `slcli dataframe schema <table-id>`
+
+Purpose: make table shape inspection first-class for shell scripting and humans.
+
+Recommended output:
+
+- one row per column
+- columns: `Name`, `Data Type`, `Column Type`, `Properties`
+
+Recommended options:
+
+- `--format, -f [table|json]`
+- `--properties/--no-properties` — include column property maps in table output
+
+Rationale:
+
+- `get` is useful for resource metadata.
+- `schema` is the command users will actually reach for when they need to know how to query or append data.
+
+### Data Access Commands
+
+#### `slcli dataframe query <table-id>`
+
+Purpose: read rows with column selection, filtering, ordering, and pagination.
+
+Recommended options:
+
+- `--columns TEXT` — comma-separated column list in response order
+- `--where TEXT` — repeatable shorthand in the form `column,operation,value`
+- `--order-by TEXT` — repeatable shorthand in the form `column[:asc|desc]`
+- `--take, -t INTEGER` — default 100 for interactive use, max 10000
+- `--continuation-token TEXT`
+- `--request FILE` — raw JSON request body for advanced use
+- `--format, -f [table|json]`
+
+Recommended JSON behavior:
+
+- return `frame`, `totalRowCount`, and `continuationToken`
+- do not silently reshape split-format data into record arrays
+
+Recommended table behavior:
+
+- render the returned frame as a normal table using `frame.columns`
+- if `continuationToken` exists, display a pager prompt similar to other list commands
+
+Implementation notes:
+
+- Use `POST /tables/{id}/query-data` for almost everything.
+- Keep `GET /tables/{id}/data` as an internal fast-path only if the request is a simple projection/order case.
+- Add a `--request` file path because structured filter syntax is too awkward to force entirely through flags.
+
+#### `slcli dataframe export <table-id>`
+
+Purpose: export query results to CSV for downstream tools.
+
+Recommended options:
+
+- same filter, column, and ordering options as `query`
+- `--take INTEGER`
+- `--output, -o FILE` — required for file export workflow
+- `--inline` — print CSV to stdout when no output file is given
+
+Implementation notes:
+
+- Use `POST /tables/{id}/export-data` with `responseFormat=CSV`.
+- Default to inline response handling for simple piping.
+- Support writing the CSV body directly to `--output`.
+- Do not add XLSX or Parquet until the service supports it or the CLI intentionally performs a client-side conversion.
+
+### Write Commands
+
+#### `slcli dataframe append <table-id>`
+
+Purpose: append new rows to an existing table.
+
+Recommended options:
+
+- `--input, -i FILE` — JSON file in DataFrame split format
+- `--columns TEXT` — optional override when reading row-only input formats later
+- `--end-of-data` — mark the table complete after append
+- `--format, -f [json]` only if we want a machine-readable confirmation block
+
+Initial scope recommendation:
+
+- support JSON input first
+- defer Arrow stream input unless a clear performance use case appears
+
+Example input:
+
+```json
+{
+  "frame": {
+    "columns": ["Time", "Voltage", "State"],
+    "data": [
+      ["2026-04-27T10:00:00.000Z", "5.01", "PASS"],
+      ["2026-04-27T10:00:01.000Z", "4.72", "FAIL"]
+    ]
+  },
+  "endOfData": false
+}
+```
+
+Implementation notes:
+
+- Use `POST /tables/{id}/data`.
+- Validate input early against obvious table constraints when practical:
+  - referenced columns exist
+  - non-nullable columns are present unless omitted by design with full-column ordering
+  - `endOfData` semantics are explicit
+
+#### `slcli dataframe create`
+
+Purpose: create a new table with explicit schema.
+
+Recommended options:
+
+- `--definition FILE` — JSON request body file
+- `--name TEXT` — convenience override
+- `--workspace, -w TEXT`
+- `--format, -f [table|json]`
+
+Initial scope recommendation:
+
+- require a JSON definition file in the service schema
+- optionally add repeated `--column` convenience flags later if users ask for it
+
+Rationale:
+
+- table definitions are structured enough that file-based input is clearer and safer than a long list of flags
+- this matches the service contract closely and keeps the first implementation small
+
+#### `slcli dataframe update <table-id>`
+
+Purpose: update table metadata and column properties.
+
+Recommended options:
+
+- `--name TEXT`
+- `--workspace, -w TEXT`
+- `--test-result-id TEXT`
+- `--property KEY=VALUE` — repeatable
+- `--remove-property KEY` — repeatable
+- `--column-property COLUMN:KEY=VALUE` — repeatable
+- `--remove-column-property COLUMN:KEY` — repeatable
+- `--metadata-revision INTEGER` — optional optimistic concurrency support
+
+Implementation notes:
+
+- Use `PATCH /tables/{id}` for single-table edits.
+- Keep batch metadata modification out of the first release.
+
+#### `slcli dataframe delete <table-id>`
+
+Purpose: remove a table and all of its data.
+
+Recommended options:
+
+- `-y, --yes` — skip confirmation
+
+Implementation notes:
+
+- Use `DELETE /tables/{id}` for the initial version.
+- Add multi-delete only if we see a real need.
+
+---
+
+## Recommended UX Priorities
+
+### Priority 1: Schema-first discoverability
+
+The first user story to optimize is:
+
+```bash
+slcli dataframe schema <table-id>
+slcli dataframe get <table-id> -f json
+slcli dataframe query <table-id> --take 5 -f json
+```
+
+This covers the fastest path to understanding:
+
+- what columns exist
+- which one is the index
+- what types values must use
+- how row data is returned
+
+### Priority 2: Shell-safe advanced querying
+
+Structured filters are powerful but awkward to express inline. The CLI should support both:
+
+```bash
+slcli dataframe query <id> \
+  --where 'State,EQUALS,FAIL' \
+  --where 'Voltage,LESS_THAN,4.8' \
+  --columns Time,Voltage,State
+```
+
+and:
+
+```bash
+slcli dataframe query <id> --request query.json -f json
+```
+
+The file-based path is important for maintainability in scripts.
+
+### Priority 3: Honest write semantics
+
+Use `append`, not `write`, and document clearly that existing rows cannot be mutated through this API.
+
+---
+
+## Implementation Plan
+
+### Phase 1: MVP
+
+Deliver the commands that provide immediate schema and scripting value:
+
+1. `slcli dataframe list`
+2. `slcli dataframe get`
+3. `slcli dataframe schema`
+4. `slcli dataframe query`
+5. `slcli dataframe export`
+6. `slcli dataframe append`
+
+Why this set first:
+
+- it covers discovery, inspection, read access, CSV export, and append workflows
+- it avoids spending time on metadata mutation before the data read path is proven useful
+- it matches the user's stated priority around understanding table shape
+
+### Phase 2: Full management
+
+Add metadata lifecycle operations:
+
+1. `slcli dataframe create`
+2. `slcli dataframe update`
+3. `slcli dataframe delete`
+
+### Phase 3: Advanced and optional
+
+Only add after validating demand:
+
+1. `slcli dataframe decimate` backed by `query-decimated-data`
+2. Arrow stream import for high-volume append workflows
+3. batch metadata operations
+4. batch delete
+
+---
+
+## Implementation Notes For This Repository
+
+### File layout
+
+Expected files:
+
+- `slcli/dataframe_click.py`
+- `tests/unit/test_dataframe_click.py`
+
+Possible helpers if the command grows beyond one file:
+
+- `slcli/dataframe_utils.py`
+- `slcli/cli_formatters.py` additions for schema and row formatting
+
+### Registration
+
+Add `register_dataframe_commands(cli)` in `slcli/main.py`.
+
+### Shared patterns to follow
+
+- Use `handle_api_error()` for all API failures.
+- Use `format_success()` for create, update, append, and delete confirmations.
+- Use `UniversalResponseHandler` where it fits list responses.
+- Reuse workspace resolution helpers so `--workspace` accepts both workspace name and ID.
+- Keep `--format table|json` behavior consistent with other command groups.
+
+### Existing useful reference
+
+`slcli/example_provisioner.py` already contains lightweight helper logic for:
+
+- create table
+- query table by name
+- delete table by name
+
+That code should be treated as a reference for endpoint usage, not copied directly into the CLI implementation.
+
+---
+
+## Testing Plan
+
+### Unit tests
+
+Add focused tests for:
+
+1. `list` building the expected `query-tables` request payload
+2. `schema` rendering column definitions correctly
+3. `query` translating `--where` and `--order-by` into the expected API request
+4. `query --request FILE` passing through raw JSON safely
+5. `export` writing CSV output correctly
+6. `append` validating input and posting the expected payload
+7. `update` building property and column-property patch payloads correctly
+8. error handling for not found, invalid filters, and append conflicts
+
+### Validation commands for implementation work
+
+After code changes:
+
+```bash
+poetry run ni-python-styleguide lint
+poetry run mypy slcli tests
+poetry run pytest tests/unit/test_dataframe_click.py -q
+poetry run pytest tests/unit -q
+poetry run pytest
+```
+
+---
+
+## Open Questions
+
+1. Should `query --format table` auto-page through continuation tokens interactively, or only show a single page unless the user passes a follow-up token?
+2. Should `append` support CSV input in addition to JSON, or is JSON enough for the first version?
+3. Should `list --format json` return the raw API response with `tables` and `continuationToken`, or a flattened array plus token metadata wrapper?
+4. Do we want `schema` to accept table name lookup when unique within workspace, or should it stay ID-only initially?
+
+---
+
+## Bottom Line
+
+The right `slcli dataframe` plan is not a generic CRUD surface. It is a **schema-first, table-centric** command group that makes dataframe shape easy to inspect and row data easy to query and export, while exposing row writes accurately as **append-only**.
+
+If we scope the first implementation to `list`, `get`, `schema`, `query`, `export`, and `append`, we will cover the most valuable scripting workflows without over-designing unsupported capabilities.

--- a/newsfragments/134.minor.md
+++ b/newsfragments/134.minor.md
@@ -1,0 +1,1 @@
+Add a new `slcli dataframe` command group for DataFrame table discovery, schema inspection, row query and decimation, CSV export, append, and metadata lifecycle operations.

--- a/scripts/styleguide.py
+++ b/scripts/styleguide.py
@@ -11,7 +11,7 @@ from typing import Sequence
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FLAKE8_CONFIG = REPO_ROOT / ".flake8"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
-DEFAULT_EXCLUDE = "__pycache__,.git,.venv"
+DEFAULT_EXCLUDE = "__pycache__,.git,.venv,build"
 
 
 def _run(cmd: Sequence[str]) -> int:

--- a/site/commands.html
+++ b/site/commands.html
@@ -83,7 +83,7 @@
         <div class="cmd-group"><h3>testmonitor</h3><p>Test results, products, steps, measurements</p><code>slcli testmonitor result list</code></div>
         <div class="cmd-group"><h3>asset</h3><p>Hardware assets, calibration, fleet summary</p><code>slcli asset list</code></div>
         <div class="cmd-group"><h3>system</h3><p>Managed systems, package comparison, jobs, reports</p><code>slcli system list</code></div>
-        <div class="cmd-group"><h3>dataframe</h3><p>DataFrame tables, schema inspection, row queries, CSV export</p><code>slcli dataframe schema</code></div>
+        <div class="cmd-group"><h3>dataframe</h3><p>DataFrame tables, schema inspection, row queries, CSV export</p><code>slcli dataframe schema &lt;table-id&gt;</code></div>
         <div class="cmd-group"><h3>spec</h3><p>Product specifications, limits, conditions, bulk import/export</p><code>slcli spec list</code></div>
         <div class="cmd-group"><h3>workitem</h3><p>Work items, templates, workflows</p><code>slcli workitem list</code></div>
         <div class="cmd-group"><h3>template</h3><p>Test plan templates</p><code>slcli template list</code></div>

--- a/site/commands.html
+++ b/site/commands.html
@@ -52,6 +52,7 @@
         <a href="#testmonitor" class="sidebar-link">testmonitor</a>
         <a href="#asset" class="sidebar-link">asset</a>
         <a href="#system" class="sidebar-link">system</a>
+        <a href="#dataframe" class="sidebar-link">dataframe</a>
         <a href="#spec" class="sidebar-link">spec</a>
         <a href="#workitem" class="sidebar-link">workitem</a>
         <a href="#template" class="sidebar-link">template</a>
@@ -82,6 +83,7 @@
         <div class="cmd-group"><h3>testmonitor</h3><p>Test results, products, steps, measurements</p><code>slcli testmonitor result list</code></div>
         <div class="cmd-group"><h3>asset</h3><p>Hardware assets, calibration, fleet summary</p><code>slcli asset list</code></div>
         <div class="cmd-group"><h3>system</h3><p>Managed systems, package comparison, jobs, reports</p><code>slcli system list</code></div>
+        <div class="cmd-group"><h3>dataframe</h3><p>DataFrame tables, schema inspection, row queries, CSV export</p><code>slcli dataframe schema</code></div>
         <div class="cmd-group"><h3>spec</h3><p>Product specifications, limits, conditions, bulk import/export</p><code>slcli spec list</code></div>
         <div class="cmd-group"><h3>workitem</h3><p>Work items, templates, workflows</p><code>slcli workitem list</code></div>
         <div class="cmd-group"><h3>template</h3><p>Test plan templates</p><code>slcli template list</code></div>
@@ -284,6 +286,81 @@ slcli system job cancel &lt;job-id&gt;</code></pre>
       <h3>Update &amp; Remove</h3>
       <pre><code>slcli system update &lt;system-id&gt; --alias "New Name" --workspace "Production"
 slcli system remove &lt;system-id&gt; --force</code></pre>
+
+      <!-- ─── DATAFRAME ─── -->
+      <h2 id="dataframe">dataframe</h2>
+      <p>Inspect DataFrame table shape, query and decimate row data, export CSV, append rows, and manage table metadata.</p>
+
+      <h3>Discover Tables</h3>
+      <pre><code># List tables across all workspaces
+    slcli dataframe list --workspace all
+
+    # Filter by name, associated test result, or append capability
+    slcli dataframe list --name "Battery" --supports-append
+    slcli dataframe list --test-result-id &lt;result-id&gt; --format json
+
+    # Apply advanced table filters with substitutions
+    slcli dataframe list \
+      --filter '(name.Contains(@0)) &amp;&amp; (supportsAppend == @1)' \
+      --substitution "Battery" \
+      --substitution true</code></pre>
+
+      <h3>Inspect Metadata &amp; Schema</h3>
+      <pre><code># Summary plus schema preview
+    slcli dataframe get &lt;table-id&gt;
+
+    # Schema only
+    slcli dataframe schema &lt;table-id&gt;
+    slcli dataframe schema &lt;table-id&gt; --properties --format json</code></pre>
+
+      <h3>Query &amp; Decimate Row Data</h3>
+      <pre><code># Query selected columns with filters and sorting
+    slcli dataframe query &lt;table-id&gt; \
+      --columns Time,Voltage,State \
+      --where State,EQUALS,FAIL \
+      --order-by Time:desc
+
+    # Resume a paged read from a continuation token
+    slcli dataframe query &lt;table-id&gt; --continuation-token &lt;token&gt; --format json
+
+    # Use a raw request payload for advanced queries
+    slcli dataframe query &lt;table-id&gt; --request query.json --format json
+
+    # Decimate large time-series tables for plotting
+    slcli dataframe decimate &lt;table-id&gt; \
+      --x-column Time \
+      --y-column Voltage \
+      --y-column Current \
+      --method MAX_MIN \
+      --intervals 500</code></pre>
+
+      <h3>Export &amp; Append</h3>
+      <pre><code># Export CSV inline or to a file
+    slcli dataframe export &lt;table-id&gt; --where Cycle,GREATER_THAN,3
+    slcli dataframe export &lt;table-id&gt; --output rows.csv
+
+    # Append JSON frame payloads
+    slcli dataframe append &lt;table-id&gt; --input append.json
+
+    # Append Arrow stream payloads and mark the table complete
+    slcli dataframe append &lt;table-id&gt; --input rows.arrow --input-format arrow --end-of-data</code></pre>
+
+      <h3>Create, Update, &amp; Delete</h3>
+      <pre><code># Create from a definition file
+    slcli dataframe create --definition table.json --workspace Production
+
+    # Update metadata and column properties
+    slcli dataframe update &lt;table-id&gt; \
+      --property owner=qa \
+      --column-property Voltage:units=V \
+      --metadata-revision 2
+
+    # Batch metadata updates from a raw request payload
+    slcli dataframe update-many --definition modify-tables.json
+
+    # Delete one or more tables
+    slcli dataframe delete &lt;table-id&gt; --yes
+    slcli dataframe delete &lt;id-1&gt; &lt;id-2&gt; --yes</code></pre>
 
       <!-- ─── SPEC ─── -->
       <h2 id="spec">spec</h2>

--- a/slcli/comment_click.py
+++ b/slcli/comment_click.py
@@ -20,6 +20,7 @@ from urllib.parse import urlencode
 import click
 
 from .cli_utils import validate_output_format
+from .platform import require_feature
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
     ExitCodes,
@@ -185,14 +186,16 @@ def register_comment_commands(cli: Any) -> None:
     """Register the 'comment' command group and its subcommands."""
 
     @cli.group()
-    def comment() -> None:
+    @click.pass_context
+    def comment(ctx: click.Context) -> None:
         """Manage comments on SystemLink resources.
 
         Comments can be attached to any resource identified by a resource type
         and resource ID. Known resource types: testmonitor:Result, niapm:Asset,
         nisysmgmt:System, workorder:workorder, workitem:workitem, DataSpace.
         """
-        pass
+        if ctx.invoked_subcommand is not None:
+            require_feature("comments_service")
 
     # ─────────────────────────────────────────────────────────────
     # comment list

--- a/slcli/dataframe_click.py
+++ b/slcli/dataframe_click.py
@@ -629,7 +629,7 @@ def _post_arrow_append(table_id: str, input_path: str, end_of_data: bool) -> req
             response = requests_lib.post(
                 url,
                 headers=get_headers("application/vnd.apache.arrow.stream"),
-                data=arrow_file.read(),
+                data=arrow_file,
                 verify=get_ssl_verify(),
             )
         response.raise_for_status()
@@ -649,7 +649,12 @@ def register_dataframe_commands(cli: Any) -> None:
 
     @dataframe.command(name="list")
     @click.option("--name", help="Filter tables by name using contains matching")
-    @click.option("--workspace", "workspace_name", "-w", help="Workspace name or ID")
+    @click.option(
+        "--workspace",
+        "workspace_name",
+        "-w",
+        help="Workspace name or ID. Use 'all' to disable workspace filtering.",
+    )
     @click.option("--test-result-id", help="Filter by associated test result ID")
     @click.option(
         "--supports-append/--no-supports-append",
@@ -958,7 +963,7 @@ def register_dataframe_commands(cli: Any) -> None:
             if output:
                 with open(output, "w", encoding="utf-8") as output_file:
                     output_file.write(csv_text)
-                format_success("Dataframe table exported", {"id": table_id, "output": output})
+                format_success("DataFrame table exported", {"id": table_id, "output": output})
                 return
 
             click.echo(csv_text, nl=not csv_text.endswith("\n"))
@@ -967,7 +972,14 @@ def register_dataframe_commands(cli: Any) -> None:
 
     @dataframe.command(name="append")
     @click.argument("table_id")
-    @click.option("--input", "input_path", "-i", required=True, help="Input file path")
+    @click.option(
+        "--input",
+        "input_path",
+        "-i",
+        required=True,
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        help="Input file path",
+    )
     @click.option(
         "--input-format",
         type=click.Choice(["json", "arrow"]),
@@ -986,7 +998,7 @@ def register_dataframe_commands(cli: Any) -> None:
             if input_format == "arrow":
                 _post_arrow_append(table_id, input_path, end_of_data)
                 format_success(
-                    "Dataframe rows appended",
+                    "DataFrame rows appended",
                     {"id": table_id, "input": input_path, "format": input_format},
                 )
                 return
@@ -1003,7 +1015,7 @@ def register_dataframe_commands(cli: Any) -> None:
             frame = payload.get("frame", {}) if isinstance(payload.get("frame"), dict) else {}
             rows_appended = len(frame.get("data", []) or [])
             format_success(
-                "Dataframe rows appended",
+                "DataFrame rows appended",
                 {
                     "id": table_id,
                     "rows": rows_appended,
@@ -1057,7 +1069,7 @@ def register_dataframe_commands(cli: Any) -> None:
                 return
 
             format_success(
-                "Dataframe table created",
+                "DataFrame table created",
                 {"id": created.get("id", ""), "name": payload.get("name", "")},
             )
         except Exception as exc:
@@ -1114,7 +1126,7 @@ def register_dataframe_commands(cli: Any) -> None:
             make_api_request(
                 "PATCH", f"{_get_dataframe_base_url()}/tables/{table_id}", payload=payload
             )
-            format_success("Dataframe table updated", {"id": table_id})
+            format_success("DataFrame table updated", {"id": table_id})
         except Exception as exc:
             handle_api_error(exc)
 
@@ -1137,13 +1149,13 @@ def register_dataframe_commands(cli: Any) -> None:
                 "POST", f"{_get_dataframe_base_url()}/modify-tables", payload=payload
             )
             if response.status_code == 204:
-                format_success("Dataframe tables updated")
+                format_success("DataFrame tables updated")
                 return
 
             data = response.json() if response.text.strip() else {}
             modified_ids = data.get("modifiedTableIds", []) or []
             format_success(
-                "Dataframe tables updated with partial success", {"updated": len(modified_ids)}
+                "DataFrame tables updated with partial success", {"updated": len(modified_ids)}
             )
             if data.get("failedModifications"):
                 error_value = data.get("error")
@@ -1170,21 +1182,21 @@ def register_dataframe_commands(cli: Any) -> None:
         try:
             if len(ids) == 1:
                 make_api_request("DELETE", f"{_get_dataframe_base_url()}/tables/{ids[0]}")
-                format_success("Dataframe table deleted", {"id": ids[0]})
+                format_success("DataFrame table deleted", {"id": ids[0]})
                 return
 
             response = make_api_request(
                 "POST", f"{_get_dataframe_base_url()}/delete-tables", payload={"ids": ids}
             )
             if response.status_code == 204:
-                format_success("Dataframe tables deleted", {"count": len(ids)})
+                format_success("DataFrame tables deleted", {"count": len(ids)})
                 return
 
             data = response.json() if response.text.strip() else {}
             deleted_ids = data.get("deletedTableIds", []) or []
             failed_ids = data.get("failedTableIds", []) or []
             format_success(
-                "Dataframe tables deleted with partial success", {"deleted": len(deleted_ids)}
+                "DataFrame tables deleted with partial success", {"deleted": len(deleted_ids)}
             )
             if failed_ids:
                 error_value = data.get("error")

--- a/slcli/dataframe_click.py
+++ b/slcli/dataframe_click.py
@@ -10,6 +10,7 @@ import requests as requests_lib
 from click.core import ParameterSource
 
 from .cli_utils import confirm_bulk_operation, validate_output_format
+from .platform import require_feature
 from .rich_output import render_table
 from .utils import (
     ExitCodes,
@@ -643,9 +644,11 @@ def register_dataframe_commands(cli: Any) -> None:
     """Register the dataframe command group and subcommands."""
 
     @cli.group()
-    def dataframe() -> None:
+    @click.pass_context
+    def dataframe(ctx: click.Context) -> None:
         """Manage SystemLink DataFrame tables and row data."""
-        pass
+        if ctx.invoked_subcommand is not None:
+            require_feature("dataframe_service")
 
     @dataframe.command(name="list")
     @click.option("--name", help="Filter tables by name using contains matching")
@@ -791,7 +794,11 @@ def register_dataframe_commands(cli: Any) -> None:
     )
     @click.option("--take", "-t", type=int, default=100, show_default=True, help="Rows per page")
     @click.option("--continuation-token", help="Continuation token for paged reads")
-    @click.option("--request", type=click.Path(exists=True), help="Path to raw query JSON")
+    @click.option(
+        "--request",
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        help="Path to raw query JSON",
+    )
     @click.option(
         "--format",
         "-f",
@@ -863,7 +870,11 @@ def register_dataframe_commands(cli: Any) -> None:
         type=click.Choice(DECIMATION_DISTRIBUTION_CHOICES),
         help="Distribution for interval bucketing",
     )
-    @click.option("--request", type=click.Path(exists=True), help="Path to raw decimation JSON")
+    @click.option(
+        "--request",
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        help="Path to raw decimation JSON",
+    )
     @click.option(
         "--format",
         "-f",
@@ -930,8 +941,17 @@ def register_dataframe_commands(cli: Any) -> None:
         help="Sort clause in the form column[:asc|desc]. Repeat for multiple clauses.",
     )
     @click.option("--take", type=int, help="Limit the number of exported rows")
-    @click.option("--request", type=click.Path(exists=True), help="Path to raw export JSON")
-    @click.option("--output", "-o", help="Output CSV file path")
+    @click.option(
+        "--request",
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        help="Path to raw export JSON",
+    )
+    @click.option(
+        "--output",
+        "-o",
+        type=click.Path(dir_okay=False, writable=True),
+        help="Output CSV file path",
+    )
     def export_table_data(
         table_id: str,
         columns: Optional[str],
@@ -1027,7 +1047,10 @@ def register_dataframe_commands(cli: Any) -> None:
 
     @dataframe.command(name="create")
     @click.option(
-        "--definition", type=click.Path(exists=True), required=True, help="Create request JSON"
+        "--definition",
+        type=click.Path(exists=True, dir_okay=False, readable=True),
+        required=True,
+        help="Create request JSON",
     )
     @click.option("--name", help="Override the table name in the definition file")
     @click.option("--workspace", "workspace_name", "-w", help="Workspace name or ID")
@@ -1133,7 +1156,7 @@ def register_dataframe_commands(cli: Any) -> None:
     @dataframe.command(name="update-many")
     @click.option(
         "--definition",
-        type=click.Path(exists=True),
+        type=click.Path(exists=True, dir_okay=False, readable=True),
         required=True,
         help="Modify-tables request JSON",
     )

--- a/slcli/dataframe_click.py
+++ b/slcli/dataframe_click.py
@@ -1,0 +1,1196 @@
+"""CLI commands for managing SystemLink DataFrame tables."""
+
+import json
+import sys
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, NoReturn, Optional, Tuple
+
+import click
+import requests as requests_lib
+from click.core import ParameterSource
+
+from .cli_utils import confirm_bulk_operation, validate_output_format
+from .rich_output import render_table
+from .utils import (
+    ExitCodes,
+    check_readonly_mode,
+    format_success,
+    get_base_url,
+    get_headers,
+    get_ssl_verify,
+    get_workspace_map,
+    handle_api_error,
+    load_json_file,
+    make_api_request,
+)
+from .workspace_utils import (
+    get_effective_workspace,
+    get_workspace_display_name,
+    resolve_workspace_filter,
+)
+
+TABLE_ORDER_BY_CHOICES = [
+    "CREATED_AT",
+    "METADATA_MODIFIED_AT",
+    "NAME",
+    "NUMBER_OF_ROWS",
+    "ROWS_MODIFIED_AT",
+]
+
+FILTER_OPERATION_CHOICES = [
+    "EQUALS",
+    "LESS_THAN",
+    "LESS_THAN_EQUALS",
+    "GREATER_THAN",
+    "GREATER_THAN_EQUALS",
+    "NOT_EQUALS",
+    "CONTAINS",
+    "NOT_CONTAINS",
+]
+
+DECIMATION_METHOD_CHOICES = ["LOSSY", "MAX_MIN", "ENTRY_EXIT"]
+DECIMATION_DISTRIBUTION_CHOICES = ["EQUAL_FREQUENCY", "EQUAL_WIDTH"]
+
+
+def _get_dataframe_base_url() -> str:
+    """Return the DataFrame service base URL."""
+    return f"{get_base_url()}/nidataframe/v1"
+
+
+def _exit_invalid_input(message: str) -> NoReturn:
+    """Exit with a consistent invalid input message."""
+    click.echo(f"✗ {message}", err=True)
+    sys.exit(ExitCodes.INVALID_INPUT)
+
+
+def _validate_take(value: int, maximum: int, label: str = "take") -> int:
+    """Validate take-style limits against the service maximum."""
+    if value < 1 or value > maximum:
+        _exit_invalid_input(f"{label} must be between 1 and {maximum}")
+    return value
+
+
+def _parse_substitutions(values: Iterable[str]) -> List[Any]:
+    """Parse query-table substitutions from CLI strings."""
+    parsed: List[Any] = []
+    for value in values:
+        try:
+            parsed.append(json.loads(value))
+        except (json.JSONDecodeError, TypeError):
+            parsed.append(value)
+    return parsed
+
+
+def _offset_substitutions(filter_expr: str, offset: int) -> str:
+    """Offset substitution indices in a Dynamic LINQ filter."""
+    if offset <= 0:
+        return filter_expr
+
+    def _replace(match: Any) -> str:
+        return f"@{int(match.group(1)) + offset}"
+
+    import re
+
+    return re.sub(r"@(\d+)", _replace, filter_expr)
+
+
+def _combine_filter_parts(
+    base_filter: Optional[str],
+    base_substitutions: List[Any],
+    extra_filter: Optional[str],
+    extra_substitutions: List[Any],
+) -> Tuple[Optional[str], List[Any]]:
+    """Combine structured and raw table filters."""
+    if not extra_filter:
+        return base_filter, base_substitutions
+
+    if base_filter:
+        offset_filter = _offset_substitutions(extra_filter, len(base_substitutions))
+        return (
+            f"({base_filter}) && ({offset_filter})",
+            base_substitutions + extra_substitutions,
+        )
+
+    return extra_filter, extra_substitutions
+
+
+def _append_filter(
+    filter_parts: List[str],
+    substitutions: List[Any],
+    expression: str,
+    value: Optional[Any],
+) -> None:
+    """Append a filter expression if the value is present."""
+    if value is None or value == "":
+        return
+    index = len(substitutions)
+    filter_parts.append(expression.format(index=index))
+    substitutions.append(value)
+
+
+def _resolve_workspace_id(workspace: Optional[str], apply_default: bool = True) -> Optional[str]:
+    """Resolve a workspace name or ID to a workspace ID."""
+    effective = get_effective_workspace(workspace) if apply_default else workspace
+    if not effective:
+        return None
+
+    workspace_map = get_workspace_map()
+    return resolve_workspace_filter(effective, workspace_map)
+
+
+def _parse_columns(columns_text: Optional[str]) -> Optional[List[str]]:
+    """Parse a comma-separated column list."""
+    if not columns_text:
+        return None
+
+    columns = [column.strip() for column in columns_text.split(",") if column.strip()]
+    return columns or None
+
+
+def _parse_filter_value(value: str) -> Optional[str]:
+    """Parse a row filter value while preserving the API's string semantics."""
+    normalized = value.strip()
+    if normalized.lower() == "null":
+        return None
+    return normalized
+
+
+def _parse_where_clause(where_clause: str) -> Dict[str, Any]:
+    """Parse a `column,operation,value` row filter clause."""
+    parts = [part.strip() for part in where_clause.split(",", maxsplit=2)]
+    if len(parts) != 3 or not parts[0] or not parts[1]:
+        _exit_invalid_input(
+            "--where must use the format column,operation,value "
+            "for example Voltage,LESS_THAN,4.8"
+        )
+
+    column, operation, value = parts
+    if operation not in FILTER_OPERATION_CHOICES:
+        _exit_invalid_input(
+            f"Unsupported filter operation '{operation}'. "
+            f"Valid options: {', '.join(FILTER_OPERATION_CHOICES)}"
+        )
+
+    return {"column": column, "operation": operation, "value": _parse_filter_value(value)}
+
+
+def _parse_order_by_clause(order_by_clause: str) -> Dict[str, Any]:
+    """Parse a `column[:asc|desc]` order-by clause."""
+    column = order_by_clause.strip()
+    descending = False
+
+    if ":" in order_by_clause:
+        column, direction = [part.strip() for part in order_by_clause.rsplit(":", maxsplit=1)]
+        lowered = direction.lower()
+        if lowered not in {"asc", "desc"}:
+            _exit_invalid_input("--order-by must use :asc or :desc when a direction is provided")
+        descending = lowered == "desc"
+
+    if not column:
+        _exit_invalid_input("--order-by requires a column name")
+
+    return {"column": column, "descending": descending}
+
+
+def _format_properties(properties: Any, maximum_length: int = 60) -> str:
+    """Format property dictionaries for compact table output."""
+    if not properties:
+        return ""
+
+    rendered = json.dumps(properties, sort_keys=True)
+    if len(rendered) <= maximum_length:
+        return rendered
+    return rendered[: maximum_length - 3] + "..."
+
+
+def _format_bool(value: Any) -> str:
+    """Format a boolean-like value for table output."""
+    return "✓" if bool(value) else ""
+
+
+def _calculate_column_widths(
+    headers: List[str], rows: List[List[str]], maximum: int = 36
+) -> List[int]:
+    """Calculate display widths for Rich table rendering."""
+    widths: List[int] = []
+    for index, header in enumerate(headers):
+        width = len(header)
+        for row in rows:
+            width = max(width, len(row[index]))
+        widths.append(min(max(width, 8), maximum))
+    return widths
+
+
+def _render_grid(
+    headers: List[str], rows: List[List[str]], total_label: Optional[str] = None
+) -> None:
+    """Render a grid table using shared rich output."""
+    render_table(
+        headers,
+        _calculate_column_widths(headers, rows),
+        rows,
+        show_total=bool(total_label),
+        total_label=total_label or "item(s)",
+    )
+
+
+def _render_key_value_table(title: str, data: Dict[str, Any]) -> None:
+    """Render a vertical key-value table."""
+    click.echo(title)
+    rows = [[key, "" if value is None else str(value)] for key, value in data.items()]
+    _render_grid(["Field", "Value"], rows)
+
+
+def _render_table_summary(table_data: Dict[str, Any], workspace_map: Dict[str, str]) -> None:
+    """Render table metadata in a compact human-readable form."""
+    summary = {
+        "ID": table_data.get("id", ""),
+        "Name": table_data.get("name", ""),
+        "Workspace": get_workspace_display_name(table_data.get("workspace", ""), workspace_map),
+        "Rows": table_data.get("rowCount", ""),
+        "Columns": len(table_data.get("columns", []) or []),
+        "Supports Append": table_data.get("supportsAppend", False),
+        "Test Result": table_data.get("testResultId", ""),
+        "Created": table_data.get("createdAt", ""),
+        "Rows Modified": table_data.get("rowsModifiedAt", ""),
+        "Metadata Modified": table_data.get("metadataModifiedAt", ""),
+        "Properties": _format_properties(table_data.get("properties", {})),
+    }
+    _render_key_value_table("DataFrame Table", summary)
+
+
+def _render_schema_table(columns: List[Dict[str, Any]], include_properties: bool) -> None:
+    """Render table schema rows."""
+    headers = ["Name", "Data Type", "Column Type"]
+    if include_properties:
+        headers.append("Properties")
+
+    rows: List[List[str]] = []
+    for column in columns:
+        row = [
+            str(column.get("name", "")),
+            str(column.get("dataType", "")),
+            str(column.get("columnType", "")),
+        ]
+        if include_properties:
+            row.append(_format_properties(column.get("properties", {}), maximum_length=80))
+        rows.append(row)
+
+    if not rows:
+        click.echo("No columns found.")
+        return
+
+    _render_grid(headers, rows, total_label="column(s)")
+
+
+def _render_frame_table(frame: Dict[str, Any], empty_message: str = "No rows found.") -> None:
+    """Render a split-oriented dataframe payload as a Rich table."""
+    columns = frame.get("columns") or []
+    data_rows = frame.get("data") or []
+
+    if not columns or not data_rows:
+        click.echo(empty_message)
+        return
+
+    rows: List[List[str]] = []
+    for row in data_rows:
+        rows.append(["" if value is None else str(value) for value in row])
+
+    _render_grid([str(column) for column in columns], rows, total_label="row(s)")
+
+
+def _load_request_payload(path: Optional[str]) -> Dict[str, Any]:
+    """Load a JSON request payload from disk when provided."""
+    if not path:
+        return {}
+
+    payload = load_json_file(path)
+    if not isinstance(payload, dict):
+        _exit_invalid_input("Request files must contain a JSON object")
+    return payload
+
+
+def _build_table_list_payload(
+    name: Optional[str],
+    workspace: Optional[str],
+    test_result_id: Optional[str],
+    supports_append: Optional[bool],
+    custom_filter: Optional[str],
+    substitutions: Tuple[str, ...],
+    order_by: Optional[str],
+    descending: bool,
+    take: int,
+) -> Dict[str, Any]:
+    """Build the query-tables payload from list command options."""
+    filter_parts: List[str] = []
+    base_substitutions: List[Any] = []
+
+    _append_filter(filter_parts, base_substitutions, "name.Contains(@{index})", name)
+    _append_filter(filter_parts, base_substitutions, "testResultId == @{index}", test_result_id)
+    if supports_append is not None:
+        _append_filter(
+            filter_parts, base_substitutions, "supportsAppend == @{index}", supports_append
+        )
+
+    workspace_id = _resolve_workspace_id(workspace)
+    _append_filter(filter_parts, base_substitutions, "workspace == @{index}", workspace_id)
+
+    combined_filter, combined_substitutions = _combine_filter_parts(
+        " && ".join(filter_parts) if filter_parts else None,
+        base_substitutions,
+        custom_filter,
+        _parse_substitutions(substitutions),
+    )
+
+    payload: Dict[str, Any] = {"take": _validate_take(take, 1000)}
+    if combined_filter:
+        payload["filter"] = combined_filter
+    if combined_substitutions:
+        payload["substitutions"] = combined_substitutions
+    if order_by:
+        payload["orderBy"] = order_by
+        payload["orderByDescending"] = descending
+    return payload
+
+
+def _fetch_table_page(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a query-tables request."""
+    return make_api_request(
+        "POST", f"{_get_dataframe_base_url()}/query-tables", payload=payload
+    ).json()
+
+
+def _confirm_next_page() -> bool:
+    """Ask the user if more paged data should be fetched."""
+    try:
+        is_tty = sys.stdout.isatty() and sys.stdin.isatty()
+    except Exception:
+        is_tty = False
+
+    if not is_tty:
+        return False
+    return click.confirm("Show next page?", default=True)
+
+
+def _display_table_pages(initial_payload: Dict[str, Any], workspace_map: Dict[str, str]) -> None:
+    """Interactively page through query-tables results for table output."""
+    payload = dict(initial_payload)
+    shown = 0
+
+    while True:
+        data = _fetch_table_page(payload)
+        tables = data.get("tables", []) or []
+        continuation_token = data.get("continuationToken")
+
+        if not tables and shown == 0:
+            click.echo("No dataframe tables found.")
+            return
+
+        if not tables:
+            return
+
+        rows = [
+            [
+                str(table.get("name", "")),
+                str(table.get("id", "")),
+                get_workspace_display_name(table.get("workspace", ""), workspace_map),
+                str(table.get("rowCount", "")),
+                _format_bool(table.get("supportsAppend", False)),
+                str(table.get("rowsModifiedAt", "")),
+            ]
+            for table in tables
+        ]
+        _render_grid(["Name", "ID", "Workspace", "Rows", "Append", "Modified"], rows)
+
+        shown += len(tables)
+        if not continuation_token:
+            return
+
+        click.echo(f"\nShowing {shown} dataframe table(s) so far. More may be available.")
+        if not _confirm_next_page():
+            return
+        payload["continuationToken"] = continuation_token
+
+
+def _fetch_all_table_pages(initial_payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Fetch every table page for JSON output."""
+    payload = dict(initial_payload)
+    all_tables: List[Dict[str, Any]] = []
+
+    while True:
+        data = _fetch_table_page(payload)
+        all_tables.extend(data.get("tables", []) or [])
+        continuation_token = data.get("continuationToken")
+        if not continuation_token:
+            return {"tables": all_tables, "continuationToken": None}
+        payload["continuationToken"] = continuation_token
+
+
+def _build_data_query_payload(
+    request: Optional[str],
+    columns: Optional[str],
+    where: Tuple[str, ...],
+    order_by: Tuple[str, ...],
+    take: Optional[int],
+    continuation_token: Optional[str],
+) -> Dict[str, Any]:
+    """Build a table row query payload."""
+    payload = _load_request_payload(request)
+
+    parsed_columns = _parse_columns(columns)
+    if parsed_columns is not None:
+        payload["columns"] = parsed_columns
+    if where:
+        payload["filters"] = [_parse_where_clause(clause) for clause in where]
+    if order_by:
+        payload["orderBy"] = [_parse_order_by_clause(clause) for clause in order_by]
+    if take is not None:
+        payload["take"] = _validate_take(take, 10000)
+    if continuation_token:
+        payload["continuationToken"] = continuation_token
+
+    return payload
+
+
+def _display_query_pages(table_id: str, payload: Dict[str, Any], endpoint: str) -> None:
+    """Display paged query responses for table output."""
+    query_payload = dict(payload)
+    first_page = True
+
+    while True:
+        data = make_api_request(
+            "POST",
+            f"{_get_dataframe_base_url()}/tables/{table_id}/{endpoint}",
+            payload=query_payload,
+        ).json()
+        frame = data.get("frame", {}) or {}
+
+        if not frame.get("data") and first_page:
+            click.echo("No rows found.")
+            return
+
+        _render_frame_table(frame)
+
+        continuation_token = data.get("continuationToken")
+        if not continuation_token:
+            return
+
+        click.echo(f"\nMatched {data.get('totalRowCount', '?')} row(s). More rows are available.")
+        if not _confirm_next_page():
+            click.echo(f"Next continuation token: {continuation_token}")
+            return
+
+        query_payload["continuationToken"] = continuation_token
+        first_page = False
+
+
+def _build_decimation_payload(
+    request: Optional[str],
+    columns: Optional[str],
+    where: Tuple[str, ...],
+    x_column: Optional[str],
+    y_columns: Tuple[str, ...],
+    intervals: Optional[int],
+    method: Optional[str],
+    distribution: Optional[str],
+) -> Dict[str, Any]:
+    """Build a decimated data query payload."""
+    payload = _load_request_payload(request)
+    parsed_columns = _parse_columns(columns)
+    if parsed_columns is not None:
+        payload["columns"] = parsed_columns
+    if where:
+        payload["filters"] = [_parse_where_clause(clause) for clause in where]
+
+    decimation = payload.get("decimation", {})
+    if decimation and not isinstance(decimation, dict):
+        _exit_invalid_input("The decimation request payload must be a JSON object")
+    if not isinstance(decimation, dict):
+        decimation = {}
+
+    if intervals is not None:
+        decimation["intervals"] = _validate_take(intervals, 2147483647, label="intervals")
+    if x_column:
+        decimation["xColumn"] = x_column
+    if y_columns:
+        decimation["yColumns"] = [column for column in y_columns]
+    if method:
+        decimation["method"] = method
+    if distribution:
+        decimation["distribution"] = distribution
+
+    payload["decimation"] = decimation
+    return payload
+
+
+def _parse_property_assignment(value: str) -> Tuple[str, str]:
+    """Parse a KEY=VALUE property assignment."""
+    if "=" not in value:
+        _exit_invalid_input(f"Expected KEY=VALUE but received '{value}'")
+    key, property_value = value.split("=", maxsplit=1)
+    if not key.strip():
+        _exit_invalid_input(f"Expected KEY=VALUE but received '{value}'")
+    return key.strip(), property_value
+
+
+def _parse_column_property_assignment(value: str) -> Tuple[str, str, str]:
+    """Parse a COLUMN:KEY=VALUE column property assignment."""
+    if ":" not in value or "=" not in value:
+        _exit_invalid_input(f"Expected COLUMN:KEY=VALUE but received '{value}'")
+    column_name, remainder = value.split(":", maxsplit=1)
+    property_key, property_value = _parse_property_assignment(remainder)
+    if not column_name.strip():
+        _exit_invalid_input(f"Expected COLUMN:KEY=VALUE but received '{value}'")
+    return column_name.strip(), property_key, property_value
+
+
+def _parse_column_property_removal(value: str) -> Tuple[str, str]:
+    """Parse a COLUMN:KEY column property removal."""
+    if ":" not in value:
+        _exit_invalid_input(f"Expected COLUMN:KEY but received '{value}'")
+    column_name, property_key = value.split(":", maxsplit=1)
+    if not column_name.strip() or not property_key.strip():
+        _exit_invalid_input(f"Expected COLUMN:KEY but received '{value}'")
+    return column_name.strip(), property_key.strip()
+
+
+def _build_update_payload(
+    name: Optional[str],
+    workspace: Optional[str],
+    test_result_id: Optional[str],
+    property_assignments: Tuple[str, ...],
+    remove_properties: Tuple[str, ...],
+    column_property_assignments: Tuple[str, ...],
+    remove_column_properties: Tuple[str, ...],
+    metadata_revision: Optional[int],
+) -> Dict[str, Any]:
+    """Build a modify-table payload from CLI options."""
+    payload: Dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = name
+    if workspace is not None:
+        payload["workspace"] = _resolve_workspace_id(workspace, apply_default=False)
+    if test_result_id is not None:
+        payload["testResultId"] = test_result_id
+    if metadata_revision is not None:
+        payload["metadataRevision"] = metadata_revision
+
+    properties: Dict[str, Optional[str]] = {}
+    for assignment in property_assignments:
+        key, value = _parse_property_assignment(assignment)
+        properties[key] = value
+    for key in remove_properties:
+        properties[key] = None
+    if properties:
+        payload["properties"] = properties
+
+    column_properties: Dict[str, Dict[str, Optional[str]]] = defaultdict(dict)
+    for assignment in column_property_assignments:
+        column_name, property_key, value = _parse_column_property_assignment(assignment)
+        column_properties[column_name][property_key] = value
+    for removal in remove_column_properties:
+        column_name, property_key = _parse_column_property_removal(removal)
+        column_properties[column_name][property_key] = None
+    if column_properties:
+        payload["columns"] = [
+            {"name": column_name, "properties": properties}
+            for column_name, properties in column_properties.items()
+        ]
+
+    return payload
+
+
+def _validate_append_payload(payload: Dict[str, Any]) -> None:
+    """Validate JSON append payload structure before sending it to the API."""
+    if payload.get("endOfData") is True:
+        return
+
+    frame = payload.get("frame")
+    if not isinstance(frame, dict):
+        _exit_invalid_input("Append payload must contain a JSON object under 'frame'")
+
+    data_rows = frame.get("data")
+    if not isinstance(data_rows, list):
+        _exit_invalid_input("Append payload frame must contain a 'data' array")
+
+    columns = frame.get("columns")
+    if columns is not None and not isinstance(columns, list):
+        _exit_invalid_input("Append payload frame 'columns' must be an array when provided")
+
+
+def _post_arrow_append(table_id: str, input_path: str, end_of_data: bool) -> requests_lib.Response:
+    """Append Arrow IPC stream data to a table."""
+    url = f"{_get_dataframe_base_url()}/tables/{table_id}/data"
+    if end_of_data:
+        url += "?endOfData=true"
+
+    try:
+        with open(input_path, "rb") as arrow_file:
+            response = requests_lib.post(
+                url,
+                headers=get_headers("application/vnd.apache.arrow.stream"),
+                data=arrow_file.read(),
+                verify=get_ssl_verify(),
+            )
+        response.raise_for_status()
+        return response
+    except requests_lib.RequestException as exc:
+        handle_api_error(exc)
+        raise
+
+
+def register_dataframe_commands(cli: Any) -> None:
+    """Register the dataframe command group and subcommands."""
+
+    @cli.group()
+    def dataframe() -> None:
+        """Manage SystemLink DataFrame tables and row data."""
+        pass
+
+    @dataframe.command(name="list")
+    @click.option("--name", help="Filter tables by name using contains matching")
+    @click.option("--workspace", "workspace_name", "-w", help="Workspace name or ID")
+    @click.option("--test-result-id", help="Filter by associated test result ID")
+    @click.option(
+        "--supports-append/--no-supports-append",
+        default=None,
+        help="Filter by whether the table supports append",
+    )
+    @click.option("--filter", "custom_filter", help="Raw query-tables Dynamic LINQ filter")
+    @click.option(
+        "--substitution",
+        multiple=True,
+        help="Substitution value for --filter. Repeat for multiple values.",
+    )
+    @click.option(
+        "--order-by",
+        type=click.Choice(TABLE_ORDER_BY_CHOICES),
+        help="Sort field for tables",
+    )
+    @click.option("--descending/--ascending", default=False, help="Sort descending")
+    @click.option("--take", "-t", type=int, default=25, show_default=True, help="Page size")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def list_tables(
+        name: Optional[str],
+        workspace_name: Optional[str],
+        test_result_id: Optional[str],
+        supports_append: Optional[bool],
+        custom_filter: Optional[str],
+        substitution: Tuple[str, ...],
+        order_by: Optional[str],
+        descending: bool,
+        take: int,
+        format: str,
+    ) -> None:
+        """List DataFrame tables."""
+        format_output = validate_output_format(format)
+        payload = _build_table_list_payload(
+            name=name,
+            workspace=workspace_name,
+            test_result_id=test_result_id,
+            supports_append=supports_append,
+            custom_filter=custom_filter,
+            substitutions=substitution,
+            order_by=order_by,
+            descending=descending,
+            take=take,
+        )
+
+        try:
+            if format_output == "json":
+                click.echo(json.dumps(_fetch_all_table_pages(payload), indent=2))
+                return
+
+            _display_table_pages(payload, get_workspace_map())
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="get")
+    @click.argument("table_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def get_table(table_id: str, format: str) -> None:
+        """Get DataFrame table metadata."""
+        format_output = validate_output_format(format)
+
+        try:
+            data = make_api_request("GET", f"{_get_dataframe_base_url()}/tables/{table_id}").json()
+            if format_output == "json":
+                click.echo(json.dumps(data, indent=2))
+                return
+
+            workspace_map = get_workspace_map()
+            _render_table_summary(data, workspace_map)
+            if data.get("columns"):
+                click.echo("")
+                click.echo("Schema")
+                _render_schema_table(data.get("columns", []), include_properties=False)
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="schema")
+    @click.argument("table_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    @click.option(
+        "--properties/--no-properties",
+        default=False,
+        help="Include column property maps in table output",
+    )
+    def show_schema(table_id: str, format: str, properties: bool) -> None:
+        """Show table schema and column definitions."""
+        format_output = validate_output_format(format)
+
+        try:
+            data = make_api_request("GET", f"{_get_dataframe_base_url()}/tables/{table_id}").json()
+            columns = data.get("columns", []) or []
+            if format_output == "json":
+                click.echo(json.dumps(columns, indent=2))
+                return
+            _render_schema_table(columns, include_properties=properties)
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="query")
+    @click.argument("table_id")
+    @click.option("--columns", help="Comma-separated list of columns to return")
+    @click.option(
+        "--where",
+        multiple=True,
+        help="Filter clause in the form column,operation,value. Repeat for multiple filters.",
+    )
+    @click.option(
+        "--order-by",
+        "order_by_clauses",
+        multiple=True,
+        help="Sort clause in the form column[:asc|desc]. Repeat for multiple clauses.",
+    )
+    @click.option("--take", "-t", type=int, default=100, show_default=True, help="Rows per page")
+    @click.option("--continuation-token", help="Continuation token for paged reads")
+    @click.option("--request", type=click.Path(exists=True), help="Path to raw query JSON")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def query_table_data(
+        table_id: str,
+        columns: Optional[str],
+        where: Tuple[str, ...],
+        order_by_clauses: Tuple[str, ...],
+        take: int,
+        continuation_token: Optional[str],
+        request: Optional[str],
+        format: str,
+    ) -> None:
+        """Query row data from a DataFrame table."""
+        format_output = validate_output_format(format)
+        ctx = click.get_current_context()
+        take_source = ctx.get_parameter_source("take")
+        effective_take = None if request and take_source == ParameterSource.DEFAULT else take
+        payload = _build_data_query_payload(
+            request=request,
+            columns=columns,
+            where=where,
+            order_by=order_by_clauses,
+            take=effective_take,
+            continuation_token=continuation_token,
+        )
+
+        try:
+            if format_output == "json":
+                data = make_api_request(
+                    "POST",
+                    f"{_get_dataframe_base_url()}/tables/{table_id}/query-data",
+                    payload=payload,
+                ).json()
+                click.echo(json.dumps(data, indent=2))
+                return
+
+            _display_query_pages(table_id, payload, endpoint="query-data")
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="decimate")
+    @click.argument("table_id")
+    @click.option("--columns", help="Comma-separated list of columns to return")
+    @click.option(
+        "--where",
+        multiple=True,
+        help="Filter clause in the form column,operation,value. Repeat for multiple filters.",
+    )
+    @click.option("--x-column", help="Column to use as the x-axis for decimation")
+    @click.option(
+        "--y-column", "y_columns", multiple=True, help="Y column for MAX_MIN or ENTRY_EXIT"
+    )
+    @click.option(
+        "--intervals", type=int, default=1000, show_default=True, help="Number of intervals"
+    )
+    @click.option(
+        "--method",
+        type=click.Choice(DECIMATION_METHOD_CHOICES),
+        help="Decimation method",
+    )
+    @click.option(
+        "--distribution",
+        type=click.Choice(DECIMATION_DISTRIBUTION_CHOICES),
+        help="Distribution for interval bucketing",
+    )
+    @click.option("--request", type=click.Path(exists=True), help="Path to raw decimation JSON")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def decimate_table_data(
+        table_id: str,
+        columns: Optional[str],
+        where: Tuple[str, ...],
+        x_column: Optional[str],
+        y_columns: Tuple[str, ...],
+        intervals: int,
+        method: Optional[str],
+        distribution: Optional[str],
+        request: Optional[str],
+        format: str,
+    ) -> None:
+        """Query decimated row data for numeric or timeseries tables."""
+        format_output = validate_output_format(format)
+        ctx = click.get_current_context()
+        intervals_source = ctx.get_parameter_source("intervals")
+        effective_intervals = (
+            None if request and intervals_source == ParameterSource.DEFAULT else intervals
+        )
+        payload = _build_decimation_payload(
+            request=request,
+            columns=columns,
+            where=where,
+            x_column=x_column,
+            y_columns=y_columns,
+            intervals=effective_intervals,
+            method=method,
+            distribution=distribution,
+        )
+
+        try:
+            data = make_api_request(
+                "POST",
+                f"{_get_dataframe_base_url()}/tables/{table_id}/query-decimated-data",
+                payload=payload,
+            ).json()
+            if format_output == "json":
+                click.echo(json.dumps(data, indent=2))
+                return
+            _render_frame_table(data.get("frame", {}) or {})
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="export")
+    @click.argument("table_id")
+    @click.option("--columns", help="Comma-separated list of columns to export")
+    @click.option(
+        "--where",
+        multiple=True,
+        help="Filter clause in the form column,operation,value. Repeat for multiple filters.",
+    )
+    @click.option(
+        "--order-by",
+        "order_by_clauses",
+        multiple=True,
+        help="Sort clause in the form column[:asc|desc]. Repeat for multiple clauses.",
+    )
+    @click.option("--take", type=int, help="Limit the number of exported rows")
+    @click.option("--request", type=click.Path(exists=True), help="Path to raw export JSON")
+    @click.option("--output", "-o", help="Output CSV file path")
+    def export_table_data(
+        table_id: str,
+        columns: Optional[str],
+        where: Tuple[str, ...],
+        order_by_clauses: Tuple[str, ...],
+        take: Optional[int],
+        request: Optional[str],
+        output: Optional[str],
+    ) -> None:
+        """Export table rows as CSV."""
+        payload = _build_data_query_payload(
+            request=request,
+            columns=columns,
+            where=where,
+            order_by=order_by_clauses,
+            take=take,
+            continuation_token=None,
+        )
+        payload["responseFormat"] = "CSV"
+        payload["destination"] = "INLINE"
+
+        try:
+            response = make_api_request(
+                "POST",
+                f"{_get_dataframe_base_url()}/tables/{table_id}/export-data",
+                payload=payload,
+            )
+            csv_text = response.text
+            if output:
+                with open(output, "w", encoding="utf-8") as output_file:
+                    output_file.write(csv_text)
+                format_success("Dataframe table exported", {"id": table_id, "output": output})
+                return
+
+            click.echo(csv_text, nl=not csv_text.endswith("\n"))
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="append")
+    @click.argument("table_id")
+    @click.option("--input", "input_path", "-i", required=True, help="Input file path")
+    @click.option(
+        "--input-format",
+        type=click.Choice(["json", "arrow"]),
+        default="json",
+        show_default=True,
+        help="Input payload format",
+    )
+    @click.option("--end-of-data", is_flag=True, help="Mark the table as complete after append")
+    def append_table_data(
+        table_id: str, input_path: str, input_format: str, end_of_data: bool
+    ) -> None:
+        """Append JSON or Arrow row data to a DataFrame table."""
+        check_readonly_mode("append dataframe rows")
+
+        try:
+            if input_format == "arrow":
+                _post_arrow_append(table_id, input_path, end_of_data)
+                format_success(
+                    "Dataframe rows appended",
+                    {"id": table_id, "input": input_path, "format": input_format},
+                )
+                return
+
+            payload = load_json_file(input_path)
+            if not isinstance(payload, dict):
+                _exit_invalid_input("Append input file must contain a JSON object")
+            if end_of_data:
+                payload["endOfData"] = True
+            _validate_append_payload(payload)
+            make_api_request(
+                "POST", f"{_get_dataframe_base_url()}/tables/{table_id}/data", payload=payload
+            )
+            frame = payload.get("frame", {}) if isinstance(payload.get("frame"), dict) else {}
+            rows_appended = len(frame.get("data", []) or [])
+            format_success(
+                "Dataframe rows appended",
+                {
+                    "id": table_id,
+                    "rows": rows_appended,
+                    "endOfData": payload.get("endOfData", False),
+                },
+            )
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="create")
+    @click.option(
+        "--definition", type=click.Path(exists=True), required=True, help="Create request JSON"
+    )
+    @click.option("--name", help="Override the table name in the definition file")
+    @click.option("--workspace", "workspace_name", "-w", help="Workspace name or ID")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def create_table(
+        definition: str,
+        name: Optional[str],
+        workspace_name: Optional[str],
+        format: str,
+    ) -> None:
+        """Create a new DataFrame table."""
+        check_readonly_mode("create a dataframe table")
+        format_output = validate_output_format(format)
+
+        payload = load_json_file(definition)
+        if not isinstance(payload, dict):
+            _exit_invalid_input("Table definition must contain a JSON object")
+        if name is not None:
+            payload["name"] = name
+
+        workspace_id = _resolve_workspace_id(workspace_name)
+        if workspace_id and "workspace" not in payload:
+            payload["workspace"] = workspace_id
+
+        try:
+            response = make_api_request(
+                "POST", f"{_get_dataframe_base_url()}/tables", payload=payload
+            )
+            created = response.json() if response.text.strip() else {}
+            if format_output == "json":
+                click.echo(json.dumps(created, indent=2))
+                return
+
+            format_success(
+                "Dataframe table created",
+                {"id": created.get("id", ""), "name": payload.get("name", "")},
+            )
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="update")
+    @click.argument("table_id")
+    @click.option("--name", help="New table name")
+    @click.option("--workspace", "workspace_name", "-w", help="New workspace name or ID")
+    @click.option("--test-result-id", help="New associated test result ID")
+    @click.option(
+        "--property", "property_assignments", multiple=True, help="Set KEY=VALUE property"
+    )
+    @click.option("--remove-property", multiple=True, help="Remove a table property by key")
+    @click.option(
+        "--column-property",
+        "column_property_assignments",
+        multiple=True,
+        help="Set COLUMN:KEY=VALUE property",
+    )
+    @click.option(
+        "--remove-column-property",
+        multiple=True,
+        help="Remove a column property with COLUMN:KEY",
+    )
+    @click.option("--metadata-revision", type=int, help="Expected next metadata revision")
+    def update_table(
+        table_id: str,
+        name: Optional[str],
+        workspace_name: Optional[str],
+        test_result_id: Optional[str],
+        property_assignments: Tuple[str, ...],
+        remove_property: Tuple[str, ...],
+        column_property_assignments: Tuple[str, ...],
+        remove_column_property: Tuple[str, ...],
+        metadata_revision: Optional[int],
+    ) -> None:
+        """Update table metadata or column properties."""
+        check_readonly_mode("update dataframe metadata")
+        payload = _build_update_payload(
+            name=name,
+            workspace=workspace_name,
+            test_result_id=test_result_id,
+            property_assignments=property_assignments,
+            remove_properties=remove_property,
+            column_property_assignments=column_property_assignments,
+            remove_column_properties=remove_column_property,
+            metadata_revision=metadata_revision,
+        )
+        if not payload:
+            _exit_invalid_input("Specify at least one field to update")
+
+        try:
+            make_api_request(
+                "PATCH", f"{_get_dataframe_base_url()}/tables/{table_id}", payload=payload
+            )
+            format_success("Dataframe table updated", {"id": table_id})
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="update-many")
+    @click.option(
+        "--definition",
+        type=click.Path(exists=True),
+        required=True,
+        help="Modify-tables request JSON",
+    )
+    def update_many_tables(definition: str) -> None:
+        """Update metadata for one or more DataFrame tables."""
+        check_readonly_mode("update dataframe metadata")
+        payload = load_json_file(definition)
+        if not isinstance(payload, dict):
+            _exit_invalid_input("Batch update definition must contain a JSON object")
+
+        try:
+            response = make_api_request(
+                "POST", f"{_get_dataframe_base_url()}/modify-tables", payload=payload
+            )
+            if response.status_code == 204:
+                format_success("Dataframe tables updated")
+                return
+
+            data = response.json() if response.text.strip() else {}
+            modified_ids = data.get("modifiedTableIds", []) or []
+            format_success(
+                "Dataframe tables updated with partial success", {"updated": len(modified_ids)}
+            )
+            if data.get("failedModifications"):
+                error_value = data.get("error")
+                error_data: Dict[str, Any] = error_value if isinstance(error_value, dict) else {}
+                click.echo(
+                    f"✗ Failed modifications: {len(data.get('failedModifications', []))}", err=True
+                )
+                click.echo(str(error_data.get("message", "Unknown error")), err=True)
+                sys.exit(ExitCodes.GENERAL_ERROR)
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @dataframe.command(name="delete")
+    @click.argument("table_ids", nargs=-1, required=True)
+    @click.option("--yes", "force", is_flag=True, help="Skip confirmation prompt")
+    def delete_tables(table_ids: Tuple[str, ...], force: bool) -> None:
+        """Delete one or more DataFrame tables."""
+        check_readonly_mode("delete dataframe table(s)")
+
+        ids = list(table_ids)
+        if not confirm_bulk_operation("delete", "dataframe table", len(ids), force=force):
+            return
+
+        try:
+            if len(ids) == 1:
+                make_api_request("DELETE", f"{_get_dataframe_base_url()}/tables/{ids[0]}")
+                format_success("Dataframe table deleted", {"id": ids[0]})
+                return
+
+            response = make_api_request(
+                "POST", f"{_get_dataframe_base_url()}/delete-tables", payload={"ids": ids}
+            )
+            if response.status_code == 204:
+                format_success("Dataframe tables deleted", {"count": len(ids)})
+                return
+
+            data = response.json() if response.text.strip() else {}
+            deleted_ids = data.get("deletedTableIds", []) or []
+            failed_ids = data.get("failedTableIds", []) or []
+            format_success(
+                "Dataframe tables deleted with partial success", {"deleted": len(deleted_ids)}
+            )
+            if failed_ids:
+                error_value = data.get("error")
+                error_data: Dict[str, Any] = error_value if isinstance(error_value, dict) else {}
+                click.echo(f"✗ Failed to delete: {', '.join(failed_ids)}", err=True)
+                click.echo(str(error_data.get("message", "Unknown error")), err=True)
+                sys.exit(ExitCodes.GENERAL_ERROR)
+        except Exception as exc:
+            handle_api_error(exc)

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -14,6 +14,7 @@ from .asset_click import register_asset_commands
 from .comment_click import register_comment_commands
 from .completion_click import register_completion_command
 from .config_click import register_config_commands
+from .dataframe_click import register_dataframe_commands
 from .dff_click import register_dff_commands
 from .example_click import register_example_commands
 from .feed_click import register_feed_commands
@@ -418,6 +419,7 @@ def info(format: str, skip_health: bool) -> None:
 register_completion_command(cli)
 register_asset_commands(cli)
 register_comment_commands(cli)
+register_dataframe_commands(cli)
 register_dff_commands(cli)
 register_config_commands(cli)
 register_example_commands(cli)

--- a/slcli/platform.py
+++ b/slcli/platform.py
@@ -7,14 +7,17 @@ This module provides utilities to detect and manage the target platform
 import json
 import os
 import sys
+import time
 from functools import lru_cache
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
 import keyring
 import requests
 
 from .utils import ExitCodes, get_ssl_verify
+
+DEFAULT_SERVICE_PROBE_CACHE_TTL_SECONDS = 300
 
 # Platform identifiers
 PLATFORM_SLE = "SLE"  # SystemLink Enterprise (cloud)
@@ -26,6 +29,8 @@ PLATFORM_UNREACHABLE = "unreachable"  # Server could not be contacted
 PLATFORM_FEATURES: Dict[str, Dict[str, bool]] = {
     PLATFORM_SLE: {
         "service_accounts": True,
+        "comments_service": True,
+        "dataframe_service": True,
         "workorder_service": True,
         "dynamic_form_fields": True,
         "function_execution": True,
@@ -35,6 +40,8 @@ PLATFORM_FEATURES: Dict[str, Dict[str, bool]] = {
     },
     PLATFORM_SLS: {
         "service_accounts": False,
+        "comments_service": False,
+        "dataframe_service": False,
         "workorder_service": False,
         "dynamic_form_fields": False,
         "function_execution": False,
@@ -47,12 +54,30 @@ PLATFORM_FEATURES: Dict[str, Dict[str, bool]] = {
 # Human-readable feature names for error messages
 FEATURE_DISPLAY_NAMES: Dict[str, str] = {
     "service_accounts": "Service Accounts",
+    "comments_service": "Comments",
+    "dataframe_service": "DataFrames",
     "workorder_service": "Work Order Service",
     "dynamic_form_fields": "Dynamic Form Fields",
     "function_execution": "Function Execution",
     "templates": "Test Plan Templates",
     "workflows": "Workflows",
     "webapp": "Web Applications",
+}
+
+FEATURE_SERVICE_DEPENDENCIES: Dict[str, str] = {
+    "comments_service": "Comments",
+    "dataframe_service": "DataFrame",
+    "workorder_service": "Work Order",
+    "templates": "Work Order",
+    "workflows": "Work Order",
+}
+
+FEATURE_REQUIREMENT_MESSAGES: Dict[str, str] = {
+    "comments_service": "  This feature requires the Comments service.",
+    "dataframe_service": "  This feature requires the DataFrame service.",
+    "workorder_service": "  This feature requires the Work Order service.",
+    "templates": "  This feature requires the Work Order service.",
+    "workflows": "  This feature requires the Work Order service.",
 }
 
 FILE_SEARCH_PATH = "/nifile/v1/service-groups/Default/search-files"
@@ -171,6 +196,192 @@ def clear_platform_cache() -> None:
     to ensure the next get_platform() call re-detects the platform.
     """
     get_platform.cache_clear()
+    _get_cached_service_status.cache_clear()
+
+
+def _probe_service_status(api_url: str, api_key: str, method: str, url_path: str) -> str:
+    """Probe a single service endpoint and return its normalized status."""
+    headers = {
+        "x-ni-api-key": api_key,
+        "Content-Type": "application/json",
+        "User-Agent": "SystemLink-CLI/1.0 (cross-platform)",
+    }
+    ssl_verify = get_ssl_verify()
+
+    try:
+        full_url = f"{api_url}{url_path}"
+        if method == "POST":
+            response = requests.post(
+                full_url,
+                headers=headers,
+                json={"take": 1},
+                verify=ssl_verify,
+                timeout=10,
+            )
+        else:
+            response = requests.get(
+                full_url,
+                headers=headers,
+                verify=ssl_verify,
+                timeout=10,
+            )
+    except requests.RequestException:
+        return "unreachable"
+
+    if response.status_code in (200, 400):
+        return "ok"
+    if response.status_code in (401, 403):
+        return "unauthorized"
+    if response.status_code in (404, 501):
+        return "not_found"
+    return "error"
+
+
+@lru_cache(maxsize=None)
+def _get_cached_service_status(service_name: str, api_url: str, api_key: str) -> str:
+    """Probe and cache a service status for a specific server and credential pair."""
+    service_check = next((entry for entry in SERVICE_CHECKS if entry[0] == service_name), None)
+    if service_check is None:
+        return "error"
+
+    return _probe_service_status(api_url, api_key, service_check[1], service_check[2])
+
+
+def _get_current_api_context() -> Optional[Tuple[Optional[str], str, str]]:
+    """Resolve the current profile name, API URL, and key for service probing."""
+    api_url = os.environ.get("SYSTEMLINK_API_URL")
+    api_key = os.environ.get("SYSTEMLINK_API_KEY")
+    if api_url and api_key:
+        return None, api_url, api_key
+
+    cfg = _get_keyring_config()
+    config_api_url = cfg.get("api_url") if cfg else None
+    config_api_key = cfg.get("api_key") if cfg else None
+    if config_api_url and config_api_key:
+        return None, str(config_api_url), str(config_api_key)
+
+    try:
+        from .profiles import get_active_profile_name
+        from .utils import get_api_key, get_base_url
+
+        return get_active_profile_name(), get_base_url(), get_api_key()
+    except Exception:
+        return None
+
+
+def _get_service_probe_cache_ttl_seconds() -> int:
+    """Return the persisted probe cache TTL in seconds."""
+    raw_value = os.environ.get("SLCLI_SERVICE_PROBE_CACHE_TTL_SECONDS")
+    if not raw_value:
+        return DEFAULT_SERVICE_PROBE_CACHE_TTL_SECONDS
+
+    try:
+        ttl_seconds = int(raw_value)
+    except ValueError:
+        return DEFAULT_SERVICE_PROBE_CACHE_TTL_SECONDS
+
+    return max(ttl_seconds, 0)
+
+
+def _build_service_probe_cache_key(profile_name: Optional[str], api_url: str, api_key: str) -> str:
+    """Build a stable cache key for persisted service probe snapshots."""
+    import hashlib
+
+    identity = profile_name or api_url.rstrip("/")
+    api_key_fingerprint = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    return f"{identity}|{api_url.rstrip('/')}|{api_key_fingerprint}"
+
+
+def _load_cached_service_status_snapshot(
+    api_context: Tuple[Optional[str], str, str], max_age_seconds: Optional[int] = None
+) -> Optional[Dict[str, Any]]:
+    """Load a fresh persisted service probe snapshot when available."""
+    from .profiles import get_service_probe_cache_entry
+
+    ttl_seconds = (
+        _get_service_probe_cache_ttl_seconds() if max_age_seconds is None else max_age_seconds
+    )
+    if ttl_seconds <= 0:
+        return None
+
+    profile_name, api_url, api_key = api_context
+    cache_key = _build_service_probe_cache_key(profile_name, api_url, api_key)
+    entry = get_service_probe_cache_entry(cache_key)
+    if entry is None:
+        return None
+
+    cached_at = entry.get("cached_at")
+    status = entry.get("status")
+    if not isinstance(cached_at, (int, float)) or not isinstance(status, dict):
+        return None
+    if entry.get("server") != api_url:
+        return None
+    if time.time() - float(cached_at) > ttl_seconds:
+        return None
+    return status
+
+
+def _save_service_status_snapshot(
+    api_context: Tuple[Optional[str], str, str], status: Dict[str, Any]
+) -> None:
+    """Persist a service probe snapshot for reuse across CLI invocations."""
+    from .profiles import save_service_probe_cache_entry
+
+    profile_name, api_url, api_key = api_context
+    cache_key = _build_service_probe_cache_key(profile_name, api_url, api_key)
+    save_service_probe_cache_entry(
+        cache_key,
+        {
+            "profile": profile_name,
+            "server": api_url,
+            "cached_at": time.time(),
+            "status": status,
+        },
+    )
+
+
+def _get_service_status_snapshot(force_refresh: bool = False) -> Optional[Dict[str, Any]]:
+    """Get a cached or live service probe snapshot for the active connection."""
+    api_context = _get_current_api_context()
+    if api_context is None:
+        return None
+
+    if not force_refresh:
+        cached_status = _load_cached_service_status_snapshot(api_context)
+        if cached_status is not None:
+            return cached_status
+
+    _, api_url, api_key = api_context
+    status = check_service_status(api_url, api_key)
+    _save_service_status_snapshot(api_context, status)
+    return status
+
+
+def _get_service_status(service_name: str) -> Optional[str]:
+    """Probe a service endpoint on demand when a feature depends on it."""
+    status_snapshot = _get_service_status_snapshot(force_refresh=False)
+    if status_snapshot is None:
+        return None
+
+    services = status_snapshot.get("services")
+    if not isinstance(services, dict):
+        return None
+    service_status = services.get(service_name)
+    return service_status if isinstance(service_status, str) else None
+
+
+def _get_runtime_platform() -> str:
+    """Resolve the best available platform identifier for user-facing feature messages."""
+    platform = get_platform()
+    if platform != PLATFORM_UNKNOWN:
+        return platform
+
+    status_snapshot = _get_service_status_snapshot(force_refresh=False)
+    if status_snapshot is None:
+        return platform
+
+    detected_platform = status_snapshot.get("platform", PLATFORM_UNKNOWN)
+    return detected_platform if isinstance(detected_platform, str) else PLATFORM_UNKNOWN
 
 
 def has_feature(feature_name: str) -> bool:
@@ -184,6 +395,14 @@ def has_feature(feature_name: str) -> bool:
         Returns True if platform is unknown (graceful degradation).
     """
     platform = get_platform()
+    service_dependency = FEATURE_SERVICE_DEPENDENCIES.get(feature_name)
+
+    if service_dependency is not None:
+        service_status = _get_service_status(service_dependency)
+        if service_status in ("ok", "unauthorized"):
+            return True
+        if service_status == "not_found":
+            return False
 
     # If platform is unknown, allow all features (fail later if actually unavailable)
     if platform == PLATFORM_UNKNOWN:
@@ -206,16 +425,18 @@ def require_feature(feature_name: str) -> None:
     if has_feature(feature_name):
         return
 
-    platform = get_platform()
+    platform = _get_runtime_platform()
     feature_display = FEATURE_DISPLAY_NAMES.get(feature_name, feature_name)
-    platform_display = "SystemLink Server" if platform == PLATFORM_SLS else platform
+    platform_display = _get_platform_display_name(platform)
 
     click.echo(
         f"✗ Error: {feature_display} is not available on {platform_display}.",
         err=True,
     )
     click.echo(
-        "  This feature requires SystemLink Enterprise (SLE).",
+        FEATURE_REQUIREMENT_MESSAGES.get(
+            feature_name, "  This feature requires SystemLink Enterprise (SLE)."
+        ),
         err=True,
     )
     sys.exit(ExitCodes.INVALID_INPUT)
@@ -599,15 +820,16 @@ def get_platform_info(skip_health: bool = False) -> Dict[str, Any]:
     materialized_search_available: Optional[bool] = None
 
     if not skip_health and logged_in and isinstance(api_url, str) and api_url != "Not configured":
-        status = check_service_status(api_url, api_key)
-        server_reachable = status["server_reachable"]
-        auth_valid = status["auth_valid"]
-        services = status["services"]
-        platform = status["platform"]
-        file_query_endpoint = status.get("file_query_endpoint")
-        elasticsearch_available = status.get("elasticsearch_available")
-        system_query_endpoint = status.get("system_query_endpoint")
-        materialized_search_available = status.get("materialized_search_available")
+        status = _get_service_status_snapshot(force_refresh=True)
+        if status is not None:
+            server_reachable = status["server_reachable"]
+            auth_valid = status["auth_valid"]
+            services = status["services"]
+            platform = status["platform"]
+            file_query_endpoint = status.get("file_query_endpoint")
+            elasticsearch_available = status.get("elasticsearch_available")
+            system_query_endpoint = status.get("system_query_endpoint")
+            materialized_search_available = status.get("materialized_search_available")
 
     info: Dict[str, Any] = {
         "api_url": api_url,

--- a/slcli/platform.py
+++ b/slcli/platform.py
@@ -61,6 +61,37 @@ FILE_QUERY_LINQ_PATH = "/nifile/v1/service-groups/Default/query-files-linq"
 SYSTEM_SEARCH_PATH = "/nisysmgmt/v1/materialized/search-systems"
 SYSTEM_QUERY_PATH = "/nisysmgmt/v1/query-systems"
 
+SLE_ONLY_SERVICE_NAMES = (
+    "Dynamic Form Fields",
+    "Comments",
+    "Notebook",
+    "Routine v2",
+)
+
+
+def _detect_platform_from_services(services: Dict[str, str]) -> str:
+    """Infer the platform from SLE-only service probes.
+
+    Args:
+        services: Mapping of service display name to probe status.
+
+    Returns:
+        PLATFORM_SLE when any SLE-only service is reachable or explicitly
+        unauthorized, PLATFORM_SLS when all SLE-only services are missing,
+        otherwise PLATFORM_UNKNOWN.
+    """
+    sle_statuses = [services.get(name) for name in SLE_ONLY_SERVICE_NAMES if name in services]
+    if not sle_statuses:
+        return PLATFORM_UNKNOWN
+
+    if any(status in ("ok", "unauthorized") for status in sle_statuses):
+        return PLATFORM_SLE
+
+    if all(status == "not_found" for status in sle_statuses):
+        return PLATFORM_SLS
+
+    return PLATFORM_UNKNOWN
+
 
 def _get_keyring_config() -> Dict[str, Any]:
     """Attempt to read a single JSON config entry from keyring.
@@ -199,7 +230,14 @@ SERVICE_CHECKS: List[List[str]] = [
     ["Systems", "POST", SYSTEM_QUERY_PATH],
     ["Tag", "GET", "/nitag/v2/tags?take=0"],
     ["File", "POST", FILE_SEARCH_PATH],
+    ["DataFrame", "POST", "/nidataframe/v1/query-tables"],
     ["Notebook", "POST", "/ninotebook/v1/notebook/query"],
+    [
+        "Comments",
+        "GET",
+        "/nicomments/v1/comments?resourceType=testmonitor%3AResult&resourceId=health-check",
+    ],
+    ["Routine v2", "GET", "/niroutine/v2/routines?take=1"],
     ["Web Application", "POST", "/niapp/v1/webapps/query"],
     ["Dynamic Form Fields", "GET", "/nidynamicformfields/v1/groups"],
     ["Work Order", "POST", "/niworkorder/v1/query-testplan-templates"],
@@ -491,14 +529,8 @@ def check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
     if all_unauthorized and any_responded:
         auth_valid = False
 
-    # Determine platform from service responses
-    workorder_status = services.get("Work Order")
-    if workorder_status in ("ok",):
-        platform = PLATFORM_SLE
-    elif workorder_status == "not_found":
-        platform = PLATFORM_SLS
-    else:
-        platform = PLATFORM_UNKNOWN
+    # Determine platform from multiple SLE-only service responses.
+    platform = _detect_platform_from_services(services)
 
     file_capability = get_file_query_capability(api_url, api_key)
     services["File"] = file_capability["status"]

--- a/slcli/profiles.py
+++ b/slcli/profiles.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Optional
 
 import click
 
+SERVICE_PROBE_CACHE_SETTING = "service-probe-cache"
+
 
 @dataclass
 class Profile:
@@ -261,6 +263,29 @@ def get_active_profile_name() -> Optional[str]:
     """Get the name of the currently active profile."""
     profile = get_active_profile()
     return profile.name if profile else None
+
+
+def get_service_probe_cache() -> Dict[str, Dict[str, Any]]:
+    """Get the persisted service probe cache from config settings."""
+    config = ProfileConfig.load()
+    cache = config.settings.get(SERVICE_PROBE_CACHE_SETTING, {})
+    return cache if isinstance(cache, dict) else {}
+
+
+def get_service_probe_cache_entry(cache_key: str) -> Optional[Dict[str, Any]]:
+    """Get a specific persisted service probe cache entry."""
+    entry = get_service_probe_cache().get(cache_key)
+    return entry if isinstance(entry, dict) else None
+
+
+def save_service_probe_cache_entry(cache_key: str, entry: Dict[str, Any]) -> None:
+    """Save a persisted service probe cache entry."""
+    config = ProfileConfig.load()
+    cache = config.settings.get(SERVICE_PROBE_CACHE_SETTING, {})
+    normalized_cache = cache.copy() if isinstance(cache, dict) else {}
+    normalized_cache[cache_key] = entry
+    config.settings[SERVICE_PROBE_CACHE_SETTING] = normalized_cache
+    config.save()
 
 
 def get_default_workspace() -> Optional[str]:

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -144,6 +144,42 @@ Consult these for detailed guidance. Load only what you need for the current tas
 | Analysis recipes            | [analysis-recipes.md](./references/analysis-recipes.md)     | Multi-step analysis: yield, calibration, operator performance |
 | Troubleshooting             | [troubleshooting.md](./references/troubleshooting.md)       | Workspace ID issues, SSL errors, encoding, PowerShell quoting |
 
+## Platform availability
+
+Not all command groups are available on every SystemLink server. Some services exist only on
+SystemLink Enterprise (SLE) or require a specific microservice to be deployed.
+
+**Check what's available on your server:**
+
+```bash
+slcli info                # Shows platform type and service health
+slcli info -f json        # Machine-readable; check .services for per-service status
+```
+
+| Command group                | Required service     | SLE | SLS | Notes                                   |
+| ---------------------------- | -------------------- | --- | --- | --------------------------------------- |
+| `dataframe`                  | DataFrame            | ✓   | ✗   | Table row storage                       |
+| `comment`                    | Comments             | ✓   | ✗   | Resource annotations                    |
+| `template`                   | Work Order           | ✓   | ✗   | Test plan configuration templates       |
+| `workitem template`          | Work Order           | ✓   | ✗   | Work item template CRUD                 |
+| `workitem workflow`          | Work Order           | ✓   | ✗   | Workflow lifecycle                       |
+| `customfield`                | Dynamic Form Fields  | ✓   | ✗   | Custom metadata fields                  |
+| `notebook`                   | Notebook             | ✓   | ✗   | Jupyter execution                       |
+| `routine` (v2)               | Routine v2           | ✓   | ✗   | Event-action routines                   |
+| `testmonitor`, `asset`, etc. | Core services        | ✓   | ✓   | Available on both platforms             |
+
+When a gated command is run on a server that lacks the required service, the CLI exits with
+code 2 and a message like:
+
+```
+✗ Error: DataFrames is not available on SystemLink Server.
+  This feature requires the DataFrame service.
+```
+
+Service probe results are cached for 5 minutes across CLI invocations. Running `slcli info`
+force-refreshes and persists the latest snapshot. Set `SLCLI_SERVICE_PROBE_CACHE_TTL_SECONDS=0`
+to disable caching for debugging.
+
 ## Command groups at a glance
 
 | Group         | Purpose                 | Key subcommands                                      |
@@ -169,6 +205,7 @@ Consult these for detailed guidance. Load only what you need for the current tas
 | `workspace`   | Workspaces              | `list`, `get`                                        |
 | `skill`       | AI skill installation   | `install`                                            |
 | `example`     | Demo provisioning       | `list`, `install`, `delete`                          |
+
 ## Key rules
 
 1. **Always use `-f json`** when piping output to `jq` or doing programmatic analysis.

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -3,18 +3,20 @@ name: slcli
 description: >-
   Query and manage NI SystemLink resources using the slcli command-line interface.
   Covers test results, assets, systems, tags, feeds, files, notebooks,
+  dataframe tables,
   routines, work items, work item templates, workflows, test plan templates,
   specifications, products, datasheet-to-specification ingestion (PDF and CSV),
   custom fields, web applications, authorization policies, users, workspaces, and more.
   Use when the user asks about test data analysis, asset management, calibration status,
   system fleet health, operator performance, failure analysis, production metrics,
-  equipment utilization, work order tracking, specification management,
+  equipment utilization, dataframe schema inspection, row export or append workflows,
+  work order tracking, specification management,
   importing datasheets, creating products from spec sheets,
   or any SystemLink resource operations.
   Supports filtering, aggregation, summary statistics, and JSON output for programmatic processing.
 argument-hint: >-
-  Describe what you want to do: query test results, import a datasheet,
-  list assets, manage work items, etc.
+  Describe what you want to do: query test results, inspect a dataframe schema,
+  export table rows, import a datasheet, list assets, manage work items, etc.
 compatibility: >-
   Requires slcli installed and authenticated (slcli login). Python 3.10+.
   Requires network access to a SystemLink server instance.
@@ -150,6 +152,7 @@ Consult these for detailed guidance. Load only what you need for the current tas
 | `spec`        | Specifications          | `list`, `query`, `get`, `create`, `import`, `export` |
 | `asset`       | Assets & calibration    | `list`, `get`, `summary`, `calibration`              |
 | `system`      | System fleet            | `list`, `get`, `compare`, `summary`, `job`           |
+| `dataframe`   | DataFrame tables        | `list`, `schema`, `query`, `export`, `append`        |
 | `tag`         | Tag read/write          | `list`, `get-value`, `set-value`, `create`           |
 | `routine`     | Event-action routines   | `list`, `create`, `enable/disable` (v1 + v2)         |
 | `comment`     | Resource comments       | `list`, `add`, `update`, `delete`                    |

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -216,6 +216,77 @@ slcli system job summary [-f json]
 slcli system job cancel <JOB_ID>
 ```
 
+## dataframe — DataFrame tables and row access
+
+```bash
+# List tables with metadata filters
+slcli dataframe list [OPTIONS]
+
+  --name TEXT                # Filter by table name (contains)
+  --workspace, -w TEXT       # Filter by workspace name or ID
+  --test-result-id TEXT      # Filter by associated test result ID
+  --supports-append / --no-supports-append
+  --filter TEXT              # Dynamic LINQ table filter
+  --substitution TEXT        # Parameterized value for --filter (repeatable)
+  --order-by CHOICE          # CREATED_AT, METADATA_MODIFIED_AT, NAME,
+                             # NUMBER_OF_ROWS, ROWS_MODIFIED_AT
+  --descending / --ascending
+  --take, -t INTEGER         # Default 25
+  -f [table|json]
+
+# Inspect a single table and its schema
+slcli dataframe get <TABLE_ID> [-f json]
+slcli dataframe schema <TABLE_ID> [--properties] [-f json]
+
+# Query row data
+slcli dataframe query <TABLE_ID> [OPTIONS]
+  --columns TEXT             # Comma-separated column list
+  --where TEXT               # column,operation,value (repeatable)
+  --order-by TEXT            # column[:asc|desc] (repeatable)
+  --take, -t INTEGER         # Default 100
+  --continuation-token TEXT  # Resume a paged read
+  --request FILE             # Raw query-data request JSON
+  -f [table|json]
+
+# Query decimated rows for plotting or large series
+slcli dataframe decimate <TABLE_ID> [OPTIONS]
+  --columns TEXT
+  --where TEXT
+  --x-column TEXT
+  --y-column TEXT            # Repeatable
+  --intervals INTEGER        # Default 1000
+  --method [LOSSY|MAX_MIN|ENTRY_EXIT]
+  --distribution [EQUAL_FREQUENCY|EQUAL_WIDTH]
+  --request FILE
+  -f [table|json]
+
+# Export or append rows
+slcli dataframe export <TABLE_ID> [OPTIONS]
+  --columns TEXT
+  --where TEXT
+  --order-by TEXT
+  --take INTEGER
+  --request FILE
+  --output, -o FILE          # Write CSV to a file
+
+slcli dataframe append <TABLE_ID> --input FILE [--input-format json|arrow] [--end-of-data]
+
+# Manage table metadata
+slcli dataframe create --definition FILE [--name TEXT] [--workspace TEXT] [-f json]
+slcli dataframe update <TABLE_ID> [OPTIONS]
+  --name TEXT
+  --workspace, -w TEXT
+  --test-result-id TEXT
+  --property KEY=VALUE                # Repeatable
+  --remove-property KEY               # Repeatable
+  --column-property COLUMN:KEY=VALUE  # Repeatable
+  --remove-column-property COLUMN:KEY # Repeatable
+  --metadata-revision INTEGER
+
+slcli dataframe update-many --definition FILE
+slcli dataframe delete <TABLE_ID>... [--yes]
+```
+
 ## tag — Tag operations
 
 ```bash

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -218,6 +218,8 @@ slcli system job cancel <JOB_ID>
 
 ## dataframe — DataFrame tables and row access
 
+> **Requires:** DataFrame service (SLE only). Check `slcli info` for availability.
+
 ```bash
 # List tables with metadata filters
 slcli dataframe list [OPTIONS]
@@ -454,6 +456,8 @@ slcli routine create \
 
 ## comment — Resource comments
 
+> **Requires:** Comments service (SLE only). Check `slcli info` for availability.
+
 Attach, edit, and remove comments on any SystemLink resource. User IDs in responses
 are automatically resolved to display names.
 
@@ -633,6 +637,8 @@ slcli customfield edit [--directory DIR]                 # Interactively edit + 
 
 ## template — Test plan template management
 
+> **Requires:** Work Order service (SLE only). Check `slcli info` for availability.
+
 > **Note:** Work item templates are managed separately via `slcli workitem template`.
 > The `slcli template` command manages test plan _configuration_ templates used
 > when provisioning new test plan instances.
@@ -647,6 +653,10 @@ slcli template delete <TEMPLATE_ID>
 ```
 
 ## workitem — Work item, template, and workflow management
+
+> **Partially gated:** The `workitem template` and `workitem workflow` subgroups require the
+> Work Order service (SLE only). Core work item commands (`list`, `create`, `get`) are available
+> on both platforms. Check `slcli info` for service availability.
 
 Unified command group for managing work items, work item templates, and workflows.
 

--- a/slcli/skills/slcli/references/troubleshooting.md
+++ b/slcli/skills/slcli/references/troubleshooting.md
@@ -43,3 +43,33 @@ PowerShell mangles inline Python f-strings that contain dictionary key access
 File uploads to SystemLink can take 30+ seconds for multi-MB PDFs. If the
 command appears to hang, give it time — the upload is still in progress.
 Set a generous timeout (60–120 s) when automating uploads.
+
+## Feature not available on this server
+
+If a command exits with code 2 and a message like:
+
+```
+✗ Error: DataFrames is not available on SystemLink Server.
+  This feature requires the DataFrame service.
+```
+
+The connected server does not have the required microservice deployed.
+This is expected for features that only exist on SystemLink Enterprise (SLE).
+
+**Diagnose:**
+
+```bash
+# Check which services are reachable
+slcli info -f json | jq '.services'
+
+# Force a fresh probe (bypasses 5-minute cache)
+slcli info
+```
+
+**Gated command groups:** `dataframe`, `comment`, `template`,
+`workitem template`, `workitem workflow`, `customfield`, `notebook`, `routine` (v2).
+
+**Workaround:** If you believe the service should be available, verify the
+server URL is correct (`slcli config view`) and that the service is installed
+and running on the target server. Set `SLCLI_SERVICE_PROBE_CACHE_TTL_SECONDS=0`
+to disable probe caching for debugging stale results.

--- a/slcli/workitem_click.py
+++ b/slcli/workitem_click.py
@@ -1182,8 +1182,11 @@ def register_workitem_commands(cli: Any) -> None:
     # =======================================================================
 
     @workitem.group(name="template")
-    def template_group() -> None:
+    @click.pass_context
+    def template_group(ctx: click.Context) -> None:
         """Manage work item templates."""
+        if ctx.invoked_subcommand is not None:
+            require_feature("templates")
 
     @template_group.command(name="list")
     @click.option(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -513,6 +513,7 @@ def pytest_configure(config: Any) -> None:
     config.addinivalue_line("markers", "comment: mark test as comment management related")
     config.addinivalue_line("markers", "routine: mark test as routine management related")
     config.addinivalue_line("markers", "workitem: mark test as work item management related")
+    config.addinivalue_line("markers", "dataframe: mark test as dataframe related")
 
 
 def pytest_collection_modifyitems(config: Any, items: List[Any]) -> None:

--- a/tests/e2e/test_dataframe_e2e.py
+++ b/tests/e2e/test_dataframe_e2e.py
@@ -1,0 +1,293 @@
+"""E2E tests for dataframe commands against configured tiers."""
+
+import json
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_DATAFRAME_AVAILABLE: bool | None = None
+_DATAFRAME_SKIP_REASON: str | None = None
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    """Write a JSON payload to disk for CLI file-based commands."""
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _probe_name() -> str:
+    """Return a unique list filter that should never match existing tables."""
+    return f"slcli-e2e-probe-{uuid.uuid4().hex}"
+
+
+def _resolve_table_id(
+    cli_runner: Any, cli_helper: Any, table_name: str, workspace_name: str
+) -> str:
+    """Find a table ID by name with a short retry window for eventual consistency."""
+    max_attempts = 5
+    for attempt in range(max_attempts):
+        result = cli_runner(
+            [
+                "dataframe",
+                "list",
+                "--name",
+                table_name,
+                "--workspace",
+                workspace_name,
+                "--format",
+                "json",
+                "--take",
+                "25",
+            ],
+            check=False,
+        )
+        if result.returncode == 0:
+            payload = cli_helper.get_json_output(result)
+            table = cli_helper.find_resource_by_name(payload.get("tables", []), table_name)
+            if table and table.get("id"):
+                return str(table["id"])
+
+        if attempt < max_attempts - 1:
+            time.sleep(0.5 * (2**attempt))
+
+    pytest.fail(f"DataFrame table '{table_name}' was not visible after creation")
+
+
+def _wait_for_query_rows(cli_runner: Any, cli_helper: Any, table_id: str) -> Dict[str, Any]:
+    """Wait until appended rows are queryable for the target table."""
+    for attempt in range(5):
+        result = cli_runner(
+            ["dataframe", "query", table_id, "--format", "json", "--take", "10"],
+            check=False,
+        )
+        if result.returncode == 0:
+            payload = cli_helper.get_json_output(result)
+            frame = payload.get("frame", {}) or {}
+            if frame.get("data"):
+                return payload
+
+        if attempt < 4:
+            time.sleep(0.5 * (2**attempt))
+
+    pytest.fail(f"Appended rows for dataframe table '{table_id}' were not queryable in time")
+
+
+@pytest.fixture
+def require_dataframe_service(cli_runner: Any) -> None:
+    """Skip dataframe E2E tests when the backend is unavailable on the selected tier."""
+    global _DATAFRAME_AVAILABLE, _DATAFRAME_SKIP_REASON
+
+    if _DATAFRAME_AVAILABLE is True:
+        return
+    if _DATAFRAME_AVAILABLE is False:
+        pytest.skip(_DATAFRAME_SKIP_REASON or "DataFrame service is not available")
+
+    try:
+        result = cli_runner(["dataframe", "list", "--format", "table", "--take", "1"], check=False)
+    except subprocess.TimeoutExpired:
+        _DATAFRAME_AVAILABLE = False
+        _DATAFRAME_SKIP_REASON = "DataFrame service probe timed out on the selected E2E target"
+        pytest.skip(_DATAFRAME_SKIP_REASON)
+
+    if result.returncode == 0:
+        _DATAFRAME_AVAILABLE = True
+        _DATAFRAME_SKIP_REASON = None
+        return
+
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    if "404" in output or "not found" in output or "nidataframe" in output:
+        _DATAFRAME_AVAILABLE = False
+        _DATAFRAME_SKIP_REASON = "DataFrame service is not available on the selected E2E target"
+        pytest.skip(_DATAFRAME_SKIP_REASON)
+
+    pytest.fail(
+        "DataFrame availability probe failed unexpectedly\n"
+        f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.dataframe
+@pytest.mark.usefixtures("require_dataframe_service")
+class TestDataframeE2E:
+    """End-to-end tests for dataframe commands."""
+
+    def test_dataframe_list_basic(
+        self, cli_runner: Any, cli_helper: Any, configured_workspace: str
+    ) -> None:
+        """Ensure dataframe list returns the expected JSON shape."""
+        probe_name = _probe_name()
+        result = cli_runner(
+            [
+                "dataframe",
+                "list",
+                "--name",
+                probe_name,
+                "--workspace",
+                configured_workspace,
+                "--format",
+                "json",
+                "--take",
+                "5",
+            ]
+        )
+        cli_helper.assert_success(result)
+
+        payload = cli_helper.get_json_output(result)
+        assert isinstance(payload, dict)
+        assert "tables" in payload
+        assert isinstance(payload["tables"], list)
+        assert "continuationToken" in payload
+
+    def test_dataframe_lifecycle(
+        self, cli_runner: Any, cli_helper: Any, configured_workspace: str, tmp_path: Path
+    ) -> None:
+        """Create, inspect, append, query, export, update, and delete a dataframe table."""
+        unique_id = uuid.uuid4().hex[:8]
+        table_name = f"e2e-dataframe-{unique_id}"
+        definition_path = tmp_path / "table.json"
+        append_path = tmp_path / "append.json"
+        export_path = tmp_path / "rows.csv"
+        table_id = ""
+
+        _write_json(
+            definition_path,
+            {
+                "name": table_name,
+                "columns": [
+                    {"name": "Time", "dataType": "TIMESTAMP", "columnType": "INDEX"},
+                    {"name": "Voltage", "dataType": "FLOAT64", "columnType": "NORMAL"},
+                    {"name": "State", "dataType": "STRING", "columnType": "NORMAL"},
+                ],
+                "properties": {"owner": "e2e", "suite": "dataframe"},
+            },
+        )
+        _write_json(
+            append_path,
+            {
+                "frame": {
+                    "columns": ["Time", "Voltage", "State"],
+                    "data": [
+                        ["2026-04-28T00:00:00.000Z", "5.01", "PASS"],
+                        ["2026-04-28T00:00:01.000Z", "4.72", "FAIL"],
+                    ],
+                }
+            },
+        )
+
+        try:
+            create_result = cli_runner(
+                [
+                    "dataframe",
+                    "create",
+                    "--definition",
+                    str(definition_path),
+                    "--workspace",
+                    configured_workspace,
+                    "--format",
+                    "json",
+                ]
+            )
+            cli_helper.assert_success(create_result)
+            created = cli_helper.get_json_output(create_result)
+            table_id = str(created.get("id") or "")
+            if not table_id:
+                table_id = _resolve_table_id(
+                    cli_runner, cli_helper, table_name, configured_workspace
+                )
+
+            get_result = cli_runner(["dataframe", "get", table_id, "--format", "json"])
+            cli_helper.assert_success(get_result)
+            table_data = cli_helper.get_json_output(get_result)
+            assert table_data.get("id") == table_id
+            assert table_data.get("name") == table_name
+
+            schema_result = cli_runner(["dataframe", "schema", table_id, "--format", "json"])
+            cli_helper.assert_success(schema_result)
+            schema = cli_helper.get_json_output(schema_result)
+            assert isinstance(schema, list)
+            assert any(column.get("columnType") == "INDEX" for column in schema)
+            assert [column.get("name") for column in schema] == ["Time", "Voltage", "State"]
+
+            append_result = cli_runner(
+                ["dataframe", "append", table_id, "--input", str(append_path)]
+            )
+            cli_helper.assert_success(append_result)
+            assert "Dataframe rows appended" in append_result.stdout
+
+            queried = _wait_for_query_rows(cli_runner, cli_helper, table_id)
+            assert queried.get("totalRowCount", 0) >= 2
+
+            fail_query_result = cli_runner(
+                [
+                    "dataframe",
+                    "query",
+                    table_id,
+                    "--columns",
+                    "Time,Voltage,State",
+                    "--where",
+                    "State,EQUALS,FAIL",
+                    "--format",
+                    "json",
+                ]
+            )
+            cli_helper.assert_success(fail_query_result)
+            fail_rows = cli_helper.get_json_output(fail_query_result)
+            assert fail_rows.get("frame", {}).get("columns") == ["Time", "Voltage", "State"]
+            assert len(fail_rows.get("frame", {}).get("data", [])) >= 1
+
+            export_result = cli_runner(
+                ["dataframe", "export", table_id, "--output", str(export_path)]
+            )
+            cli_helper.assert_success(export_result)
+            assert export_path.exists()
+            exported_csv = export_path.read_text(encoding="utf-8")
+            assert "Time" in exported_csv
+            assert "Voltage" in exported_csv
+            assert "FAIL" in exported_csv
+
+            update_result = cli_runner(
+                [
+                    "dataframe",
+                    "update",
+                    table_id,
+                    "--property",
+                    "owner=qa",
+                    "--column-property",
+                    "Voltage:units=V",
+                ]
+            )
+            cli_helper.assert_success(update_result)
+
+            updated_get_result = cli_runner(["dataframe", "get", table_id, "--format", "json"])
+            cli_helper.assert_success(updated_get_result)
+            updated = cli_helper.get_json_output(updated_get_result)
+            assert updated.get("properties", {}).get("owner") == "qa"
+            voltage_column = next(
+                (
+                    column
+                    for column in updated.get("columns", [])
+                    if column.get("name") == "Voltage"
+                ),
+                None,
+            )
+            assert voltage_column is not None
+            assert voltage_column.get("properties", {}).get("units") == "V"
+
+            delete_result = cli_runner(["dataframe", "delete", table_id, "--yes"])
+            cli_helper.assert_success(delete_result)
+            deleted_table_id = table_id
+            table_id = ""
+
+            missing_result = cli_runner(
+                ["dataframe", "get", deleted_table_id, "--format", "json"],
+                check=False,
+            )
+            cli_helper.assert_failure(missing_result)
+
+        finally:
+            if table_id:
+                cli_runner(["dataframe", "delete", table_id, "--yes"], check=False)

--- a/tests/e2e/test_dataframe_e2e.py
+++ b/tests/e2e/test_dataframe_e2e.py
@@ -216,7 +216,7 @@ class TestDataframeE2E:
                 ["dataframe", "append", table_id, "--input", str(append_path)]
             )
             cli_helper.assert_success(append_result)
-            assert "Dataframe rows appended" in append_result.stdout
+            assert "DataFrame rows appended" in append_result.stdout
 
             queried = _wait_for_query_rows(cli_runner, cli_helper, table_id)
             assert queried.get("totalRowCount", 0) >= 2

--- a/tests/unit/test_comment_click.py
+++ b/tests/unit/test_comment_click.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from slcli.comment_click import register_comment_commands
@@ -19,6 +20,12 @@ def make_cli() -> click.Group:
 
     register_comment_commands(test_cli)
     return test_cli
+
+
+@pytest.fixture(autouse=True)
+def allow_comments_service(monkeypatch: Any) -> None:
+    """Keep comment command tests focused on command behavior, not feature probing."""
+    monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "ok")
 
 
 def mock_response(data: Any, status_code: int = 200) -> Any:

--- a/tests/unit/test_dataframe_click.py
+++ b/tests/unit/test_dataframe_click.py
@@ -1,12 +1,14 @@
 """Unit tests for dataframe CLI commands."""
 
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 import click
 import pytest
 from click.testing import CliRunner
 
+from slcli import dataframe_click as dataframe_module
 from slcli.dataframe_click import register_dataframe_commands
 
 
@@ -59,6 +61,156 @@ class MockResponse:
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise Exception(f"HTTP error {self.status_code}")
+
+
+def test_dataframe_filter_helpers_apply_offsets_and_substitutions() -> None:
+    """Test filter helper utilities preserve substitution semantics."""
+    assert dataframe_module._parse_substitutions(['"qa"', "7", "not-json"]) == ["qa", 7, "not-json"]
+    assert dataframe_module._offset_substitutions("A == @0 && B == @12", 2) == "A == @2 && B == @14"
+
+    combined_filter, substitutions = dataframe_module._combine_filter_parts(
+        "name.Contains(@0)", ["Voltage"], 'properties["team"] == @0', ["qa"]
+    )
+
+    assert combined_filter == '(name.Contains(@0)) && (properties["team"] == @1)'
+    assert substitutions == ["Voltage", "qa"]
+
+
+def test_dataframe_where_and_order_by_helpers_parse_expected_values() -> None:
+    """Test helper parsing for row filters, columns, and ordering."""
+    assert dataframe_module._parse_columns("Time, Voltage ,,State") == ["Time", "Voltage", "State"]
+    assert dataframe_module._parse_filter_value(" null ") is None
+    assert dataframe_module._parse_where_clause("Voltage,LESS_THAN,4.8") == {
+        "column": "Voltage",
+        "operation": "LESS_THAN",
+        "value": "4.8",
+    }
+    assert dataframe_module._parse_order_by_clause("Time:desc") == {
+        "column": "Time",
+        "descending": True,
+    }
+    assert dataframe_module._format_properties({"b": 2, "a": 1}, maximum_length=12).endswith("...")
+
+
+@pytest.mark.parametrize(
+    ("callable_obj", "argument"),
+    [
+        (dataframe_module._parse_where_clause, "Voltage,INVALID,4.8"),
+        (dataframe_module._parse_order_by_clause, "Time:sideways"),
+        (dataframe_module._parse_property_assignment, "invalid"),
+        (dataframe_module._parse_column_property_assignment, "Voltageunits=V"),
+        (dataframe_module._parse_column_property_removal, "Voltage"),
+    ],
+)
+def test_dataframe_helper_validations_reject_invalid_input(
+    callable_obj: Any, argument: str
+) -> None:
+    """Test helper validation exits on malformed CLI shorthand."""
+    with pytest.raises(SystemExit) as exc_info:
+        callable_obj(argument)
+
+    assert exc_info.value.code == 2
+
+
+def test_dataframe_load_request_payload_rejects_non_object(monkeypatch: Any) -> None:
+    """Test raw request files must decode to a JSON object."""
+    monkeypatch.setattr("slcli.dataframe_click.load_json_file", lambda _: ["not", "an", "object"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        dataframe_module._load_request_payload("request.json")
+
+    assert exc_info.value.code == 2
+
+
+def test_dataframe_build_decimation_payload_rejects_non_object_decimation(monkeypatch: Any) -> None:
+    """Test decimation payloads reject non-object decimation definitions."""
+    monkeypatch.setattr("slcli.dataframe_click.load_json_file", lambda _: {"decimation": ["bad"]})
+
+    with pytest.raises(SystemExit) as exc_info:
+        dataframe_module._build_decimation_payload(
+            request="decimation.json",
+            columns=None,
+            where=(),
+            x_column=None,
+            y_columns=(),
+            intervals=None,
+            method=None,
+            distribution=None,
+        )
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        ({}, "Append payload must contain a JSON object under 'frame'"),
+        ({"frame": {}}, "Append payload frame must contain a 'data' array"),
+        (
+            {"frame": {"data": [], "columns": "Voltage"}},
+            "Append payload frame 'columns' must be an array when provided",
+        ),
+    ],
+)
+def test_dataframe_validate_append_payload_rejects_invalid_shapes(
+    payload: Dict[str, Any], expected_message: str, capsys: Any
+) -> None:
+    """Test append payload validation catches malformed JSON structures."""
+    with pytest.raises(SystemExit) as exc_info:
+        dataframe_module._validate_append_payload(payload)
+
+    assert exc_info.value.code == 2
+    assert expected_message in capsys.readouterr().err
+
+
+def test_dataframe_display_query_pages_reports_empty_results(monkeypatch: Any, capsys: Any) -> None:
+    """Test table output reports empty query results without prompting."""
+    monkeypatch.setattr(
+        "slcli.dataframe_click.make_api_request",
+        lambda *args, **kwargs: MockResponse({"frame": {"columns": ["Time"], "data": []}}),
+    )
+
+    dataframe_module._display_query_pages("tbl-1", {}, endpoint="query-data")
+
+    assert "No rows found." in capsys.readouterr().out
+
+
+def test_dataframe_render_schema_table_reports_no_columns(capsys: Any) -> None:
+    """Test schema rendering handles empty column lists."""
+    dataframe_module._render_schema_table([], include_properties=False)
+
+    assert "No columns found." in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "command_args",
+    [
+        ["query", "tbl-1", "--request", "payload-dir", "--format", "json"],
+        ["decimate", "tbl-1", "--request", "payload-dir", "--format", "json"],
+        ["export", "tbl-1", "--request", "payload-dir"],
+        ["create", "--definition", "payload-dir", "--format", "json"],
+        ["update-many", "--definition", "payload-dir"],
+        ["export", "tbl-1", "--output", "payload-dir"],
+    ],
+)
+def test_dataframe_file_options_reject_directory_paths(
+    monkeypatch: Any, runner: CliRunner, command_args: List[str]
+) -> None:
+    """Test file-backed options reject directories before issuing requests."""
+    patch_keyring(monkeypatch)
+
+    def fail_request(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("command should not issue a request for an invalid file path")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", fail_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        os.mkdir("payload-dir")
+        result = runner.invoke(cli, ["dataframe", *command_args])
+
+    assert result.exit_code == 2
+    assert "File 'payload-dir' is a directory" in result.output
 
 
 def test_dataframe_list_builds_filters(monkeypatch: Any, runner: CliRunner) -> None:
@@ -148,6 +300,34 @@ def test_dataframe_schema_table_output(monkeypatch: Any, runner: CliRunner) -> N
     assert "Time" in result.output
     assert "TIMESTAMP" in result.output
     assert "Voltage" in result.output
+
+
+def test_dataframe_schema_json_output(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test schema command JSON output."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(
+            {
+                "columns": [
+                    {
+                        "name": "Voltage",
+                        "dataType": "FLOAT64",
+                        "columnType": "NORMAL",
+                        "properties": {"units": "V"},
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "schema", "tbl-1", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output[0]["name"] == "Voltage"
 
 
 def test_dataframe_get_json_output(monkeypatch: Any, runner: CliRunner) -> None:
@@ -269,6 +449,72 @@ def test_dataframe_query_builds_payload(monkeypatch: Any, runner: CliRunner) -> 
     assert payload["take"] == 50
 
 
+def test_dataframe_list_table_output_renders_rows(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test list command table output routes through interactive table rendering."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(
+        method: str, url: str, payload: Optional[Dict[str, Any]] = None, **_: Any
+    ) -> Any:
+        return MockResponse(
+            {
+                "tables": [
+                    {
+                        "id": "tbl-1",
+                        "name": "Voltage Log",
+                        "workspace": "ws-1",
+                        "rowCount": 42,
+                        "supportsAppend": True,
+                        "rowsModifiedAt": "2026-04-27T10:00:00Z",
+                    }
+                ],
+                "continuationToken": None,
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "list"])
+
+    assert result.exit_code == 0
+    assert "Voltage Log" in result.output
+    assert "Dev" in result.output
+
+
+def test_dataframe_list_json_fetches_all_pages(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test JSON list output combines continuation-token pages."""
+    patch_keyring(monkeypatch)
+    calls: List[Optional[str]] = []
+
+    def mock_request(
+        method: str, url: str, payload: Optional[Dict[str, Any]] = None, **_: Any
+    ) -> Any:
+        continuation = None if payload is None else payload.get("continuationToken")
+        calls.append(continuation)
+        if continuation is None:
+            return MockResponse(
+                {
+                    "tables": [{"id": "tbl-1", "name": "First"}],
+                    "continuationToken": "token-1",
+                }
+            )
+        return MockResponse(
+            {"tables": [{"id": "tbl-2", "name": "Second"}], "continuationToken": None}
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "list", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert [table["id"] for table in output["tables"]] == ["tbl-1", "tbl-2"]
+    assert calls == [None, "token-1"]
+
+
 def test_dataframe_query_request_preserves_file_take(monkeypatch: Any, runner: CliRunner) -> None:
     """Test raw query request files are not overridden by default take."""
     patch_keyring(monkeypatch)
@@ -306,6 +552,34 @@ def test_dataframe_query_request_preserves_file_take(monkeypatch: Any, runner: C
     assert captured_payloads[0]["take"] == 250
 
 
+def test_dataframe_query_table_output_reports_next_token(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test table query output shows the continuation token when paging stops."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(
+        method: str, url: str, payload: Optional[Dict[str, Any]] = None, **_: Any
+    ) -> Any:
+        return MockResponse(
+            {
+                "frame": {"columns": ["Time", "Voltage"], "data": [["1", "5.01"]]},
+                "totalRowCount": 2,
+                "continuationToken": "next-token",
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click._confirm_next_page", lambda: False)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "query", "tbl-1"])
+
+    assert result.exit_code == 0
+    assert "5.01" in result.output
+    assert "Next continuation token: next-token" in result.output
+
+
 def test_dataframe_query_rejects_invalid_filter_operation(
     monkeypatch: Any, runner: CliRunner
 ) -> None:
@@ -340,6 +614,22 @@ def test_dataframe_export_writes_csv(monkeypatch: Any, runner: CliRunner) -> Non
         assert result.exit_code == 0
         with open("rows.csv", "r", encoding="utf-8") as exported:
             assert exported.read() == '"Voltage","State"\n"5.01","PASS"\n'
+
+
+def test_dataframe_export_inline_writes_stdout(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test CSV export without --output writes inline CSV."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(text_data='"Voltage"\n"5.01"')
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "export", "tbl-1"])
+
+    assert result.exit_code == 0
+    assert result.output == '"Voltage"\n"5.01"\n'
 
 
 def test_dataframe_create_uses_definition_and_workspace(
@@ -396,6 +686,46 @@ def test_dataframe_create_uses_definition_and_workspace(
         assert captured_payloads[0]["workspace"] == "ws-1"
 
 
+def test_dataframe_create_table_output_reports_success(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test create command table output uses the success formatter path."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(
+        method: str, url: str, payload: Optional[Dict[str, Any]] = None, **_: Any
+    ) -> Any:
+        return MockResponse({"id": "tbl-created"})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("definition.json", "w", encoding="utf-8") as definition_file:
+            json.dump({"name": "Voltage Log", "columns": []}, definition_file)
+
+        result = runner.invoke(cli, ["dataframe", "create", "--definition", "definition.json"])
+
+    assert result.exit_code == 0
+    assert "DataFrame table created" in result.output
+
+
+def test_dataframe_create_rejects_non_object_definition(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test create rejects definition files that are not JSON objects."""
+    patch_keyring(monkeypatch)
+    monkeypatch.setattr("slcli.dataframe_click.load_json_file", lambda _: [])
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("definition.json", "w", encoding="utf-8") as definition_file:
+            definition_file.write("[]")
+
+        result = runner.invoke(cli, ["dataframe", "create", "--definition", "definition.json"])
+
+    assert result.exit_code == 2
+    assert "Table definition must contain a JSON object" in result.output
+
+
 def test_dataframe_update_builds_patch(monkeypatch: Any, runner: CliRunner) -> None:
     """Test metadata update payload construction."""
     patch_keyring(monkeypatch)
@@ -438,6 +768,17 @@ def test_dataframe_update_builds_patch(monkeypatch: Any, runner: CliRunner) -> N
     assert payload["properties"] == {"team": "qa", "obsolete": None}
     assert payload["columns"] == [{"name": "Voltage", "properties": {"units": "V", "alias": None}}]
     assert payload["metadataRevision"] == 4
+
+
+def test_dataframe_update_requires_changes(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test update exits when no changes are requested."""
+    patch_keyring(monkeypatch)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "update", "tbl-1"])
+
+    assert result.exit_code == 2
+    assert "Specify at least one field to update" in result.output
 
 
 def test_dataframe_delete_multiple_uses_batch_endpoint(monkeypatch: Any, runner: CliRunner) -> None:
@@ -501,6 +842,40 @@ def test_dataframe_append_arrow_uses_binary_request(monkeypatch: Any, runner: Cl
         assert captured_request["url"].endswith("/tables/tbl-1/data?endOfData=true")
         assert captured_request["headers"]["Content-Type"] == "application/vnd.apache.arrow.stream"
         assert captured_request["data"] == b"arrow-data"
+
+
+def test_dataframe_append_json_reports_rows_and_end_of_data(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test JSON append counts rows and carries the end-of-data flag."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("rows.json", "w", encoding="utf-8") as rows_file:
+            json.dump({"frame": {"columns": ["Voltage"], "data": [["5.01"], ["4.98"]]}}, rows_file)
+
+        result = runner.invoke(
+            cli,
+            ["dataframe", "append", "tbl-1", "--input", "rows.json", "--end-of-data"],
+        )
+
+    assert result.exit_code == 0
+    assert captured_payloads[0]["endOfData"] is True
+    assert "rows: 2" in result.output
 
 
 def test_dataframe_append_uses_click_path_validation(monkeypatch: Any, runner: CliRunner) -> None:
@@ -567,6 +942,22 @@ def test_dataframe_decimate_builds_payload(monkeypatch: Any, runner: CliRunner) 
         "method": "MAX_MIN",
         "distribution": "EQUAL_WIDTH",
     }
+
+
+def test_dataframe_decimate_table_output_renders_rows(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test decimate command table output renders returned frame data."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse({"frame": {"columns": ["Time", "Voltage"], "data": [["1", "5.01"]]}})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "decimate", "tbl-1"])
+
+    assert result.exit_code == 0
+    assert "5.01" in result.output
 
 
 def test_dataframe_decimate_request_preserves_file_intervals(
@@ -650,6 +1041,24 @@ def test_dataframe_update_many_posts_definition(monkeypatch: Any, runner: CliRun
         assert captured_payloads[0] == {"tables": [{"id": "tbl-1", "properties": {"team": "qa"}}]}
 
 
+def test_dataframe_update_many_rejects_non_object_definition(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test update-many rejects definition files that are not JSON objects."""
+    patch_keyring(monkeypatch)
+    monkeypatch.setattr("slcli.dataframe_click.load_json_file", lambda _: [])
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("modify.json", "w", encoding="utf-8") as modify_file:
+            modify_file.write("[]")
+
+        result = runner.invoke(cli, ["dataframe", "update-many", "--definition", "modify.json"])
+
+    assert result.exit_code == 2
+    assert "Batch update definition must contain a JSON object" in result.output
+
+
 def test_dataframe_update_many_partial_success_exits_with_error(
     monkeypatch: Any, runner: CliRunner
 ) -> None:
@@ -702,3 +1111,52 @@ def test_dataframe_delete_partial_success_exits_with_error(
     assert result.exit_code == 1
     assert "Failed to delete: tbl-2" in result.output
     assert "table is locked" in result.output
+
+
+def test_dataframe_delete_single_uses_delete_endpoint(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test single-table delete uses the direct DELETE endpoint."""
+    patch_keyring(monkeypatch)
+    calls: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        calls.append({"method": method, "url": url, "payload": payload})
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_base_url", lambda: "https://test.com")
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "delete", "tbl-1", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "method": "DELETE",
+            "url": "https://test.com/nidataframe/v1/tables/tbl-1",
+            "payload": None,
+        }
+    ]
+
+
+def test_dataframe_delete_returns_when_not_confirmed(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test delete exits quietly when bulk confirmation is declined."""
+    patch_keyring(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.dataframe_click.confirm_bulk_operation", lambda *args, **kwargs: False
+    )
+
+    def fail_request(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("delete should not issue a request when confirmation is declined")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", fail_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "delete", "tbl-1", "tbl-2"])
+
+    assert result.exit_code == 0
+    assert result.output == ""

--- a/tests/unit/test_dataframe_click.py
+++ b/tests/unit/test_dataframe_click.py
@@ -1,0 +1,553 @@
+"""Unit tests for dataframe CLI commands."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from slcli.dataframe_click import register_dataframe_commands
+
+
+def patch_keyring(monkeypatch: Any) -> None:
+    """Patch keyring to return test credentials."""
+    monkeypatch.setattr(
+        "slcli.utils.keyring.get_password",
+        lambda service, key: "test-key" if key == "SYSTEMLINK_API_KEY" else "https://test.com",
+    )
+
+
+def make_cli() -> click.Group:
+    """Create a CLI with the dataframe command group registered."""
+
+    @click.group()
+    def test_cli() -> None:
+        pass
+
+    register_dataframe_commands(test_cli)
+    return test_cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class MockResponse:
+    """Mock requests-style response for CLI unit tests."""
+
+    def __init__(
+        self,
+        json_data: Any = None,
+        status_code: int = 200,
+        text_data: Optional[str] = None,
+    ) -> None:
+        """Initialize a mock response payload and status code."""
+        self._json_data = json_data
+        self.status_code = status_code
+        if text_data is not None:
+            self.text = text_data
+        elif json_data is None:
+            self.text = ""
+        else:
+            self.text = json.dumps(json_data)
+
+    def json(self) -> Any:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP error {self.status_code}")
+
+
+def test_dataframe_list_builds_filters(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test list filter building, substitution offsets, and JSON output."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse(
+            {
+                "tables": [
+                    {
+                        "id": "tbl-1",
+                        "name": "Voltage Log",
+                        "workspace": "ws-1",
+                        "rowCount": 42,
+                        "supportsAppend": True,
+                    }
+                ],
+                "continuationToken": None,
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+    cli = make_cli()
+    result = runner.invoke(
+        cli,
+        [
+            "dataframe",
+            "list",
+            "--name",
+            "Voltage",
+            "--workspace",
+            "Dev",
+            "--supports-append",
+            "--filter",
+            'properties["tester"] == @0',
+            "--substitution",
+            '"12"',
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["tables"][0]["id"] == "tbl-1"
+    assert captured_payloads
+    payload = captured_payloads[0]
+    assert "name.Contains(@0)" in payload["filter"]
+    assert "supportsAppend == @1" in payload["filter"]
+    assert "workspace == @2" in payload["filter"]
+    assert 'properties["tester"] == @3' in payload["filter"]
+    assert payload["substitutions"] == ["Voltage", True, "ws-1", "12"]
+
+
+def test_dataframe_schema_table_output(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test schema command table output."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(
+            {
+                "id": "tbl-1",
+                "columns": [
+                    {"name": "Time", "dataType": "TIMESTAMP", "columnType": "INDEX"},
+                    {"name": "Voltage", "dataType": "FLOAT64", "columnType": "NORMAL"},
+                ],
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "schema", "tbl-1"])
+
+    assert result.exit_code == 0
+    assert "Time" in result.output
+    assert "TIMESTAMP" in result.output
+    assert "Voltage" in result.output
+
+
+def test_dataframe_query_builds_payload(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test query payload construction from shorthand flags."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse(
+            {
+                "frame": {
+                    "columns": ["Time", "Voltage"],
+                    "data": [["2026-04-27T10:00:00.000Z", "5.01"]],
+                },
+                "totalRowCount": 1,
+                "continuationToken": None,
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(
+        cli,
+        [
+            "dataframe",
+            "query",
+            "tbl-1",
+            "--columns",
+            "Time,Voltage",
+            "--where",
+            "State,EQUALS,FAIL",
+            "--order-by",
+            "Time:desc",
+            "--take",
+            "50",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = captured_payloads[0]
+    assert payload["columns"] == ["Time", "Voltage"]
+    assert payload["filters"] == [{"column": "State", "operation": "EQUALS", "value": "FAIL"}]
+    assert payload["orderBy"] == [{"column": "Time", "descending": True}]
+    assert payload["take"] == 50
+
+
+def test_dataframe_query_request_preserves_file_take(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test raw query request files are not overridden by default take."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse({"frame": {"columns": ["Time"], "data": [["1"]]}})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("query.json", "w", encoding="utf-8") as query_file:
+            json.dump(
+                {
+                    "take": 250,
+                    "filters": [{"column": "State", "operation": "EQUALS", "value": "FAIL"}],
+                },
+                query_file,
+            )
+
+        result = runner.invoke(
+            cli,
+            ["dataframe", "query", "tbl-1", "--request", "query.json", "--format", "json"],
+        )
+
+    assert result.exit_code == 0
+    assert captured_payloads[0]["take"] == 250
+
+
+def test_dataframe_export_writes_csv(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test CSV export to an output file."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(text_data='"Voltage","State"\n"5.01","PASS"\n')
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["dataframe", "export", "tbl-1", "--output", "rows.csv"],
+        )
+        assert result.exit_code == 0
+        with open("rows.csv", "r", encoding="utf-8") as exported:
+            assert exported.read() == '"Voltage","State"\n"5.01","PASS"\n'
+
+
+def test_dataframe_create_uses_definition_and_workspace(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test table creation with definition override and workspace resolution."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse({"id": "tbl-created"})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("definition.json", "w", encoding="utf-8") as definition_file:
+            json.dump(
+                {
+                    "columns": [
+                        {"name": "Time", "dataType": "TIMESTAMP", "columnType": "INDEX"},
+                        {"name": "Voltage", "dataType": "FLOAT64"},
+                    ]
+                },
+                definition_file,
+            )
+
+        result = runner.invoke(
+            cli,
+            [
+                "dataframe",
+                "create",
+                "--definition",
+                "definition.json",
+                "--name",
+                "Voltage Log",
+                "--workspace",
+                "Dev",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured_payloads[0]["name"] == "Voltage Log"
+        assert captured_payloads[0]["workspace"] == "ws-1"
+
+
+def test_dataframe_update_builds_patch(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test metadata update payload construction."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(
+        cli,
+        [
+            "dataframe",
+            "update",
+            "tbl-1",
+            "--property",
+            "team=qa",
+            "--remove-property",
+            "obsolete",
+            "--column-property",
+            "Voltage:units=V",
+            "--remove-column-property",
+            "Voltage:alias",
+            "--metadata-revision",
+            "4",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = captured_payloads[0]
+    assert payload["properties"] == {"team": "qa", "obsolete": None}
+    assert payload["columns"] == [{"name": "Voltage", "properties": {"units": "V", "alias": None}}]
+    assert payload["metadataRevision"] == 4
+
+
+def test_dataframe_delete_multiple_uses_batch_endpoint(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test multi-delete routing to the batch endpoint."""
+    patch_keyring(monkeypatch)
+    calls: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        calls.append({"method": method, "url": url, "payload": payload})
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "delete", "tbl-1", "tbl-2", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["payload"] == {"ids": ["tbl-1", "tbl-2"]}
+
+
+def test_dataframe_append_arrow_uses_binary_request(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test Arrow append path with raw binary request."""
+    patch_keyring(monkeypatch)
+    captured_request: Dict[str, Any] = {}
+
+    def mock_post(url: str, headers: Dict[str, str], data: bytes, verify: bool) -> Any:
+        captured_request["url"] = url
+        captured_request["headers"] = headers
+        captured_request["data"] = data
+        captured_request["verify"] = verify
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.requests_lib.post", mock_post)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("rows.arrow", "wb") as arrow_file:
+            arrow_file.write(b"arrow-data")
+
+        result = runner.invoke(
+            cli,
+            [
+                "dataframe",
+                "append",
+                "tbl-1",
+                "--input",
+                "rows.arrow",
+                "--input-format",
+                "arrow",
+                "--end-of-data",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured_request["url"].endswith("/tables/tbl-1/data?endOfData=true")
+        assert captured_request["headers"]["Content-Type"] == "application/vnd.apache.arrow.stream"
+        assert captured_request["data"] == b"arrow-data"
+
+
+def test_dataframe_decimate_builds_payload(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test decimation request payload construction."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse({"frame": {"columns": ["Time"], "data": [["1"]]}})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(
+        cli,
+        [
+            "dataframe",
+            "decimate",
+            "tbl-1",
+            "--x-column",
+            "Time",
+            "--y-column",
+            "Voltage",
+            "--intervals",
+            "25",
+            "--method",
+            "MAX_MIN",
+            "--distribution",
+            "EQUAL_WIDTH",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = captured_payloads[0]
+    assert payload["decimation"] == {
+        "intervals": 25,
+        "xColumn": "Time",
+        "yColumns": ["Voltage"],
+        "method": "MAX_MIN",
+        "distribution": "EQUAL_WIDTH",
+    }
+
+
+def test_dataframe_decimate_request_preserves_file_intervals(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test raw decimation request files are not overridden by default intervals."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse({"frame": {"columns": ["Time"], "data": [["1"]]}})
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("decimate.json", "w", encoding="utf-8") as decimate_file:
+            json.dump(
+                {
+                    "decimation": {
+                        "intervals": 25,
+                        "xColumn": "Time",
+                        "yColumns": ["Voltage"],
+                    }
+                },
+                decimate_file,
+            )
+
+        result = runner.invoke(
+            cli,
+            [
+                "dataframe",
+                "decimate",
+                "tbl-1",
+                "--request",
+                "decimate.json",
+                "--format",
+                "json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert captured_payloads[0]["decimation"]["intervals"] == 25
+
+
+def test_dataframe_update_many_posts_definition(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test batch metadata update routing to modify-tables."""
+    patch_keyring(monkeypatch)
+    captured_payloads: List[Dict[str, Any]] = []
+
+    def mock_request(
+        method: str,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Any:
+        if payload is not None:
+            captured_payloads.append(payload)
+        return MockResponse(status_code=204, text_data="")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("modify.json", "w", encoding="utf-8") as modify_file:
+            json.dump({"tables": [{"id": "tbl-1", "properties": {"team": "qa"}}]}, modify_file)
+
+        result = runner.invoke(
+            cli,
+            ["dataframe", "update-many", "--definition", "modify.json"],
+        )
+
+        assert result.exit_code == 0
+        assert captured_payloads[0] == {"tables": [{"id": "tbl-1", "properties": {"team": "qa"}}]}

--- a/tests/unit/test_dataframe_click.py
+++ b/tests/unit/test_dataframe_click.py
@@ -241,6 +241,22 @@ def test_dataframe_query_request_preserves_file_take(monkeypatch: Any, runner: C
     assert captured_payloads[0]["take"] == 250
 
 
+def test_dataframe_query_rejects_invalid_filter_operation(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test invalid row filter operations exit with invalid input."""
+    patch_keyring(monkeypatch)
+
+    cli = make_cli()
+    result = runner.invoke(
+        cli,
+        ["dataframe", "query", "tbl-1", "--where", "State,INVALID,FAIL", "--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    assert "Unsupported filter operation 'INVALID'" in result.output
+
+
 def test_dataframe_export_writes_csv(monkeypatch: Any, runner: CliRunner) -> None:
     """Test CSV export to an output file."""
     patch_keyring(monkeypatch)
@@ -551,3 +567,57 @@ def test_dataframe_update_many_posts_definition(monkeypatch: Any, runner: CliRun
 
         assert result.exit_code == 0
         assert captured_payloads[0] == {"tables": [{"id": "tbl-1", "properties": {"team": "qa"}}]}
+
+
+def test_dataframe_update_many_partial_success_exits_with_error(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test batch update partial success reports failures and exits nonzero."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(
+            {
+                "modifiedTableIds": ["tbl-1"],
+                "failedModifications": [{"tableId": "tbl-2"}],
+                "error": {"message": "metadata revision conflict"},
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    with runner.isolated_filesystem():
+        with open("modify.json", "w", encoding="utf-8") as modify_file:
+            json.dump({"tables": [{"id": "tbl-1"}, {"id": "tbl-2"}]}, modify_file)
+
+        result = runner.invoke(cli, ["dataframe", "update-many", "--definition", "modify.json"])
+
+    assert result.exit_code == 1
+    assert "Failed modifications: 1" in result.output
+    assert "metadata revision conflict" in result.output
+
+
+def test_dataframe_delete_partial_success_exits_with_error(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test batch delete partial success reports failed IDs and exits nonzero."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(
+            {
+                "deletedTableIds": ["tbl-1"],
+                "failedTableIds": ["tbl-2"],
+                "error": {"message": "table is locked"},
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "delete", "tbl-1", "tbl-2", "--yes"])
+
+    assert result.exit_code == 1
+    assert "Failed to delete: tbl-2" in result.output
+    assert "table is locked" in result.output

--- a/tests/unit/test_dataframe_click.py
+++ b/tests/unit/test_dataframe_click.py
@@ -150,6 +150,71 @@ def test_dataframe_schema_table_output(monkeypatch: Any, runner: CliRunner) -> N
     assert "Voltage" in result.output
 
 
+def test_dataframe_get_json_output(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test get command JSON output."""
+    patch_keyring(monkeypatch)
+    calls: List[Dict[str, str]] = []
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        calls.append({"method": method, "url": url})
+        return MockResponse(
+            {
+                "id": "tbl-1",
+                "name": "Voltage Log",
+                "workspace": "ws-1",
+                "rowCount": 42,
+                "columns": [{"name": "Time", "dataType": "TIMESTAMP", "columnType": "INDEX"}],
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_base_url", lambda: "https://test.com")
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "get", "tbl-1", "--format", "json"])
+
+    assert result.exit_code == 0
+    assert calls == [{"method": "GET", "url": "https://test.com/nidataframe/v1/tables/tbl-1"}]
+    output = json.loads(result.output)
+    assert output["id"] == "tbl-1"
+    assert output["columns"][0]["name"] == "Time"
+
+
+def test_dataframe_get_table_output_includes_schema_preview(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test get command table output includes a schema preview."""
+    patch_keyring(monkeypatch)
+
+    def mock_request(method: str, url: str, **_: Any) -> Any:
+        return MockResponse(
+            {
+                "id": "tbl-1",
+                "name": "Voltage Log",
+                "workspace": "ws-1",
+                "rowCount": 42,
+                "supportsAppend": True,
+                "columns": [
+                    {"name": "Time", "dataType": "TIMESTAMP", "columnType": "INDEX"},
+                    {"name": "Voltage", "dataType": "FLOAT64", "columnType": "NORMAL"},
+                ],
+            }
+        )
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.dataframe_click.get_workspace_map", lambda: {"ws-1": "Dev"})
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "get", "tbl-1"])
+
+    assert result.exit_code == 0
+    assert "DataFrame Table" in result.output
+    assert "Voltage Log" in result.output
+    assert "Schema" in result.output
+    assert "Time" in result.output
+    assert "Voltage" in result.output
+
+
 def test_dataframe_query_builds_payload(monkeypatch: Any, runner: CliRunner) -> None:
     """Test query payload construction from shorthand flags."""
     patch_keyring(monkeypatch)
@@ -404,10 +469,10 @@ def test_dataframe_append_arrow_uses_binary_request(monkeypatch: Any, runner: Cl
     patch_keyring(monkeypatch)
     captured_request: Dict[str, Any] = {}
 
-    def mock_post(url: str, headers: Dict[str, str], data: bytes, verify: bool) -> Any:
+    def mock_post(url: str, headers: Dict[str, str], data: Any, verify: bool) -> Any:
         captured_request["url"] = url
         captured_request["headers"] = headers
-        captured_request["data"] = data
+        captured_request["data"] = data.read()
         captured_request["verify"] = verify
         return MockResponse(status_code=204, text_data="")
 
@@ -436,6 +501,22 @@ def test_dataframe_append_arrow_uses_binary_request(monkeypatch: Any, runner: Cl
         assert captured_request["url"].endswith("/tables/tbl-1/data?endOfData=true")
         assert captured_request["headers"]["Content-Type"] == "application/vnd.apache.arrow.stream"
         assert captured_request["data"] == b"arrow-data"
+
+
+def test_dataframe_append_uses_click_path_validation(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test append rejects missing input paths before issuing any request."""
+    patch_keyring(monkeypatch)
+
+    def fail_request(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("append should not issue a request for an invalid input path")
+
+    monkeypatch.setattr("slcli.dataframe_click.make_api_request", fail_request)
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["dataframe", "append", "tbl-1", "--input", "missing.json"])
+
+    assert result.exit_code == 2
+    assert "does not exist" in result.output
 
 
 def test_dataframe_decimate_builds_payload(monkeypatch: Any, runner: CliRunner) -> None:

--- a/tests/unit/test_feature_gating.py
+++ b/tests/unit/test_feature_gating.py
@@ -80,6 +80,7 @@ class TestFeatureGatingTemplates:
             return ""
 
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
 
         runner = CliRunner()
         result = runner.invoke(cli, ["template", "list"])
@@ -105,12 +106,123 @@ class TestFeatureGatingWorkflows:
             return ""
 
         monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
 
         runner = CliRunner()
         result = runner.invoke(cli, ["workitem", "workflow", "list"])
 
         assert result.exit_code == 2  # INVALID_INPUT
         assert "Workflows is not available on SystemLink Server" in result.output
+
+
+class TestFeatureGatingWorkitemTemplates:
+    """Tests for feature gating on workitem template commands."""
+
+    def test_workitem_template_command_blocked_on_sls(self, monkeypatch: Any) -> None:
+        """Test that workitem template commands are blocked on SLS platform."""
+        config = {
+            "api_url": "https://my-server.local",
+            "api_key": "test-key",
+            "platform": "SLS",
+        }
+
+        def mock_get_password(service: str, key: str) -> str:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps(config)
+            return ""
+
+        monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["workitem", "template", "list"])
+
+        assert result.exit_code == 2
+        assert "Test Plan Templates is not available on SystemLink Server" in result.output
+
+
+class TestFeatureGatingComments:
+    """Tests for feature gating on comment commands."""
+
+    def test_comment_command_blocked_on_sls(self, monkeypatch: Any) -> None:
+        """Test that comment commands are blocked on SLS platform."""
+        config = {
+            "api_url": "https://my-server.local",
+            "api_key": "test-key",
+            "platform": "SLS",
+        }
+
+        def mock_get_password(service: str, key: str) -> str:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps(config)
+            return ""
+
+        monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["comment", "list"])
+
+        assert result.exit_code == 2
+        assert "Comments is not available on SystemLink Server" in result.output
+        assert "requires the Comments service" in result.output
+
+
+class TestFeatureGatingDataFrame:
+    """Tests for feature gating on dataframe commands."""
+
+    def test_dataframe_command_blocked_on_sls(self, monkeypatch: Any) -> None:
+        """Test that dataframe commands are blocked on SLS platform."""
+        config = {
+            "api_url": "https://my-server.local",
+            "api_key": "test-key",
+            "platform": "SLS",
+        }
+
+        def mock_get_password(service: str, key: str) -> str:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps(config)
+            return ""
+
+        monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dataframe", "list"])
+
+        assert result.exit_code == 2
+        assert "DataFrames is not available on SystemLink Server" in result.output
+        assert "requires the DataFrame service" in result.output
+
+
+class TestFeatureGatingRuntimePlatformDisplay:
+    """Tests for live platform display in feature gating messages."""
+
+    def test_template_command_uses_runtime_platform_display(self, monkeypatch: Any) -> None:
+        """Test unavailable feature messages avoid 'unknown' when SLS is detectable."""
+        config = {
+            "api_url": "https://my-server.local",
+            "api_key": "test-key",
+        }
+
+        def mock_get_password(service: str, key: str) -> str:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps(config)
+            return ""
+
+        monkeypatch.setattr("slcli.platform.keyring.get_password", mock_get_password)
+        monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "not_found")
+        monkeypatch.setattr(
+            "slcli.platform.check_service_status",
+            lambda api_url, api_key: {"platform": "SLS"},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["template", "list"])
+
+        assert result.exit_code == 2
+        assert "SystemLink Server" in result.output
+        assert "unknown" not in result.output.lower()
 
 
 class TestFeatureGatingFunctions:

--- a/tests/unit/test_info_command.py
+++ b/tests/unit/test_info_command.py
@@ -66,6 +66,7 @@ class TestInfoCommand:
             "auth_valid": True,
             "services": {
                 "Auth": "ok",
+                "DataFrame": "not_found",
                 "File": "ok",
                 "Test Monitor": "ok",
                 "Work Order": "not_found",
@@ -97,6 +98,7 @@ class TestInfoCommand:
         assert "Connected" in result.output
         assert "SystemLink Server" in result.output
         assert "Service Health" in result.output
+        assert "DataFrame" in result.output
         assert "Work Order" in result.output
         assert "Not available" in result.output
         assert "System Query" in result.output

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -114,7 +114,10 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 200,
                 "/nifile/": 200,
+                "/nidataframe/": 200,
                 "/ninotebook/": 200,
+                "/nicomments/": 200,
+                "/niroutine/v2/": 200,
                 "/niapp/": 200,
                 "/nidynamicformfields/": 200,
                 "/niworkorder/": 200,
@@ -129,6 +132,9 @@ class TestCheckServiceStatus:
         assert result["auth_valid"] is True
         assert result["platform"] == PLATFORM_SLE
         assert result["services"]["Auth"] == "ok"
+        assert result["services"]["Comments"] == "ok"
+        assert result["services"]["DataFrame"] == "ok"
+        assert result["services"]["Routine v2"] == "ok"
         assert result["services"]["Test Monitor"] == "ok"
         assert result["services"]["Work Order"] == "ok"
 
@@ -142,7 +148,10 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 200,
                 "/nifile/": 200,
+                "/nidataframe/": 404,
                 "/ninotebook/": 404,
+                "/nicomments/": 404,
+                "/niroutine/v2/": 404,
                 "/niapp/": 200,
                 "/nidynamicformfields/": 404,
                 "/niworkorder/": 404,
@@ -156,6 +165,9 @@ class TestCheckServiceStatus:
         assert result["server_reachable"] is True
         assert result["auth_valid"] is True
         assert result["platform"] == PLATFORM_SLS
+        assert result["services"]["Comments"] == "not_found"
+        assert result["services"]["DataFrame"] == "not_found"
+        assert result["services"]["Routine v2"] == "not_found"
         assert result["services"]["Work Order"] == "not_found"
 
     def test_all_services_unauthorized(self) -> None:
@@ -168,7 +180,10 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 401,
                 "/nitag/": 401,
                 "/nifile/": 401,
+                "/nidataframe/": 401,
                 "/ninotebook/": 401,
+                "/nicomments/": 401,
+                "/niroutine/v2/": 401,
                 "/niapp/": 401,
                 "/nidynamicformfields/": 401,
                 "/niworkorder/": 401,
@@ -181,7 +196,9 @@ class TestCheckServiceStatus:
 
         assert result["server_reachable"] is True
         assert result["auth_valid"] is False
+        assert result["platform"] == PLATFORM_SLE
         assert result["services"]["Auth"] == "unauthorized"
+        assert result["services"]["Comments"] == "unauthorized"
         assert result["services"]["Test Monitor"] == "unauthorized"
 
     def test_partial_unauthorized(self) -> None:
@@ -194,7 +211,10 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 200,
                 "/nifile/": 200,
+                "/nidataframe/": 404,
                 "/ninotebook/": 200,
+                "/nicomments/": 404,
+                "/niroutine/v2/": 401,
                 "/niapp/": 200,
                 "/nidynamicformfields/": 200,
                 "/niworkorder/": 200,
@@ -221,7 +241,10 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": conn_err,
                 "/nitag/": conn_err,
                 "/nifile/": conn_err,
+                "/nidataframe/": conn_err,
                 "/ninotebook/": conn_err,
+                "/nicomments/": conn_err,
+                "/niroutine/v2/": conn_err,
                 "/niapp/": conn_err,
                 "/nidynamicformfields/": conn_err,
                 "/niworkorder/": conn_err,
@@ -236,8 +259,8 @@ class TestCheckServiceStatus:
         assert result["auth_valid"] is None
         assert result["platform"] == PLATFORM_UNREACHABLE
 
-    def test_inconclusive_workorder_status_returns_unknown(self) -> None:
-        """Test that unauthorized workorder status no longer guesses the platform."""
+    def test_infer_sle_when_any_sle_only_service_is_available(self) -> None:
+        """Test that a reachable SLE-only service is enough to infer SLE."""
         mock_get, mock_post = self._mock_requests(
             {
                 "/niauth/": 200,
@@ -246,16 +269,83 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 200,
                 "/nifile/": 200,
+                "/nidataframe/": 404,
                 "/ninotebook/": 200,
+                "/nicomments/": 404,
+                "/niroutine/v2/": 404,
                 "/niapp/": 200,
-                "/nidynamicformfields/": 200,
+                "/nidynamicformfields/": 401,
                 "/niworkorder/": 401,
             }
         )
         with patch("slcli.platform.requests.get", mock_get), patch(
             "slcli.platform.requests.post", mock_post
         ):
-            result = check_service_status("https://demo-api.lifecyclesolutions.ni.com", "key")
+            result = check_service_status("https://my-server.example.com", "key")
+
+        assert result["server_reachable"] is True
+        assert result["platform"] == PLATFORM_SLE
+
+    def test_inconclusive_sle_only_probes_return_unknown(self) -> None:
+        """Test that mixed inconclusive SLE-only probes do not guess a platform."""
+        mock_get, mock_post = self._mock_requests(
+            {
+                "/niauth/": 200,
+                "/nitestmonitor/": 200,
+                "/niapm/": 200,
+                "/nisysmgmt/": 200,
+                "/nitag/": 200,
+                "/nifile/": 200,
+                "/nidataframe/": 404,
+                "/ninotebook/": 404,
+                "/nicomments/": 404,
+                "/niroutine/v2/": 404,
+                "/niapp/": 200,
+                "/nidynamicformfields/": "bad gateway",
+                "/niworkorder/": 401,
+            }
+        )
+
+        # Map the synthetic error token to an HTTP 502 response.
+        def side_effect_post(url: str, **kwargs: Any) -> MagicMock:
+            if "/nidynamicformfields/" in url:
+                return _make_mock_response(502)
+            for pattern, result in {
+                "/niauth/": 200,
+                "/nitestmonitor/": 200,
+                "/niapm/": 200,
+                "/nisysmgmt/": 200,
+                "/nitag/": 200,
+                "/nifile/": 200,
+                "/nidataframe/": 404,
+                "/ninotebook/": 404,
+                "/niapp/": 200,
+                "/niworkorder/": 401,
+            }.items():
+                if pattern in url:
+                    return _make_mock_response(result)
+            return _make_mock_response(200)
+
+        def side_effect_get(url: str, **kwargs: Any) -> MagicMock:
+            for pattern, result in {
+                "/niauth/": 200,
+                "/nitestmonitor/": 200,
+                "/nitag/": 200,
+                "/nicomments/": 404,
+                "/niroutine/v2/": 404,
+                "/nidynamicformfields/": 502,
+            }.items():
+                if pattern in url:
+                    return _make_mock_response(result)
+            return _make_mock_response(200)
+
+        mock_get.side_effect = side_effect_get
+        mock_post.side_effect = side_effect_post
+
+        with patch("slcli.platform.requests.get", mock_get), patch(
+            "slcli.platform.requests.post", mock_post
+        ):
+            result = check_service_status("https://my-lab.example.com", "key")
 
         assert result["server_reachable"] is True
         assert result["platform"] == PLATFORM_UNKNOWN
@@ -270,6 +360,7 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 404,
                 "/nifile/": 404,
+                "/nidataframe/": 404,
                 "/ninotebook/": 404,
                 "/niapp/": 404,
                 "/nidynamicformfields/": 404,
@@ -302,6 +393,7 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 404,
                 "/nifile/": 404,
+                "/nidataframe/": 404,
                 "/ninotebook/": 404,
                 "/niapp/": 404,
                 "/nidynamicformfields/": 404,
@@ -334,6 +426,7 @@ class TestCheckServiceStatus:
                 "/nisysmgmt/": 200,
                 "/nitag/": 404,
                 "/nifile/": 404,
+                "/nidataframe/": 404,
                 "/ninotebook/": 404,
                 "/niapp/": 404,
                 "/nidynamicformfields/": 404,

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,6 +1,7 @@
 """Unit tests for slcli.platform module."""
 
 import json
+import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -24,9 +25,11 @@ from slcli.platform import (
 
 
 @pytest.fixture(autouse=True)
-def clear_cache() -> None:
-    """Clear the platform cache before each test."""
+def clear_cache(tmp_path: Any, monkeypatch: Any) -> None:
+    """Clear platform caches and isolate persisted config before each test."""
     clear_platform_cache()
+    monkeypatch.setenv("SLCLI_CONFIG", str(tmp_path / "config.json"))
+    monkeypatch.delenv("SLCLI_SERVICE_PROBE_CACHE_TTL_SECONDS", raising=False)
 
 
 class TestDetectPlatform:
@@ -561,6 +564,120 @@ class TestHasFeature:
 
             assert result is True
 
+    def test_has_feature_templates_uses_workorder_service_probe(self) -> None:
+        """Test templates/workflows follow the Work Order service capability."""
+        config = {"platform": "SLS"}
+
+        with patch("slcli.platform.keyring.get_password") as mock_keyring, patch(
+            "slcli.platform._get_service_status", return_value="ok"
+        ):
+            mock_keyring.return_value = json.dumps(config)
+
+            assert has_feature("templates") is True
+            assert has_feature("workflows") is True
+
+    def test_has_feature_workorder_not_found_overrides_sle_platform(self) -> None:
+        """Test Work Order-backed features are disabled when the service is missing."""
+        config = {"platform": "SLE"}
+
+        with patch("slcli.platform.keyring.get_password") as mock_keyring, patch(
+            "slcli.platform._get_service_status", return_value="not_found"
+        ):
+            mock_keyring.return_value = json.dumps(config)
+
+            assert has_feature("workorder_service") is False
+            assert has_feature("templates") is False
+            assert has_feature("workflows") is False
+
+    def test_has_feature_uses_persisted_service_probe_cache(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Test service-backed features reuse a fresh persisted probe snapshot."""
+        from slcli.profiles import save_service_probe_cache_entry
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "current-profile": "sls",
+                    "profiles": {
+                        "sls": {
+                            "server": "https://my-server.local",
+                            "api-key": "test-key",
+                            "platform": "SLS",
+                        }
+                    },
+                }
+            )
+        )
+
+        save_service_probe_cache_entry(
+            "cache-key",
+            {
+                "server": "https://my-server.local",
+                "cached_at": time.time(),
+                "status": {
+                    "platform": PLATFORM_SLS,
+                    "services": {"Work Order": "ok"},
+                },
+            },
+        )
+
+        with patch(
+            "slcli.platform._build_service_probe_cache_key", return_value="cache-key"
+        ), patch("slcli.platform.check_service_status") as mock_check:
+            assert has_feature("templates") is True
+            mock_check.assert_not_called()
+
+    def test_has_feature_refreshes_stale_service_probe_cache(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Test stale persisted probe snapshots are refreshed before feature checks."""
+        from slcli.profiles import save_service_probe_cache_entry
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "current-profile": "sls",
+                    "profiles": {
+                        "sls": {
+                            "server": "https://my-server.local",
+                            "api-key": "test-key",
+                            "platform": "SLS",
+                        }
+                    },
+                }
+            )
+        )
+
+        save_service_probe_cache_entry(
+            "cache-key",
+            {
+                "server": "https://my-server.local",
+                "cached_at": 0.0,
+                "status": {
+                    "platform": PLATFORM_SLS,
+                    "services": {"Work Order": "not_found"},
+                },
+            },
+        )
+        monkeypatch.setenv("SLCLI_SERVICE_PROBE_CACHE_TTL_SECONDS", "60")
+
+        with patch(
+            "slcli.platform._build_service_probe_cache_key", return_value="cache-key"
+        ), patch(
+            "slcli.platform.check_service_status",
+            return_value={
+                "platform": PLATFORM_SLS,
+                "server_reachable": True,
+                "auth_valid": True,
+                "services": {"Work Order": "ok"},
+            },
+        ) as mock_check:
+            assert has_feature("templates") is True
+            mock_check.assert_called_once()
+
 
 class TestRequireFeature:
     """Tests for require_feature function."""
@@ -586,6 +703,24 @@ class TestRequireFeature:
                 require_feature("dynamic_form_fields")
 
             assert exc_info.value.code == 2  # INVALID_INPUT
+
+    def test_require_feature_templates_reports_workorder_requirement(self, capsys: Any) -> None:
+        """Test Work Order-backed features mention the service-specific requirement."""
+        config = {"platform": "SLS"}
+
+        with patch("slcli.platform.keyring.get_password") as mock_keyring, patch(
+            "slcli.platform._get_service_status", return_value="not_found"
+        ):
+            mock_keyring.return_value = json.dumps(config)
+
+            with pytest.raises(SystemExit) as exc_info:
+                require_feature("templates")
+
+            assert exc_info.value.code == 2
+
+        captured = capsys.readouterr()
+        assert "Test Plan Templates" in captured.err
+        assert "requires the Work Order service" in captured.err
 
 
 class TestGetPlatformInfo:
@@ -819,6 +954,47 @@ class TestGetPlatformInfo:
             assert result["auth_valid"] is False
             assert result["server_reachable"] is True
             assert result["services"]["Auth"] == "unauthorized"
+
+    def test_get_platform_info_persists_service_probe_snapshot(self, tmp_path: Any) -> None:
+        """Test info refreshes and persists the live service snapshot."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "current-profile": "sls",
+                    "profiles": {
+                        "sls": {
+                            "server": "https://my-server.local",
+                            "api-key": "test-key",
+                            "platform": "SLS",
+                        }
+                    },
+                }
+            )
+        )
+
+        mock_status = {
+            "server_reachable": True,
+            "auth_valid": True,
+            "services": {"Auth": "ok", "Work Order": "not_found"},
+            "platform": PLATFORM_SLS,
+            "file_query_endpoint": "query-files",
+            "elasticsearch_available": False,
+            "system_query_endpoint": "query-systems",
+            "materialized_search_available": False,
+        }
+
+        with patch("slcli.platform.check_service_status", return_value=mock_status):
+            result = get_platform_info()
+
+        assert result["platform"] == PLATFORM_SLS
+
+        saved = json.loads(config_file.read_text())
+        cache_entries = saved.get("service-probe-cache", {})
+        assert len(cache_entries) == 1
+        cached_entry = next(iter(cache_entries.values()))
+        assert cached_entry["server"] == "https://my-server.local"
+        assert cached_entry["status"]["services"]["Work Order"] == "not_found"
 
 
 class TestPlatformFeatureMatrix:

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -10,6 +10,8 @@ from slcli.profiles import (
     check_config_file_permissions,
     get_active_profile,
     get_default_workspace,
+    get_service_probe_cache_entry,
+    save_service_probe_cache_entry,
     set_profile_override,
 )
 
@@ -197,6 +199,27 @@ class TestProfileConfig:
         saved = json.loads(config_file.read_text())
         assert saved["current-profile"] == "test"
         assert "test" in saved["profiles"]
+
+    def test_service_probe_cache_entry_round_trip(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """Test persisted service probe cache entries survive save/load."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(
+            "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+        )
+
+        save_service_probe_cache_entry(
+            "cache-key",
+            {"server": "https://example.com", "cached_at": 123.0, "status": {"platform": "SLS"}},
+        )
+
+        entry = get_service_probe_cache_entry("cache-key")
+        assert entry is not None
+        assert entry["server"] == "https://example.com"
+        assert entry["status"]["platform"] == "SLS"
+
+        saved = json.loads(config_file.read_text())
+        assert "service-probe-cache" in saved
+        assert "cache-key" in saved["service-probe-cache"]
 
     def test_add_profile(self) -> None:
         """Test adding a profile."""

--- a/tests/unit/test_templates_click.py
+++ b/tests/unit/test_templates_click.py
@@ -26,6 +26,12 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def allow_workorder_service(monkeypatch: Any) -> None:
+    """Keep template command tests focused on template behavior, not feature probing."""
+    monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "ok")
+
+
 def mock_requests(
     monkeypatch: Any, method: str, response_json: Any, status_code: int = 200
 ) -> None:

--- a/tests/unit/test_workflows_click.py
+++ b/tests/unit/test_workflows_click.py
@@ -26,6 +26,12 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def allow_workorder_service(monkeypatch: Any) -> None:
+    """Keep workflow command tests focused on workflow behavior, not feature probing."""
+    monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "ok")
+
+
 def mock_requests(
     monkeypatch: Any, method: str, response_json: Any, status_code: int = 200
 ) -> None:

--- a/tests/unit/test_workitem_click.py
+++ b/tests/unit/test_workitem_click.py
@@ -33,6 +33,12 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def allow_workorder_service(monkeypatch: Any) -> None:
+    """Keep workitem command tests focused on command behavior, not feature probing."""
+    monkeypatch.setattr("slcli.platform._get_service_status", lambda _service: "ok")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a new `slcli dataframe` command group for DataFrame table discovery, schema inspection, querying, decimation, CSV export, append, and metadata lifecycle operations
- register the new command group and document it in the README and static commands site
- add a Towncrier fragment, proposal doc, and focused unit coverage for the new command surface
