### PR TITLE
Mitigate Snyk findings in editor and notebook flows

### DIFF
--- a/dff-editor/editor.js
+++ b/dff-editor/editor.js
@@ -651,9 +651,7 @@ function downloadConfiguration() {
         const a = document.createElement('a');
         a.href = url;
         a.download = 'dff-configuration.json';
-        document.body.appendChild(a);
         a.click();
-        document.body.removeChild(a);
         URL.revokeObjectURL(url);
         showStatus('Configuration downloaded', 'success');
     } catch (e) {
@@ -682,53 +680,130 @@ function refreshTree() {
     
     const config = currentConfig;
     if (!config) return;
-    
-    let html = '<div class="tree-node" onclick="selectTreeNode(\'root\')"><span class="tree-icon">📄</span><span>Root Configuration</span></div>';
-    
-    // Configurations
+
+    treeView.replaceChildren();
+    treeView.appendChild(createTreeNode({
+        nodeId: 'root',
+        icon: '📄',
+        label: 'Root Configuration'
+    }));
+
     if (config.configurations && config.configurations.length > 0) {
         config.configurations.forEach((conf, i) => {
             const confLabel = conf.displayText || conf.name || conf.key || ('Configuration ' + (i + 1));
-            html += `<div class="tree-node indent-1" onclick="selectTreeNode('config-${i}')"><span class="tree-icon">⚙️</span><span>${confLabel}</span><button class="edit-btn" aria-label="Edit configuration: ${confLabel}" title="Edit configuration" onclick="event.stopPropagation(); showEditDialog('configuration', ${i})">✎</button></div>`;
-            // Show views under each configuration
+            treeView.appendChild(createTreeNode({
+                nodeId: `config-${i}`,
+                icon: '⚙️',
+                label: confLabel,
+                indent: 1,
+                editLabel: `Edit configuration: ${confLabel}`,
+                editTitle: 'Edit configuration',
+                onEdit: () => showEditDialog('configuration', i)
+            }));
+
             if (conf.views && conf.views.length > 0) {
                 conf.views.forEach((view, vi) => {
-                    html += `<div class="tree-node indent-2" onclick="selectTreeNode('config-${i}-view-${vi}')"><span class="tree-icon">👁️</span><span>${view.displayText || view.key}</span><button class="edit-btn" aria-label="Edit view: ${view.displayText || view.key}" title="Edit view" onclick="event.stopPropagation(); showEditDialog('view', ${i}, ${vi})">✎</button></div>`;
+                    const viewLabel = view.displayText || view.key;
+                    treeView.appendChild(createTreeNode({
+                        nodeId: `config-${i}-view-${vi}`,
+                        icon: '👁️',
+                        label: viewLabel,
+                        indent: 2,
+                        editLabel: `Edit view: ${viewLabel}`,
+                        editTitle: 'Edit view',
+                        onEdit: () => showEditDialog('view', i, vi)
+                    }));
                 });
             }
         });
     }
-    
-    // Groups
+
     if (config.groups && config.groups.length > 0) {
-        html += '<div class="tree-node indent-1"><span class="tree-icon">📁</span><span>Groups (' + config.groups.length + ')</span></div>';
+        treeView.appendChild(createTreeSummaryNode('📁', `Groups (${config.groups.length})`, 1));
         config.groups.forEach((group, i) => {
             const groupLabel = group.displayText || group.key;
-            html += `<div class="tree-node indent-2" onclick="selectTreeNode('group-${i}')"><span class="tree-icon">📦</span><span>${groupLabel}</span><button class="edit-btn" aria-label="Edit group: ${groupLabel}" title="Edit group" onclick="event.stopPropagation(); showEditDialog('group', ${i})">✎</button></div>`;
+            treeView.appendChild(createTreeNode({
+                nodeId: `group-${i}`,
+                icon: '📦',
+                label: groupLabel,
+                indent: 2,
+                editLabel: `Edit group: ${groupLabel}`,
+                editTitle: 'Edit group',
+                onEdit: () => showEditDialog('group', i)
+            }));
         });
     }
-    
-    // Fields
+
     if (config.fields && config.fields.length > 0) {
-        html += '<div class="tree-node indent-1"><span class="tree-icon">📁</span><span>Fields (' + config.fields.length + ')</span></div>';
+        treeView.appendChild(createTreeSummaryNode('📁', `Fields (${config.fields.length})`, 1));
         config.fields.forEach((field, i) => {
             const icon = field.required ? '🏷️' : '🔖';
             const fieldLabel = field.displayText || field.key;
-            html += `<div class="tree-node indent-2" onclick="selectTreeNode('field-${i}')"><span class="tree-icon">${icon}</span><span>${fieldLabel}</span><button class="edit-btn" aria-label="Edit field: ${fieldLabel}" title="Edit field" onclick="event.stopPropagation(); showEditDialog('field', ${i})">✎</button></div>`;
+            treeView.appendChild(createTreeNode({
+                nodeId: `field-${i}`,
+                icon,
+                label: fieldLabel,
+                indent: 2,
+                editLabel: `Edit field: ${fieldLabel}`,
+                editTitle: 'Edit field',
+                onEdit: () => showEditDialog('field', i)
+            }));
         });
     }
-    
-    treeView.innerHTML = html;
 }
 
-function selectTreeNode(nodeId) {
+function createTreeSummaryNode(icon, label, indent = 0) {
+    const node = document.createElement('div');
+    node.className = 'tree-node';
+    if (indent > 0) {
+        node.classList.add(`indent-${indent}`);
+    }
+
+    const iconElement = document.createElement('span');
+    iconElement.className = 'tree-icon';
+    iconElement.textContent = icon;
+    node.appendChild(iconElement);
+
+    const labelElement = document.createElement('span');
+    labelElement.textContent = label;
+    node.appendChild(labelElement);
+
+    return node;
+}
+
+function createTreeNode({ nodeId, icon, label, indent = 0, editLabel = '', editTitle = '', onEdit = null }) {
+    const node = createTreeSummaryNode(icon, label, indent);
+    node.dataset.nodeId = nodeId;
+    node.addEventListener('click', () => selectTreeNode(nodeId, node));
+
+    if (onEdit) {
+        const editButton = document.createElement('button');
+        editButton.className = 'edit-btn';
+        editButton.type = 'button';
+        editButton.textContent = '✎';
+        editButton.setAttribute('aria-label', editLabel);
+        editButton.title = editTitle;
+        editButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            onEdit();
+        });
+        node.appendChild(editButton);
+    }
+
+    return node;
+}
+
+function selectTreeNode(nodeId, nodeElement = null) {
     selectedTreeNode = nodeId;
     
     // Update visual selection
     document.querySelectorAll('.tree-node').forEach(node => {
         node.classList.remove('selected');
     });
-    event.currentTarget.classList.add('selected');
+    const activeNode = nodeElement || document.querySelector(`[data-node-id="${nodeId}"]`);
+    if (activeNode) {
+        activeNode.classList.add('selected');
+    }
     
     // Highlight corresponding JSON in editor
     selectNodeInEditor(nodeId);

--- a/newsfragments/141.patch.md
+++ b/newsfragments/141.patch.md
@@ -1,0 +1,1 @@
+Harden custom field editor proxying and notebook download path handling.

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -51,6 +51,31 @@ PREDEFINED_NOTEBOOK_INTERFACES = [
     "Work Item Scheduler",
 ]
 
+WINDOWS_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+}
+
 
 def _get_safe_notebook_download_name(notebook_name: str, suffix: str) -> str:
     """Build a local filename from remote notebook metadata without honoring path segments."""
