### PR TITLE
Refine top-level CLI help layout

### DIFF
--- a/newsfragments/142.misc.md
+++ b/newsfragments/142.misc.md
@@ -1,0 +1,1 @@
+Improve top-level slcli help grouping, description consistency, and panel alignment.

--- a/slcli/comment_click.py
+++ b/slcli/comment_click.py
@@ -188,7 +188,7 @@ def register_comment_commands(cli: Any) -> None:
     @cli.group()
     @click.pass_context
     def comment(ctx: click.Context) -> None:
-        """Manage comments on SystemLink resources.
+        """Manage SystemLink comments.
 
         Comments can be attached to any resource identified by a resource type
         and resource ID. Known resource types: testmonitor:Result, niapm:Asset,

--- a/slcli/completion_click.py
+++ b/slcli/completion_click.py
@@ -386,7 +386,7 @@ def register_completion_command(cli: Any) -> None:
         help="Install completion script to shell config file",
     )
     def completion(shell: Optional[str], install: bool) -> None:
-        """Generate and optionally install shell completion scripts.
+        """Generate shell completion scripts and optionally install them.
 
         Examples:
             # Generate bash completion script

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -225,7 +225,7 @@ def register_config_commands(cli: Any) -> None:
 
     @cli.group()
     def config() -> None:
-        """Manage slcli configuration and profiles.
+        """Manage slcli settings and profiles.
 
         Profiles allow you to configure multiple SystemLink environments
         (dev, test, prod) and switch between them easily.

--- a/slcli/dataframe_click.py
+++ b/slcli/dataframe_click.py
@@ -646,7 +646,7 @@ def register_dataframe_commands(cli: Any) -> None:
     @cli.group()
     @click.pass_context
     def dataframe(ctx: click.Context) -> None:
-        """Manage SystemLink DataFrame tables and row data."""
+        """Manage SystemLink DataFrame tables and rows."""
         if ctx.invoked_subcommand is not None:
             require_feature("dataframe_service")
 

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -312,7 +312,7 @@ def register_dff_commands(cli: Any) -> None:
     @cli.group(name="customfield")
     @click.pass_context
     def dff(ctx: click.Context) -> None:
-        """Manage custom field (DFF) configurations."""
+        """Manage SystemLink custom field configurations."""
         # Check for platform feature availability
         # Only check if a subcommand is being invoked (not just --help)
         if ctx.invoked_subcommand is not None:

--- a/slcli/example_click.py
+++ b/slcli/example_click.py
@@ -121,7 +121,7 @@ def register_example_commands(cli: Any) -> None:
 
     @cli.group()
     def example() -> None:
-        """Manage example resource configurations.
+        """Browse and provision example SystemLink resource configurations.
 
         Examples help you quickly set up demo systems for training,
         testing, or evaluation. Each example includes systems, assets,

--- a/slcli/feed_click.py
+++ b/slcli/feed_click.py
@@ -436,7 +436,7 @@ def register_feed_commands(cli: Any) -> None:
 
     @cli.group()
     def feed() -> None:
-        """Manage NI Package Manager feeds and their packages.
+        """Manage SystemLink package feeds and packages.
 
         Feeds are package repositories used by NI Package Manager to install
         software on test systems. Supports Windows (.nipkg) and NI Linux RT

--- a/slcli/file_click.py
+++ b/slcli/file_click.py
@@ -508,7 +508,7 @@ def register_file_commands(cli: Any) -> None:
 
     @cli.group()
     def file() -> None:
-        """Manage files in SystemLink File Service."""
+        """Manage SystemLink files."""
         pass
 
     @file.command(name="list")

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -49,6 +49,55 @@ else:
     click = rich_click_module
 
 
