### PR TITLE
Update website workflow skills section

### DIFF
--- a/newsfragments/139.doc.md
+++ b/newsfragments/139.doc.md
@@ -1,0 +1,1 @@
+Update website to include info about new skills

--- a/site/workflows.html
+++ b/site/workflows.html
@@ -84,7 +84,7 @@
             <h3>Install the skills</h3>
             <p>One command installs every bundled skill for the supported AI clients.</p>
             <pre><code># Install for all supported clients (most agents + Claude)
-slcli skill install --client all --scope personal</code></pre>
+slcli skill install --skill all --client all --scope personal</code></pre>
           </div>
         </div>
         <div class="step">
@@ -106,13 +106,13 @@ slcli skill install --client all --scope personal</code></pre>
             <h3>Project-scoped skills (optional)</h3>
             <p>Install per-repo for team consistency — the skill files are committed alongside your code.</p>
             <pre><code># Install into the current repo
-slcli skill install --client all --scope project</code></pre>
+slcli skill install --skill all --client all --scope project</code></pre>
           </div>
         </div>
       </div>
 
       <div class="highlight-box">
-        <p><strong>Tip:</strong> The skills follow the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills open standard</a>. Most clients discover them from <code>.agents/skills/</code>; Claude also supports <code>.claude/skills/</code>.</p>
+        <p><strong>Tip:</strong> The skills follow the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills open standard</a>. Personal installs go under <code>~/.agents/skills/</code> or <code>~/.claude/skills/</code>; project installs go under <code>.agents/skills/</code> or <code>.claude/skills/</code>.</p>
       </div>
 
       <!-- ═══════════════════════════════════════════════════════ -->

--- a/site/workflows.html
+++ b/site/workflows.html
@@ -63,12 +63,16 @@
 
       <!-- ═══════════════════════════════════════════════════════ -->
       <h1 id="ai-skills">Install AI Skills</h1>
-      <p>Two bundled skills give your AI assistant deep knowledge of SystemLink — one for CLI operations, one for building web applications.</p>
+      <p>Six bundled skills give your AI assistant current SystemLink domain knowledge across CLI operations, webapps, notebooks, test applications, packaging, and job debugging.</p>
 
       <table>
         <thead><tr><th>Skill</th><th>What it teaches</th></tr></thead>
         <tbody>
+          <tr><td><strong>nipkg-file-package</strong></td><td>How to build NI Package Manager file packages for Windows and SystemLink deployment, including target roots, control metadata, and common packaging pitfalls</td></tr>
           <tr><td><strong>slcli</strong></td><td>How to query and manage every SystemLink resource type using CLI commands</td></tr>
+          <tr><td><strong>systemlink-job-debugging</strong></td><td>How to debug SystemLink Salt jobs that are stuck, timing out, failing, or returning incomplete data</td></tr>
+          <tr><td><strong>systemlink-notebook</strong></td><td>How to create and deploy SystemLink Jupyter notebooks with parameter cells, <code>sb.glue</code> outputs, papermill metadata, and scheduled execution support</td></tr>
+          <tr><td><strong>systemlink-python-test</strong></td><td>How to build Python-based test applications that integrate with Test Monitor, work items, packaging, and deployment workflows</td></tr>
           <tr><td><strong>systemlink-webapp</strong></td><td>How to build Nimble Angular webapps with <code>@ni/nimble-angular</code>, <code>@ni/systemlink-clients-ts</code>, hash routing, CSP compliance, theme sync, and deployment via <code>slcli webapp publish</code></td></tr>
         </tbody>
       </table>
@@ -78,8 +82,8 @@
           <div class="step-num">1</div>
           <div class="step-body">
             <h3>Install the skills</h3>
-            <p>One command installs both skills for all supported AI clients.</p>
-            <pre><code># Install for all clients (Copilot, Claude, Codex)
+            <p>One command installs every bundled skill for the supported AI clients.</p>
+            <pre><code># Install for all supported clients (most agents + Claude)
 slcli skill install --client all --scope personal</code></pre>
           </div>
         </div>
@@ -91,6 +95,8 @@ slcli skill install --client all --scope personal</code></pre>
             <pre><code>"Show me all failed test results from this week"
 "Which assets need calibration?"
 "Build me a fleet health dashboard for SystemLink"
+"Create a SystemLink notebook that reports daily yield by station"
+"Debug this stuck state.apply job from the Jobs API"
 "Install the demo-complete-workflow example in the Training workspace"</code></pre>
           </div>
         </div>
@@ -100,13 +106,13 @@ slcli skill install --client all --scope personal</code></pre>
             <h3>Project-scoped skills (optional)</h3>
             <p>Install per-repo for team consistency — the skill files are committed alongside your code.</p>
             <pre><code># Install into the current repo
-slcli skill install --client copilot --scope project</code></pre>
+slcli skill install --client all --scope project</code></pre>
           </div>
         </div>
       </div>
 
       <div class="highlight-box">
-        <p><strong>Tip:</strong> The skills follow the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills open standard</a>. They work with any AI client that supports skill discovery.</p>
+        <p><strong>Tip:</strong> The skills follow the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills open standard</a>. Most clients discover them from <code>.agents/skills/</code>; Claude also supports <code>.claude/skills/</code>.</p>
       </div>
 
       <!-- ═══════════════════════════════════════════════════════ -->


### PR DESCRIPTION
## Summary
- update the workflows page to list the current bundled skills
- refresh the install copy to match the supported AI clients and project-scope example
- add notebook and job-debugging prompt examples and clarify skill discovery paths

## Validation
- checked editor errors for `site/workflows.html`