@@ -60,6 +85,8 @@ def _get_safe_notebook_download_name(notebook_name: str, suffix: str) -> str:
 
     stem = name_segment[:-6] if name_segment.lower().endswith(".ipynb") else name_segment
     safe_stem = re.sub(r"[^A-Za-z0-9._ -]+", "_", stem).strip(" ._") or "notebook"
+    if safe_stem.upper() in WINDOWS_RESERVED_FILENAMES:
+        safe_stem = f"{safe_stem}_file"
     normalized_suffix = suffix if suffix.startswith(".") else f".{suffix}"
 
     return f"{safe_stem}{normalized_suffix}"

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -6,6 +6,7 @@ All commands use Click for robust CLI interfaces and error handling.
 
 import datetime
 import json
+import re
 import sys
 import time
 import urllib.parse
@@ -49,6 +50,29 @@ PREDEFINED_NOTEBOOK_INTERFACES = [
     "Work Item Operations",
     "Work Item Scheduler",
 ]
+
+
+def _get_safe_notebook_download_name(notebook_name: str, suffix: str) -> str:
+    """Build a local filename from remote notebook metadata without honoring path segments."""
+    name_segment = notebook_name.replace("\\", "/").split("/")[-1].strip()
+    if name_segment in {"", ".", ".."}:
+        name_segment = "notebook"
+
+    stem = name_segment[:-6] if name_segment.lower().endswith(".ipynb") else name_segment
+    safe_stem = re.sub(r"[^A-Za-z0-9._ -]+", "_", stem).strip(" ._") or "notebook"
+    normalized_suffix = suffix if suffix.startswith(".") else f".{suffix}"
+
+    return f"{safe_stem}{normalized_suffix}"
+
+
+def _get_safe_notebook_download_path(notebook_name: str, suffix: str) -> Path:
+    """Build a safe local output path for remote-derived notebook filenames."""
+    safe_filename = _get_safe_notebook_download_name(notebook_name, suffix)
+    working_directory = Path.cwd().resolve()
+    output_path = (working_directory / safe_filename).resolve()
+    if output_path.parent != working_directory:
+        raise ValueError("Notebook download path must stay within the current working directory")
+    return output_path
 
 
 def _normalize_sls_notebook(notebook: Dict[str, Any]) -> None:
@@ -529,9 +553,10 @@ def _download_notebook_content_and_metadata(
     if download_type in ("content", "both"):
         try:
             content = _get_notebook_content_http(notebook_id)
-            output_path = output or (
-                notebook_name if notebook_name.endswith(".ipynb") else f"{notebook_name}.ipynb"
-            )
+            if output:
+                output_path = Path(output)
+            else:
+                output_path = _get_safe_notebook_download_path(notebook_name, ".ipynb")
             with open(output_path, "wb") as f:
                 f.write(content)
             click.echo(f"Notebook content downloaded to {output_path}")
@@ -543,14 +568,17 @@ def _download_notebook_content_and_metadata(
     if download_type in ("metadata", "both"):
         try:
             meta = _get_notebook_http(notebook_id)
-            meta_path = (output or notebook_name.replace(".ipynb", "")) + ".json"
+            if output:
+                meta_path = Path(f"{output}.json")
+            else:
+                meta_path = _get_safe_notebook_download_path(notebook_name, ".json")
 
             def _json_default(obj: Any) -> str:
                 if isinstance(obj, (datetime.datetime, datetime.date)):
                     return obj.isoformat()
                 return str(obj)
 
-            save_json_file(meta, meta_path, _json_default)
+            save_json_file(meta, str(meta_path), _json_default)
             click.echo(f"Notebook metadata downloaded to {meta_path}")
         except Exception as exc:
             click.echo(f"Failed to download notebook metadata: {exc}")

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -59,6 +59,116 @@ def _validated_proxy_path(request_path: str) -> str:
     return decoded_path
 
 
+def _validated_proxy_query_params(query: str) -> dict[str, list[str]]:
+    """Return parsed proxy query parameters."""
+    if not query:
+        return {}
+
+    try:
+        return urllib.parse.parse_qs(
+            query,
+            keep_blank_values=True,
+            strict_parsing=True,
+            separator="&",
+        )
+    except ValueError as exc:
+        raise ValueError("Editor proxy received an invalid query string") from exc
+
+
+def _validated_single_query_value(
+    query_params: dict[str, list[str]],
+    name: str,
+) -> str:
+    """Return a single query value and reject repeated parameters."""
+    values = query_params.get(name)
+    if not values:
+        raise ValueError(f"Editor proxy requires query parameter: {name}")
+    if len(values) != 1:
+        raise ValueError(f"Editor proxy rejects repeated query parameter: {name}")
+    return values[0]
+
+
+def _validated_integer_query_value(
+    query_params: dict[str, list[str]],
+    name: str,
+    *,
+    minimum: int,
+    maximum: Optional[int] = None,
+) -> str:
+    """Return a validated integer query value preserved as a string."""
+    raw_value = _validated_single_query_value(query_params, name)
+
+    try:
+        parsed_value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"Editor proxy requires an integer query parameter: {name}") from exc
+
+    if parsed_value < minimum or (maximum is not None and parsed_value > maximum):
+        raise ValueError(f"Editor proxy rejected out-of-range query parameter: {name}")
+
+    return str(parsed_value)
+
+
+def _validated_identifier_query_value(query_params: dict[str, list[str]], name: str) -> str:
+    """Return a single identifier-like query value safe for proxy forwarding."""
+    value = _validated_single_query_value(query_params, name)
+    if len(value) > 256:
+        raise ValueError(f"Editor proxy rejected oversized query parameter: {name}")
+    if any(ord(character) < 32 for character in value):
+        raise ValueError(f"Editor proxy rejected invalid query parameter: {name}")
+    if any(character in value for character in "/\\?#"):
+        raise ValueError(f"Editor proxy rejected invalid query parameter: {name}")
+    return value
+
+
+def _resolve_proxy_target(
+    method: str,
+    request_path: str,
+    query: str,
+) -> Optional[tuple[str, dict[str, str]]]:
+    """Resolve a frontend route to a fixed upstream path and validated params."""
+    query_params = _validated_proxy_query_params(query)
+
+    if method == "POST":
+        post_route_map = {
+            "/api/dff/configurations": "/nidynamicformfields/v1/configurations",
+            "/api/dff/update-configurations": "/nidynamicformfields/v1/update-configurations",
+            "/nidynamicformfields/v1/update-configurations": "/nidynamicformfields/v1/update-configurations",
+        }
+        target_path = post_route_map.get(request_path)
+        if target_path is None:
+            return None
+        if query_params:
+            raise ValueError("Editor proxy does not forward query parameters for this route")
+        return target_path, {}
+
+    if method == "GET" and request_path == "/niuser/v1/workspaces":
+        unexpected_params = set(query_params) - {"take", "skip"}
+        if unexpected_params:
+            raise ValueError("Editor proxy rejected unsupported workspace query parameters")
+
+        safe_params: dict[str, str] = {}
+        if "take" in query_params:
+            safe_params["take"] = _validated_integer_query_value(
+                query_params, "take", minimum=1, maximum=1000
+            )
+        if "skip" in query_params:
+            safe_params["skip"] = _validated_integer_query_value(query_params, "skip", minimum=0)
+        return "/niuser/v1/workspaces", safe_params
+
+    if method == "GET" and request_path == "/nidynamicformfields/v1/resolved-configuration":
+        unexpected_params = set(query_params) - {"configurationId"}
+        if unexpected_params:
+            raise ValueError(
+                "Editor proxy rejected unsupported resolved-configuration query parameters"
+            )
+        return "/nidynamicformfields/v1/resolved-configuration", {
+            "configurationId": _validated_identifier_query_value(query_params, "configurationId")
+        }
+
+    return None
+
+
 class DFFWebEditor:
     """Web-based editor for custom fields configurations."""
 
@@ -224,20 +334,16 @@ class DFFWebEditor:
                         self.send_error(404, "Config file not found")
                         return True
 
-                # Handle API proxying
-                path_map = {
-                    "/api/dff/configurations": "/nidynamicformfields/v1/configurations",
-                    "/api/dff/update-configurations": "/nidynamicformfields/v1/update-configurations",
-                }
+                try:
+                    resolved_target = _resolve_proxy_target(method, request_path, parsed.query)
+                except ValueError as exc:
+                    self.send_error(400, str(exc))
+                    return True
 
-                if request_path in path_map:
-                    target_path = path_map[request_path]
-                elif request_path.startswith("/nidynamicformfields/v1/"):
-                    target_path = request_path
-                elif request_path.startswith("/niuser/v1/workspaces"):
-                    target_path = request_path
-                else:
+                if resolved_target is None:
                     return False
+
+                target_path, target_params = resolved_target
 
                 # Require per-session secret on all proxied routes
                 req_secret = self.headers.get("X-Editor-Secret")
@@ -249,7 +355,6 @@ class DFFWebEditor:
                     origin_scheme=api_scheme,
                     origin_netloc=api_netloc,
                     target_path=target_path,
-                    query=parsed.query,
                 )
 
                 headers = dict(default_headers)