+def _configure_rich_click_command_groups() -> None:
+    """Configure top-level help command groups when rich-click is available."""
+    rich_click_config = getattr(click, "rich_click", None)
+    if rich_click_config is None:
+        return
+
+    # Keep the command-name/help split consistent across top-level panels so
+    # descriptions start at the same column in every group.
+    rich_click_config.STYLE_COMMANDS_TABLE_EXPAND = True
+    rich_click_config.STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO = (1, 5)
+
+    rich_click_config.COMMAND_GROUPS = {
+        "slcli": [
+            {
+                "name": "Configure",
+                "commands": ["config", "login", "logout", "info", "completion"],
+            },
+            {
+                "name": "Administer",
+                "commands": ["auth", "user", "workspace"],
+            },
+            {
+                "name": "Operate",
+                "commands": [
+                    "asset",
+                    "system",
+                    "state",
+                    "tag",
+                    "file",
+                    "feed",
+                    "comment",
+                    "dataframe",
+                ],
+            },
+            {
+                "name": "Build & Automate",
+                "commands": ["notebook", "routine", "webapp", "customfield", "skill", "mcp"],
+            },
+            {
+                "name": "Validate & Plan",
+                "commands": ["testmonitor", "template", "spec", "workitem", "example"],
+            },
+        ]
+    }
+
+
+_configure_rich_click_command_groups()
+
+
 def get_version() -> str:
     """Get version from _version.py (built binary) or pyproject.toml (development)."""
     try:
@@ -193,7 +242,7 @@ def login(
     set_current: bool,
     readonly: bool,
 ) -> None:
-    """Save SystemLink credentials to a profile.
+    """Create or update a SystemLink profile with credentials.
 
     This is an alias for 'slcli config add'. Use that command
     for the same functionality and more configuration options.
