### PR TITLE
Tighten login and config validation

### DIFF
--- a/newsfragments/140.patch.md
+++ b/newsfragments/140.patch.md
@@ -1,0 +1,1 @@
+Harden login and config validation to reject malformed SystemLink URLs and API keys, and fail without saving unreachable or unauthorized profiles.

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -2,8 +2,10 @@
 
 import getpass
 import json
+import re
 import sys
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import click
 import questionary
@@ -17,6 +19,70 @@ from .profiles import ProfileConfig, Profile, check_config_file_permissions
 from .rich_output import render_table
 from .table_utils import output_formatted_list
 from .utils import ExitCodes
+
+EXAMPLE_API_KEY = "4LpbauiNA-UI9IhjqZoS4UeikZtExLK9Q_Q77d1bJd"
+API_KEY_LENGTH = len(EXAMPLE_API_KEY)
+API_KEY_PATTERN = re.compile(rf"^[A-Za-z0-9_-]{{{API_KEY_LENGTH}}}$")
+
+
+def _exit_with_validation_error(message: str, exit_code: int = ExitCodes.INVALID_INPUT) -> None:
+    """Exit the command with a consistent validation message."""
+    click.echo(f"✗ {message}", err=True)
+    sys.exit(exit_code)
+
+
+def _normalize_profile_name(profile: str) -> str:
+    """Normalize and validate a profile name."""
+    normalized = profile.strip()
+    if not normalized:
+        _exit_with_validation_error("Profile name cannot be empty.")
+    return normalized
+
+
+def _normalize_base_url(raw_url: str, label: str) -> str:
+    """Normalize and validate a SystemLink base URL."""
+    normalized = raw_url.strip()
+    if not normalized:
+        _exit_with_validation_error(f"{label} cannot be empty.")
+
+    if normalized.startswith("http://"):
+        click.echo("⚠️  Warning: Converting HTTP to HTTPS for security.")
+        normalized = normalized.replace("http://", "https://", 1)
+    elif "://" not in normalized:
+        click.echo(f"⚠️  Warning: Adding HTTPS protocol to {label.lower()}.")
+        normalized = f"https://{normalized}"
+
+    parsed = urlparse(normalized)
+    if parsed.scheme != "https":
+        _exit_with_validation_error(f"{label} must use HTTPS.")
+    if not parsed.hostname:
+        _exit_with_validation_error(f"{label} must include a valid host name.")
+    if parsed.path and parsed.path.strip("/"):
+        _exit_with_validation_error(
+            f"{label} must be a base URL without a path, query string, or fragment."
+        )
+    if parsed.params or parsed.query or parsed.fragment:
+        _exit_with_validation_error(
+            f"{label} must be a base URL without a path, query string, or fragment."
+        )
+
+    return normalized.rstrip("/")
+
+
+def _normalize_api_key(api_key: str) -> str:
+    """Normalize and validate an API key before probing the server."""
+    normalized = api_key.strip()
+    if not normalized:
+        _exit_with_validation_error("API key cannot be empty.")
+    if any(character.isspace() for character in normalized):
+        _exit_with_validation_error("API key must not contain spaces or line breaks.")
+    if not API_KEY_PATTERN.fullmatch(normalized):
+        _exit_with_validation_error(
+            f"API key must match the expected SystemLink format: {API_KEY_LENGTH} "
+            "URL-safe characters "
+            f"like {EXAMPLE_API_KEY}."
+        )
+    return normalized
 
 
 def _add_profile_impl(
@@ -46,93 +112,78 @@ def _add_profile_impl(
     if not profile:
         profile = click.prompt("Profile name", default="default")
     assert isinstance(profile, str)
+    profile = _normalize_profile_name(profile)
 
     # Get URL - either from flag or prompt
     if not url:
         click.echo("Example: https://api.my-systemlink.com")
         url = click.prompt("Enter your SystemLink API URL")
-    # Ensure url is a string now
     assert isinstance(url, str)
-    if not url.strip():
-        click.echo("SystemLink URL cannot be empty.")
-        raise click.ClickException("SystemLink URL cannot be empty.")
-
-    # Ensure URL uses HTTPS
-    url = url.strip()
-    if url.startswith("http://"):
-        click.echo("⚠️  Warning: Converting HTTP to HTTPS for security.")
-        url = url.replace("http://", "https://", 1)
-    elif not url.startswith("https://"):
-        click.echo("⚠️  Warning: Adding HTTPS protocol to URL.")
-        url = f"https://{url}"
-    url = url.rstrip("/")
+    url = _normalize_base_url(url, "SystemLink API URL")
 
     # Get API key - either from flag or prompt
     if not api_key:
         api_key = getpass.getpass("Enter your SystemLink API key: ")
-    # Ensure api_key is a string now
     assert isinstance(api_key, str)
-    if not api_key.strip():
-        click.echo("API key cannot be empty.")
-        raise click.ClickException("API key cannot be empty.")
+    api_key = _normalize_api_key(api_key)
 
     # Normalize and validate web_url (prompt if not provided)
     if not web_url:
         click.echo("Example: https://my-systemlink.com")
         web_url = click.prompt("Enter your SystemLink Web UI URL")
     assert isinstance(web_url, str)
-    web_url = web_url.strip()
-    if web_url.startswith("http://"):
-        click.echo("⚠️  Warning: Converting HTTP to HTTPS for security.")
-        web_url = web_url.replace("http://", "https://", 1)
-    elif not web_url.startswith("https://"):
-        click.echo("⚠️  Warning: Adding HTTPS protocol to web URL.")
-        web_url = f"https://{web_url}"
-    web_url = web_url.rstrip("/")
+    web_url = _normalize_base_url(web_url, "SystemLink Web UI URL")
 
     # Detect platform type and check service status
     click.echo("Checking server connectivity and services...")
-    status = check_service_status(url, api_key.strip())
+    status = check_service_status(url, api_key)
     platform = status["platform"]
 
     if not status["server_reachable"]:
-        click.echo("  ⚠️  Could not connect to server", err=True)
-        click.echo("      Verify the URL is correct and the server is reachable.", err=True)
-        click.echo(
-            "      Profile will be saved — run login again when the server is available.",
-            err=True,
+        _exit_with_validation_error(
+            "Could not connect to the SystemLink server. Verify the URL and network access. "
+            "Profile was not saved.",
+            ExitCodes.NETWORK_ERROR,
         )
+
+    if status["auth_valid"] is False:
+        _exit_with_validation_error(
+            "API key validation failed. The server responded, but the key was not authorized. "
+            "Profile was not saved.",
+            ExitCodes.PERMISSION_DENIED,
+        )
+
+    if status["auth_valid"] is not True:
+        _exit_with_validation_error(
+            "Connected to the server, but could not verify the API key against SystemLink "
+            "services. Profile was not saved.",
+            ExitCodes.GENERAL_ERROR,
+        )
+
+    click.echo("  Connection: ✓ Verified")
+    if platform == PLATFORM_SLE:
+        click.echo("  Platform: SystemLink Enterprise (Cloud)")
+    elif platform == PLATFORM_SLS:
+        click.echo("  Platform: SystemLink Server (On-Premises)")
     else:
-        if platform == PLATFORM_SLE:
-            click.echo("  Platform: SystemLink Enterprise (Cloud)")
-        elif platform == PLATFORM_SLS:
-            click.echo("  Platform: SystemLink Server (On-Premises)")
-        else:
-            click.echo("  Platform: Unknown (will attempt all features)")
+        click.echo("  Platform: Unknown (will attempt all features)")
 
-        # Report authorization status
-        if status["auth_valid"] is False:
-            click.echo("  ⚠️  API key: Unauthorized — check that the key is valid", err=True)
-        elif status["auth_valid"] is True:
-            click.echo("  API key:  ✓ Authorized")
+    click.echo("  API key:  ✓ Authorized")
 
-        if status.get("file_query_endpoint") == "query-files":
-            click.echo("  File query: query-files")
-        elif status.get("elasticsearch_available") is False:
-            click.echo("  File query: query-files-linq (Elasticsearch unavailable)")
-            click.echo(
-                "      'slcli file list' will fall back automatically; 'slcli file query' requires search-files."
-            )
+    if status.get("file_query_endpoint") == "query-files":
+        click.echo("  File query: query-files")
+    elif status.get("elasticsearch_available") is False:
+        click.echo("  File query: query-files-linq (Elasticsearch unavailable)")
+        click.echo(
+            "      'slcli file list' will fall back automatically; 'slcli file query' requires search-files."
+        )
 
-        # Report individual service status
-        services = status.get("services", {})
-        problem_services = [
-            name for name, svc_status in services.items() if svc_status == "unauthorized"
-        ]
-        if problem_services and status["auth_valid"] is not False:
-            # Only show per-service issues if overall auth isn't completely invalid
-            for svc_name in problem_services:
-                click.echo(f"  ⚠️  {svc_name}: unauthorized", err=True)
+    services = status.get("services", {})
+    problem_services = [
+        name for name, svc_status in services.items() if svc_status == "unauthorized"
+    ]
+    for svc_name in problem_services:
+        click.echo(f"  ⚠️  {svc_name}: unauthorized", err=True)
 
     # Get default workspace (optional)
     if workspace is None:
@@ -145,7 +196,7 @@ def _add_profile_impl(
     new_profile = Profile(
         name=profile,
         server=url,
-        api_key=api_key.strip(),
+        api_key=api_key,
         web_url=web_url,
         platform=platform,
         workspace=workspace,

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -20,8 +20,7 @@ from .rich_output import render_table
 from .table_utils import output_formatted_list
 from .utils import ExitCodes
 
-EXAMPLE_API_KEY = "4LpbauiNA-UI9IhjqZoS4UeikZtExLK9Q_Q77d1bJd"
-API_KEY_LENGTH = len(EXAMPLE_API_KEY)
+API_KEY_LENGTH = 42
 API_KEY_PATTERN = re.compile(rf"^[A-Za-z0-9_-]{{{API_KEY_LENGTH}}}$")
 
 
@@ -45,16 +44,13 @@ def _normalize_base_url(raw_url: str, label: str) -> str:
     if not normalized:
         _exit_with_validation_error(f"{label} cannot be empty.")
 
-    if normalized.startswith("http://"):
-        click.echo("⚠️  Warning: Converting HTTP to HTTPS for security.")
-        normalized = normalized.replace("http://", "https://", 1)
-    elif "://" not in normalized:
+    if "://" not in normalized:
         click.echo(f"⚠️  Warning: Adding HTTPS protocol to {label.lower()}.")
         normalized = f"https://{normalized}"
 
     parsed = urlparse(normalized)
-    if parsed.scheme != "https":
-        _exit_with_validation_error(f"{label} must use HTTPS.")
+    if parsed.scheme not in ("http", "https"):
+        _exit_with_validation_error(f"{label} must use HTTP or HTTPS.")
     if not parsed.hostname:
         _exit_with_validation_error(f"{label} must include a valid host name.")
     if parsed.path and parsed.path.strip("/"):
@@ -78,11 +74,15 @@ def _normalize_api_key(api_key: str) -> str:
         _exit_with_validation_error("API key must not contain spaces or line breaks.")
     if not API_KEY_PATTERN.fullmatch(normalized):
         _exit_with_validation_error(
-            f"API key must match the expected SystemLink format: {API_KEY_LENGTH} "
-            "URL-safe characters "
-            f"like {EXAMPLE_API_KEY}."
+            f"API key must be a {API_KEY_LENGTH}-character URL-safe token containing only "
+            "letters, digits, '-' and '_'."
         )
     return normalized
+
+
+def _all_service_probes_unauthorized(services: dict[str, str]) -> bool:
+    """Return True only when every recorded service probe failed with authorization."""
+    return bool(services) and all(status == "unauthorized" for status in services.values())
 
 
 def _add_profile_impl(
@@ -138,6 +138,7 @@ def _add_profile_impl(
     click.echo("Checking server connectivity and services...")
     status = check_service_status(url, api_key)
     platform = status["platform"]
+    services = status.get("services", {})
 
     if not status["server_reachable"]:
         _exit_with_validation_error(
@@ -146,7 +147,7 @@ def _add_profile_impl(
             ExitCodes.NETWORK_ERROR,
         )
 
-    if status["auth_valid"] is False:
+    if status["auth_valid"] is False and _all_service_probes_unauthorized(services):
         _exit_with_validation_error(
             "API key validation failed. The server responded, but the key was not authorized. "
             "Profile was not saved.",
@@ -155,8 +156,8 @@ def _add_profile_impl(
 
     if status["auth_valid"] is not True:
         _exit_with_validation_error(
-            "Connected to the server, but could not verify the API key against SystemLink "
-            "services. Profile was not saved.",
+            "Connected to the server, but profile verification was inconclusive. Check the "
+            "API URL, API key, and service availability. Profile was not saved.",
             ExitCodes.GENERAL_ERROR,
         )
 
@@ -178,7 +179,6 @@ def _add_profile_impl(
             "      'slcli file list' will fall back automatically; 'slcli file query' requires search-files."
         )
 
-    services = status.get("services", {})
     problem_services = [
         name for name, svc_status in services.items() if svc_status == "unauthorized"
     ]

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -8,6 +8,9 @@ import click
 from click.testing import CliRunner
 
 from slcli.config_click import register_config_commands
+from slcli.utils import ExitCodes
+
+VALID_API_KEY = "4LpbauiNA-UI9IhjqZoS4UeikZtExLK9Q_Q77d1bJd"
 
 
 def make_cli() -> click.Group:
@@ -354,10 +357,10 @@ class TestAddProfileTrailingSlash:
         monkeypatch.setattr(
             "slcli.config_click.check_service_status",
             lambda url, key: {
-                "server_reachable": False,
-                "platform": None,
-                "auth_valid": None,
-                "services": {},
+                "server_reachable": True,
+                "platform": "unknown",
+                "auth_valid": True,
+                "services": {"Auth": "ok"},
             },
         )
         monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
@@ -374,7 +377,7 @@ class TestAddProfileTrailingSlash:
                 "--url",
                 "https://api.example.com/",
                 "--api-key",
-                "test-key",
+                VALID_API_KEY,
                 "--web-url",
                 "https://web.example.com/",
             ],
@@ -396,10 +399,10 @@ class TestAddProfileTrailingSlash:
         monkeypatch.setattr(
             "slcli.config_click.check_service_status",
             lambda url, key: {
-                "server_reachable": False,
-                "platform": None,
-                "auth_valid": None,
-                "services": {},
+                "server_reachable": True,
+                "platform": "unknown",
+                "auth_valid": True,
+                "services": {"Auth": "ok"},
             },
         )
         monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
@@ -416,7 +419,7 @@ class TestAddProfileTrailingSlash:
                 "--url",
                 "https://api.example.com///",
                 "--api-key",
-                "test-key",
+                VALID_API_KEY,
                 "--web-url",
                 "https://web.example.com///",
             ],
@@ -428,3 +431,77 @@ class TestAddProfileTrailingSlash:
         profile = saved["profiles"]["test-multi-slash"]
         assert profile["server"] == "https://api.example.com"
         assert profile.get("web-url", "") == "https://web.example.com"
+
+    def test_config_add_rejects_unreachable_server(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """Test that config add fails instead of saving an unreachable server."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(
+            "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+        )
+        monkeypatch.setattr(
+            "slcli.config_click.check_service_status",
+            lambda url, key: {
+                "server_reachable": False,
+                "platform": "unreachable",
+                "auth_valid": None,
+                "services": {},
+            },
+        )
+
+        cli = make_cli()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                "add",
+                "--profile",
+                "offline",
+                "--url",
+                "https://offline.example.com",
+                "--api-key",
+                VALID_API_KEY,
+                "--web-url",
+                "https://web.example.com",
+            ],
+            input="\n",
+        )
+
+        assert result.exit_code == ExitCodes.NETWORK_ERROR
+        assert "Profile was not saved" in result.output
+        assert not config_file.exists()
+
+    def test_config_add_rejects_malformed_api_key(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """Test that config add rejects API keys that do not match the expected format."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(
+            "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+        )
+
+        def fail_if_called(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("check_service_status should not run for malformed API keys")
+
+        monkeypatch.setattr("slcli.config_click.check_service_status", fail_if_called)
+
+        cli = make_cli()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "config",
+                "add",
+                "--profile",
+                "bad-key",
+                "--url",
+                "https://example.test",
+                "--api-key",
+                "abc123",
+                "--web-url",
+                "https://web.example.test",
+            ],
+            input="\n",
+        )
+
+        assert result.exit_code == ExitCodes.INVALID_INPUT
+        assert "API key must match the expected SystemLink format" in result.output
+        assert not config_file.exists()

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import Any, Dict
 
 import click
+import pytest
 from click.testing import CliRunner
 
-from slcli.config_click import register_config_commands
+from slcli.config_click import _normalize_base_url, register_config_commands
 from slcli.utils import ExitCodes
 
 VALID_API_KEY = "4LpbauiNA-UI9IhjqZoS4UeikZtExLK9Q_Q77d1bJd"
@@ -503,5 +504,139 @@ class TestAddProfileTrailingSlash:
         )
 
         assert result.exit_code == ExitCodes.INVALID_INPUT
-        assert "API key must match the expected SystemLink format" in result.output
+        assert "API key must be a 42-character URL-safe token" in result.output
+        assert not config_file.exists()
+
+
+class TestAddProfileUrlValidation:
+    """Tests that config add rejects malformed URLs before probing the server."""
+
+    @pytest.mark.parametrize(
+        ("raw_url", "label", "expected_message"),
+        [
+            ("", "SystemLink API URL", "SystemLink API URL cannot be empty."),
+            (
+                "ftp://example.test",
+                "SystemLink API URL",
+                "SystemLink API URL must use HTTP or HTTPS.",
+            ),
+            (
+                "https://",
+                "SystemLink API URL",
+                "SystemLink API URL must include a valid host name.",
+            ),
+            (
+                "https://example.test/api",
+                "SystemLink API URL",
+                "SystemLink API URL must be a base URL without a path, query string, or fragment.",
+            ),
+            (
+                "https://web.example.test?foo=bar",
+                "SystemLink Web UI URL",
+                "SystemLink Web UI URL must be a base URL without a path, query string, or fragment.",
+            ),
+        ],
+    )
+    def test_normalize_base_url_rejects_invalid_values(
+        self,
+        raw_url: str,
+        label: str,
+        expected_message: str,
+        capsys: Any,
+    ) -> None:
+        """Test that malformed URLs are rejected with a clear validation error."""
+        with pytest.raises(SystemExit) as exc_info:
+            _normalize_base_url(raw_url, label)
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == ExitCodes.INVALID_INPUT
+        assert expected_message in captured.err
+
+    @pytest.mark.parametrize(
+        ("raw_url", "label", "expected_url", "expected_output"),
+        [
+            (
+                "http://example.test",
+                "SystemLink API URL",
+                "http://example.test",
+                "",
+            ),
+            (
+                "example.test",
+                "SystemLink API URL",
+                "https://example.test",
+                "Warning: Adding HTTPS protocol to systemlink api url.",
+            ),
+        ],
+    )
+    def test_normalize_base_url_normalizes_valid_shortcuts(
+        self, raw_url: str, label: str, expected_url: str, expected_output: str, capsys: Any
+    ) -> None:
+        """Test that HTTP and scheme-less URLs are normalized for convenience."""
+        normalized = _normalize_base_url(raw_url, label)
+
+        captured = capsys.readouterr()
+        assert normalized == expected_url
+        if expected_output:
+            assert expected_output in captured.out
+        else:
+            assert captured.out == ""
+
+    @pytest.mark.parametrize(
+        ("option_name", "url_value", "expected_message"),
+        [
+            ("--url", "ftp://example.test", "SystemLink API URL must use HTTP or HTTPS."),
+            ("--url", "https://", "SystemLink API URL must include a valid host name."),
+            (
+                "--url",
+                "https://example.test/api",
+                "SystemLink API URL must be a base URL without a path, query string, or fragment.",
+            ),
+            (
+                "--web-url",
+                "https://web.example.test?foo=bar",
+                "SystemLink Web UI URL must be a base URL without a path, query string, or fragment.",
+            ),
+        ],
+    )
+    def test_config_add_rejects_invalid_urls_before_connectivity_check(
+        self,
+        tmp_path: Path,
+        monkeypatch: Any,
+        option_name: str,
+        url_value: str,
+        expected_message: str,
+    ) -> None:
+        """Test that malformed URLs fail validation before any server probe occurs."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(
+            "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+        )
+
+        def fail_if_called(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("check_service_status should not run for malformed URLs")
+
+        monkeypatch.setattr("slcli.config_click.check_service_status", fail_if_called)
+
+        cli = make_cli()
+        runner = CliRunner()
+        args = [
+            "config",
+            "add",
+            "--profile",
+            "bad-url",
+            "--url",
+            "https://example.test",
+            "--api-key",
+            VALID_API_KEY,
+            "--web-url",
+            "https://web.example.test",
+        ]
+        option_index = args.index(option_name)
+        args[option_index + 1] = url_value
+
+        result = runner.invoke(cli, args, input="\n")
+
+        assert result.exit_code == ExitCodes.INVALID_INPUT
+        assert expected_message in result.output
         assert not config_file.exists()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -11,6 +11,8 @@ import slcli
 from slcli.main import cli, get_version
 from slcli.platform import PLATFORM_SLE
 
+VALID_API_KEY = "4LpbauiNA-UI9IhjqZoS4UeikZtExLK9Q_Q77d1bJd"
+
 
 def test_version_flag() -> None:
     """Test that --version flag works correctly."""
@@ -117,7 +119,7 @@ def test_login_with_flags(monkeypatch: Any, tmp_path: Any) -> None:
             "--url",
             "https://example.test",
             "--api-key",
-            "abc123",
+            VALID_API_KEY,
             "--web-url",
             "https://web.example.test",
         ],
@@ -126,9 +128,50 @@ def test_login_with_flags(monkeypatch: Any, tmp_path: Any) -> None:
 
     assert result.exit_code == 0, result.output
     assert "Profile 'test' saved successfully" in result.output
+    assert "Connection: ✓ Verified" in result.output
     assert "Platform: SystemLink Enterprise" in result.output
     # Verify config was written
     assert config_file.exists()
+
+
+def test_login_rejects_unauthorized_api_key(monkeypatch: Any, tmp_path: Any) -> None:
+    """Ensure login fails when the server rejects the API key."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    monkeypatch.setattr(
+        "slcli.config_click.check_service_status",
+        lambda *a, **kw: {
+            "server_reachable": True,
+            "auth_valid": False,
+            "services": {"Auth": "unauthorized"},
+            "platform": PLATFORM_SLE,
+        },
+    )
+    monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "login",
+            "--profile",
+            "test",
+            "--url",
+            "https://example.test",
+            "--api-key",
+            VALID_API_KEY,
+            "--web-url",
+            "https://web.example.test",
+        ],
+        input="\n\n",
+    )
+
+    assert result.exit_code != 0
+    assert "API key validation failed" in result.output
+    assert "Profile was not saved" in result.output
+    assert not config_file.exists()
 
 
 def test_login_reports_file_query_fallback(monkeypatch: Any, tmp_path: Any) -> None:
@@ -160,7 +203,7 @@ def test_login_reports_file_query_fallback(monkeypatch: Any, tmp_path: Any) -> N
             "--url",
             "https://example.test",
             "--api-key",
-            "abc123",
+            VALID_API_KEY,
             "--web-url",
             "https://web.example.test",
         ],
@@ -201,7 +244,7 @@ def test_login_reports_sls_query_files(monkeypatch: Any, tmp_path: Any) -> None:
             "--url",
             "https://example.test",
             "--api-key",
-            "abc123",
+            VALID_API_KEY,
             "--web-url",
             "https://web.example.test",
         ],

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -174,6 +174,86 @@ def test_login_rejects_unauthorized_api_key(monkeypatch: Any, tmp_path: Any) -> 
     assert not config_file.exists()
 
 
+def test_login_rejects_inconclusive_profile_verification(monkeypatch: Any, tmp_path: Any) -> None:
+    """Ensure login reports inconclusive verification for non-auth probe failures."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    monkeypatch.setattr(
+        "slcli.config_click.check_service_status",
+        lambda *a, **kw: {
+            "server_reachable": True,
+            "auth_valid": False,
+            "services": {"Auth": "unauthorized", "Comments": "not_found"},
+            "platform": PLATFORM_SLE,
+        },
+    )
+    monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "login",
+            "--profile",
+            "test",
+            "--url",
+            "https://example.test",
+            "--api-key",
+            VALID_API_KEY,
+            "--web-url",
+            "https://web.example.test",
+        ],
+        input="\n\n",
+    )
+
+    assert result.exit_code == 1
+    assert "profile verification was inconclusive" in result.output
+    assert "Profile was not saved" in result.output
+    assert not config_file.exists()
+
+
+def test_login_rejects_unknown_auth_verification_state(monkeypatch: Any, tmp_path: Any) -> None:
+    """Ensure login covers the fallback branch when auth verification returns None."""
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    monkeypatch.setattr(
+        "slcli.config_click.check_service_status",
+        lambda *a, **kw: {
+            "server_reachable": True,
+            "auth_valid": None,
+            "services": {"Auth": "error"},
+            "platform": PLATFORM_SLE,
+        },
+    )
+    monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "login",
+            "--profile",
+            "test",
+            "--url",
+            "https://example.test",
+            "--api-key",
+            VALID_API_KEY,
+            "--web-url",
+            "https://web.example.test",
+        ],
+        input="\n\n",
+    )
+
+    assert result.exit_code == 1
+    assert "profile verification was inconclusive" in result.output
+    assert "Profile was not saved" in result.output
+    assert not config_file.exists()
+
+
 def test_login_reports_file_query_fallback(monkeypatch: Any, tmp_path: Any) -> None:
     """Ensure login explains file query fallback when Elasticsearch is unavailable."""
     config_file = tmp_path / "config.json"


### PR DESCRIPTION
## Summary
- harden `slcli login` and `slcli config add` input validation for profile names, URLs, and API keys
- fail without saving a profile when the target server is unreachable or the API key is unauthorized
- add focused unit coverage for successful validation and malformed, unreachable, and unauthorized cases

## Testing
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest`

## Release Notes
- `patch`: tighten login/config validation and reject invalid or unverified profile setup