@@ -266,6 +371,7 @@ class DFFWebEditor:
                         url=target_url,
                         headers=headers,
                         data=data,
+                        params=target_params or None,
                         verify=ssl_verify,
                     )
                 except requests.RequestException as exc:  # pragma: no cover

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -43,10 +43,9 @@ def _build_proxy_url(
     origin_scheme: str,
     origin_netloc: str,
     target_path: str,
-    query: str = "",
 ) -> str:
     """Build a proxy URL from a validated origin and allowlisted path."""
-    return urllib.parse.urlunsplit((origin_scheme, origin_netloc, target_path, query, ""))
+    return urllib.parse.urlunsplit((origin_scheme, origin_netloc, target_path, "", ""))
 
 
 def _validated_proxy_path(request_path: str) -> str:

--- a/slcli/web_editor.py
+++ b/slcli/web_editor.py
@@ -111,6 +111,8 @@ def _validated_integer_query_value(
 def _validated_identifier_query_value(query_params: dict[str, list[str]], name: str) -> str:
     """Return a single identifier-like query value safe for proxy forwarding."""
     value = _validated_single_query_value(query_params, name)
+    if not value.strip():
+        raise ValueError(f"Editor proxy requires a non-empty query parameter: {name}")
     if len(value) > 256:
         raise ValueError(f"Editor proxy rejected oversized query parameter: {name}")
     if any(ord(character) < 32 for character in value):

--- a/tests/unit/test_notebook_click.py
+++ b/tests/unit/test_notebook_click.py
@@ -157,6 +157,10 @@ def test_safe_notebook_download_name_strips_remote_path_segments() -> None:
         slcli.notebook_click._get_safe_notebook_download_name("nested/remote.ipynb", ".json")
         == "remote.json"
     )