@@ -225,7 +274,7 @@ def login(
 @click.option("--all", "remove_all", is_flag=True, help="Remove all profiles")
 @click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
 def logout(profile: Optional[str], remove_all: bool, force: bool) -> None:
-    """Remove stored SystemLink credentials.
+    """Remove stored SystemLink profiles and credentials.
 
     By default, removes the current profile. Use --profile to remove a specific
     profile, or --all to remove all profiles.
@@ -309,7 +358,7 @@ def logout(profile: Optional[str], remove_all: bool, force: bool) -> None:
 @click.option("--format", "-f", type=click.Choice(["table", "json"]), default="table")
 @click.option("--skip-health", is_flag=True, default=False, help="Skip live service health checks.")
 def info(format: str, skip_health: bool) -> None:
-    """Show current configuration and detected platform."""
+    """Show the active profile, configuration, and platform status."""
     from .profiles import ProfileConfig, get_active_profile
 
     platform_info = get_platform_info(skip_health=skip_health)

--- a/slcli/mcp_click.py
+++ b/slcli/mcp_click.py
@@ -143,7 +143,7 @@ def register_mcp_commands(cli: Any) -> None:
 
     @cli.group()
     def mcp() -> None:
-        """MCP (Model Context Protocol) server integration for AI assistants."""
+        """Run and configure the SystemLink MCP server for AI assistants."""
 
     @mcp.command(name="serve")
     @click.option(

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -574,7 +574,7 @@ def register_notebook_commands(cli: Any) -> None:
 
     @cli.group()
     def notebook() -> None:  # pragma: no cover - Click wiring
-        """Manage notebooks (init locally, manage remotely, run)."""
+        """Create, run, and manage SystemLink notebooks."""
         pass
 
     # ------------------------------------------------------------------

--- a/slcli/policy_click.py
+++ b/slcli/policy_click.py
@@ -32,7 +32,7 @@ def register_policy_commands(cli: Any) -> None:
 
     @cli.group(name="auth")
     def auth() -> None:
-        """Manage SystemLink auth policies and policy templates."""
+        """Manage SystemLink authorization policies and policy templates."""
         pass
 
     @auth.group(name="policy")

--- a/slcli/routine_click.py
+++ b/slcli/routine_click.py
@@ -127,7 +127,7 @@ def register_routine_commands(cli: Any) -> None:
 
     @cli.group()
     def routine() -> None:
-        """Manage SystemLink routines (v1: notebook scheduling, v2: event-action)."""
+        """Manage SystemLink routines."""
         pass
 
     # ------------------------------------------------------------------

--- a/slcli/skill_click.py
+++ b/slcli/skill_click.py
@@ -200,7 +200,7 @@ def register_skill_commands(cli: Any) -> None:
 
     @cli.group()
     def skill() -> None:
-        """Manage AI agent skills for most agents and Claude."""
+        """Install and manage AI assistant skills."""
 
     @skill.command(name="install")
     @click.option(

--- a/slcli/spec_click.py
+++ b/slcli/spec_click.py
@@ -1263,7 +1263,7 @@ def register_spec_commands(cli: Any) -> None:
 
     @cli.group(name="spec")
     def spec() -> None:
-        """Manage specifications."""
+        """Manage SystemLink specifications."""
         pass
 
     # -- list ---------------------------------------------------------------

--- a/slcli/templates_click.py
+++ b/slcli/templates_click.py
@@ -120,7 +120,7 @@ def register_templates_commands(cli: Any) -> None:
     @cli.group()
     @click.pass_context
     def template(ctx: click.Context) -> None:
-        """Manage test plan templates."""
+        """Manage SystemLink test plan templates."""
         # Check for platform feature availability
         # Only check if a subcommand is being invoked (not just --help)
         if ctx.invoked_subcommand is not None:

--- a/slcli/testmonitor_click.py
+++ b/slcli/testmonitor_click.py
@@ -735,7 +735,7 @@ def register_testmonitor_commands(cli: Any) -> None:
 
     @cli.group()
     def testmonitor() -> None:
-        """Commands for test monitor products and results."""
+        """Manage SystemLink Test Monitor products and results."""
 
     @testmonitor.group()
     def product() -> None:

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -893,7 +893,7 @@ def register_webapp_commands(cli: Any) -> None:
 
     @cli.group()
     def webapp() -> None:  # pragma: no cover - Click wiring
-        """Manage web applications (init/pack locally, publish/CRUD remotely)."""
+        """Build, publish, and manage SystemLink web applications."""
 
     @webapp.command(name="init")
     @click.argument(

--- a/slcli/workitem_click.py
+++ b/slcli/workitem_click.py
@@ -431,7 +431,7 @@ def register_workitem_commands(cli: Any) -> None:
 
     @cli.group()
     def workitem() -> None:
-        """Manage work items, templates, and workflows."""
+        """Manage SystemLink work items, templates, and workflows."""
 
     # -----------------------------------------------------------------------
     # workitem list

--- a/slcli/workspace_click.py
+++ b/slcli/workspace_click.py
@@ -59,7 +59,7 @@ def register_workspace_commands(cli: Any) -> None:
 
     @cli.group()
     def workspace() -> None:
-        """Manage workspaces."""
+        """Manage SystemLink workspaces."""
         pass
 
     @workspace.command(name="list")

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -460,7 +460,7 @@ def test_dff_help_commands(runner: CliRunner, monkeypatch: Any) -> None:
     # Test main customfield help
     result = runner.invoke(cli, ["customfield", "--help"])
     assert result.exit_code == 0
-    assert "Manage custom field" in result.output
+    assert "Manage SystemLink custom field configurations" in result.output
 
 
 def test_dff_edit_command_help(runner: CliRunner, monkeypatch: Any) -> None:

--- a/tests/unit/test_example_click.py
+++ b/tests/unit/test_example_click.py
@@ -325,7 +325,7 @@ def test_example_group_help(runner: CliRunner) -> None:
     result = runner.invoke(cli, ["example", "--help"])
 
     assert result.exit_code == 0
-    assert "example resource configurations" in result.output.lower()
+    assert "example systemlink resource configurations" in result.output.lower()
 
 
 def test_install_example_resolves_workspace_and_outputs_table(

--- a/tests/unit/test_feature_gating.py
+++ b/tests/unit/test_feature_gating.py
@@ -60,7 +60,7 @@ class TestFeatureGatingDFF:
         result = runner.invoke(cli, ["customfield", "--help"])
 
         assert result.exit_code == 0
-        assert "Manage custom field (DFF) configurations" in result.output
+        assert "Manage SystemLink custom field configurations" in result.output
 
 
 class TestFeatureGatingTemplates:


### PR DESCRIPTION
## Summary
- group the top-level `slcli --help` commands into compact sections
- normalize visible top-level command descriptions for more consistent help text
- align the top-level help description column across command groups

## Testing
- `poetry run slcli --help`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- Added `newsfragments/142.misc.md` to cover the top-level CLI help grouping and layout updates