+    assert (
+        slcli.notebook_click._get_safe_notebook_download_name("CON", ".ipynb") == "CON_file.ipynb"
+    )
+    assert slcli.notebook_click._get_safe_notebook_download_name("nul", ".json") == "nul_file.json"
 
 
 def test_download_notebook_uses_sanitized_default_names(

--- a/tests/unit/test_notebook_click.py
+++ b/tests/unit/test_notebook_click.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 from typing import Any
 
 from click.testing import CliRunner
@@ -143,6 +144,45 @@ def test_notebook_download_by_id(monkeypatch: MonkeyPatch) -> None:
         with open(tmp.name, "rb") as f:
             assert f.read() == content
         os.unlink(tmp.name)
+
+
+def test_safe_notebook_download_name_strips_remote_path_segments() -> None:
+    import slcli.notebook_click
+
+    assert (
+        slcli.notebook_click._get_safe_notebook_download_name("../../etc/passwd", ".ipynb")
+        == "passwd.ipynb"
+    )
+    assert (
+        slcli.notebook_click._get_safe_notebook_download_name("nested/remote.ipynb", ".json")
+        == "remote.json"
+    )
+
+
+def test_download_notebook_uses_sanitized_default_names(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    import slcli.notebook_click
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        slcli.notebook_click, "_get_notebook_content_http", lambda notebook_id: b"nb"
+    )
+    monkeypatch.setattr(
+        slcli.notebook_click,
+        "_get_notebook_http",
+        lambda notebook_id: {"id": notebook_id, "name": "remote"},
+    )
+
+    slcli.notebook_click._download_notebook_content_and_metadata(
+        notebook_id="nb-1",
+        notebook_name="../../sneaky/notebook.ipynb",
+        output=None,
+        download_type="both",
+    )
+
+    assert (tmp_path / "notebook.ipynb").read_bytes() == b"nb"
+    assert (tmp_path / "notebook.json").exists()
 
 
 def test_notebook_upload(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_web_editor.py
+++ b/tests/unit/test_web_editor.py
@@ -160,6 +160,16 @@ def test_resolve_proxy_target_for_resolved_configuration() -> None:
     )
 
 
+def test_resolve_proxy_target_rejects_blank_configuration_id() -> None:
+    """Resolved configuration proxying should reject blank identifiers."""
+    with pytest.raises(ValueError, match="non-empty query parameter"):
+        _resolve_proxy_target(
+            "GET",
+            "/nidynamicformfields/v1/resolved-configuration",
+            "configurationId=",
+        )
+
+
 def test_resolve_proxy_target_rejects_unsupported_route() -> None:
     """Unsupported proxy routes should not resolve."""
     assert _resolve_proxy_target("GET", "/nidynamicformfields/v1/anything-else", "") is None

--- a/tests/unit/test_web_editor.py
+++ b/tests/unit/test_web_editor.py
@@ -101,13 +101,9 @@ def test_build_proxy_url_uses_validated_origin() -> None:
         origin_scheme=scheme,
         origin_netloc=netloc,
         target_path="/nidynamicformfields/v1/configurations",
-        query="take=25&skip=0",
     )
 
-    assert (
-        url
-        == "https://systemlink.example.test/nidynamicformfields/v1/configurations?take=25&skip=0"
-    )
+    assert url == "https://systemlink.example.test/nidynamicformfields/v1/configurations"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_web_editor.py
+++ b/tests/unit/test_web_editor.py
@@ -8,8 +8,10 @@ import pytest
 from slcli.web_editor import (
     DFFWebEditor,
     _build_proxy_url,
+    _resolve_proxy_target,
     _validated_proxy_origin,
     _validated_proxy_path,
+    _validated_proxy_query_params,
 )
 
 ESSENTIAL_FILES = ["index.html", "editor.js", "README.md"]
@@ -129,3 +131,45 @@ def test_validated_proxy_path_accepts_allowlisted_path() -> None:
         _validated_proxy_path("/nidynamicformfields/v1/configurations")
         == "/nidynamicformfields/v1/configurations"
     )
+
+
+def test_validated_proxy_query_params_parse_pairs() -> None:
+    """Proxy query validation should parse key-value pairs."""
+    assert _validated_proxy_query_params("take=25&skip=0") == {"take": ["25"], "skip": ["0"]}
+
+
+def test_validated_proxy_query_params_reject_malformed_query() -> None:
+    """Proxy query validation should reject malformed key-value input."""
+    with pytest.raises(ValueError, match="invalid query string"):
+        _validated_proxy_query_params("take=25&broken")
+
+
+def test_resolve_proxy_target_for_workspaces() -> None:
+    """Workspace proxying should resolve to a fixed path with validated params."""
+    assert _resolve_proxy_target("GET", "/niuser/v1/workspaces", "take=100&skip=0") == (
+        "/niuser/v1/workspaces",
+        {"take": "100", "skip": "0"},
+    )
+
+
+def test_resolve_proxy_target_for_resolved_configuration() -> None:
+    """Resolved configuration proxying should keep only the allowed ID parameter."""
+    assert _resolve_proxy_target(
+        "GET",
+        "/nidynamicformfields/v1/resolved-configuration",
+        "configurationId=cfg-123",
+    ) == (
+        "/nidynamicformfields/v1/resolved-configuration",
+        {"configurationId": "cfg-123"},
+    )
+
+
+def test_resolve_proxy_target_rejects_unsupported_route() -> None:
+    """Unsupported proxy routes should not resolve."""
+    assert _resolve_proxy_target("GET", "/nidynamicformfields/v1/anything-else", "") is None
+
+
+def test_resolve_proxy_target_rejects_unsupported_workspace_query_param() -> None:
+    """Workspace proxying should reject unexpected query parameters."""
+    with pytest.raises(ValueError, match="unsupported workspace query parameters"):
+        _resolve_proxy_target("GET", "/niuser/v1/workspaces", "admin=true")


### PR DESCRIPTION
## Summary
- harden the custom field editor proxy so it only resolves explicit frontend routes to fixed upstream paths with validated parameters
- sanitize remote-derived notebook download defaults and build them as cwd-anchored local paths
- replace tree HTML string rendering in the custom field editor with DOM construction and add focused regression tests

## Testing
- poetry run ni-python-styleguide lint
- poetry run mypy slcli tests
- poetry run pytest tests/unit/test_web_editor.py -q
- poetry run pytest tests/unit/test_notebook_click.py -q
- poetry run pytest

## Release Notes
- patch: harden custom field editor proxying and notebook download path handling