### PR TITLE
Refresh skill docs and move example to Configure

### DIFF
--- a/newsfragments/143.doc.md
+++ b/newsfragments/143.doc.md
@@ -1,0 +1,1 @@
+Enrich systemlink-notebook agent skill with Python client service-gap guidance and API ergonomics notes; move example command to Configure group.

--- a/site/style.css
+++ b/site/style.css
@@ -574,8 +574,8 @@ footer {
   content: '';
   position: absolute;
   left: 23px;
-  top: 40px;
-  bottom: 0;
+  top: 60px;
+  bottom: 10px;
   width: 2px;
   background: var(--border);
 }

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -64,7 +64,7 @@ def _configure_rich_click_command_groups() -> None:
         "slcli": [
             {
                 "name": "Configure",
-                "commands": ["config", "login", "logout", "info", "completion"],
+                "commands": ["config", "login", "logout", "info", "completion", "example"],
             },
             {
                 "name": "Administer",
@@ -89,7 +89,7 @@ def _configure_rich_click_command_groups() -> None:
             },
             {
                 "name": "Validate & Plan",
-                "commands": ["testmonitor", "template", "spec", "workitem", "example"],
+                "commands": ["testmonitor", "template", "spec", "workitem"],
             },
         ]
     }

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -24,6 +24,16 @@ compatibility: >-
 metadata:
   author: ni-kismet
   version: "2.0"
+---
+
+## Command style
+
+Prefer long option names in generated commands and examples. Use `--format json`,
+`--take 25`, `--workspace Default`, and `--output path.json` instead of `-f json`,
+`-t 25`, `-w Default`, or `-o path.json`.
+
+Only mention short aliases when explicitly documenting that they exist.
+
 #   --system SYSTEM_ID    Assign a system (by minion/system ID). Repeatable.
 #   --fixture ASSET_ID    Assign a fixture/slot (by asset ID, asset type FIXTURE). Repeatable.
 #   --dut ASSET_ID        Assign a DUT (by asset ID, asset type DEVICE_UNDER_TEST). Repeatable.
@@ -36,22 +46,22 @@ slcli workitem schedule <WORK_ITEM_ID> \
   [--system SYSTEM_ID]... [--fixture ASSET_ID]... [--dut ASSET_ID]...
 
 # Work item template subgroup
-slcli workitem template list [-w WORKSPACE] [--filter TEXT] [-t INT] [-f json]
-slcli workitem template get <TEMPLATE_ID> [-f json]
-slcli workitem template create --name TEXT --type TEXT --template-group TEXT [-w WORKSPACE] [OPTIONS]
+slcli workitem template list [--workspace WORKSPACE] [--filter TEXT] [--take INT] [--format json]
+slcli workitem template get <TEMPLATE_ID> [--format json]
+slcli workitem template create --name TEXT --type TEXT --template-group TEXT [--workspace WORKSPACE] [OPTIONS]
 slcli workitem template update <TEMPLATE_ID> [--name TEXT] [--description TEXT] [--summary TEXT]
 slcli workitem template delete <TEMPLATE_ID>... [--yes]
 
 # Workflow subgroup
-slcli workitem workflow list [-w WORKSPACE] [-t INT] [-f json]
-slcli workitem workflow get [--id WORKFLOW_ID] [--name NAME] [-f json]
+slcli workitem workflow list [--workspace WORKSPACE] [--take INT] [--format json]
+slcli workitem workflow get [--id WORKFLOW_ID] [--name NAME] [--format json]
 slcli workitem workflow init [--name TEXT] [--directory DIR]   # Scaffold a local workflow file
-slcli workitem workflow create --file PATH [-w WORKSPACE]      # Create from JSON file
-slcli workitem workflow import --file PATH [-w WORKSPACE]      # Import workflow from JSON
-slcli workitem workflow export [--id WORKFLOW_ID] [--name NAME] [-o FILE]  # Export to JSON
+slcli workitem workflow create --file PATH [--workspace WORKSPACE]      # Create from JSON file
+slcli workitem workflow import --file PATH [--workspace WORKSPACE]      # Import workflow from JSON
+slcli workitem workflow export [--id WORKFLOW_ID] [--name NAME] [--output FILE]  # Export to JSON
 slcli workitem workflow update --id WORKFLOW_ID --file PATH    # Update from JSON file
 slcli workitem workflow delete --id WORKFLOW_ID [--yes]
-slcli workitem workflow preview [--file PATH] [--id WORKFLOW_ID] [--html] [--no-open] [-o FILE]
+slcli workitem workflow preview [--file PATH] [--id WORKFLOW_ID] [--html] [--no-open] [--output FILE]
 ```
 
 **Create work item options:**
@@ -82,9 +92,9 @@ Scaffold, package, and publish custom web applications to SystemLink.
 ```bash
 slcli webapp init <DIRECTORY>                      # Scaffold the Angular starter
 slcli webapp manifest init <DIRECTORY> [OPTIONS]  # Create nipkg.config.json for packaging
-slcli webapp pack [FOLDER] [--config FILE] [-o OUTPUT_FILE]  # Package a webapp into a .nipkg
-slcli webapp list [-w WORKSPACE] [-t INT] [-f json]
-slcli webapp get <WEBAPP_ID> [-f json]
+slcli webapp pack [FOLDER] [--config FILE] [--output OUTPUT_FILE]  # Package a webapp into a .nipkg
+slcli webapp list [--workspace WORKSPACE] [--take INT] [--format json]
+slcli webapp get <WEBAPP_ID> [--format json]
 slcli webapp publish PATH [--workspace NAME]             # Upload and publish a webapp
 slcli webapp delete <WEBAPP_ID>
 slcli webapp open <WEBAPP_ID>                            # Open webapp URL in browser
@@ -95,19 +105,19 @@ slcli webapp open <WEBAPP_ID>                            # Open webapp URL in br
 Create, inspect, import, export, and revert saved software states managed by the SystemLink Systems State service.
 
 ```bash
-slcli state list [-w WORKSPACE] [--architecture CHOICE] [--distribution CHOICE] [-t INT] [-f json]
-slcli state get <STATE_ID> [-f json]
+slcli state list [--workspace WORKSPACE] [--architecture CHOICE] [--distribution CHOICE] [--take INT] [--format json]
+slcli state get <STATE_ID> [--format json]
 slcli state create --name TEXT --distribution CHOICE --architecture CHOICE [OPTIONS]
 slcli state update <STATE_ID> [OPTIONS]
 slcli state delete <STATE_ID> [--yes]
 
 slcli state import --name TEXT --distribution CHOICE --architecture CHOICE --file PATH [OPTIONS]
-slcli state replace-content <STATE_ID> --file PATH [--change-description TEXT] [-f json]
+slcli state replace-content <STATE_ID> --file PATH [--change-description TEXT] [--format json]
 slcli state export <STATE_ID> [--version VERSION] [--inline | --output FILE]
 slcli state capture <SYSTEM_ID> [--inline | --output FILE]
 
-slcli state history <STATE_ID> [-t INT] [-f json]
-slcli state version <STATE_ID> <VERSION> [-f json]
+slcli state history <STATE_ID> [--take INT] [--format json]
+slcli state version <STATE_ID> <VERSION> [--format json]
 slcli state revert <STATE_ID> <VERSION> [--yes]
 ```
 
@@ -148,7 +158,7 @@ Install pre-built demo configurations (systems, assets, DUTs, templates, etc.)
 for training, testing, or evaluation.
 
 ```bash
-slcli example list [-f json]                             # List available examples
+slcli example list [--format json]                       # List available examples
 slcli example info <EXAMPLE_ID>                          # Show example details
 slcli example install <EXAMPLE_ID> [--workspace NAME]    # Provision example resources
 slcli example delete <EXAMPLE_ID> [--workspace NAME]     # Remove provisioned resources
@@ -175,7 +185,7 @@ SystemLink Enterprise (SLE) or require a specific microservice to be deployed.
 
 ```bash
 slcli info                # Shows platform type and service health
-slcli info -f json        # Machine-readable; check .services for per-service status
+slcli info --format json # Machine-readable; check .services for per-service status
 ```
 
 | Command group                | Required service     | SLE | SLS | Notes                                   |
@@ -231,7 +241,7 @@ to disable caching for debugging.
 
 ## Key rules
 
-1. **Always use `-f json`** when piping output to `jq` or doing programmatic analysis.
+1. **Always use `--format json`** when piping output to `jq` or doing programmatic analysis.
 2. **Use `--summary --group-by`** for aggregation instead of fetching all records and counting.
 3. **Use convenience filters first** (e.g., `--status FAILED`), fall back to `--filter` for complex queries.
 4. **Parameterize `--filter` queries** — use `--substitution` instead of string interpolation.

--- a/slcli/skills/systemlink-notebook/SKILL.md
+++ b/slcli/skills/systemlink-notebook/SKILL.md
@@ -289,7 +289,11 @@ from nisystemlink.clients.assetmanagement import AssetManagementClient
 import requests
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-headers = {"x-ni-api-key": config.api_keys["x-ni-api-key"]}
+api_keys = getattr(config, "api_keys", {})
+api_key = api_keys.get("x-ni-api-key") if isinstance(api_keys, dict) else None
+if not api_key:
+  raise RuntimeError("Configure an x-ni-api-key before using REST fallbacks.")
+headers = {"x-ni-api-key": api_key}
 ```
 
 ### Available Python client services

--- a/slcli/skills/systemlink-notebook/SKILL.md
+++ b/slcli/skills/systemlink-notebook/SKILL.md
@@ -63,7 +63,7 @@ if response.created:
 
 ### Limited service coverage
 
-The Python client covers **~52% of available SystemLink services**. The most important gaps for notebooks:
+The Python client does **not cover all SystemLink services**. The most important gaps for notebooks (see the [client repo](https://github.com/ni/nisystemlink-clients-python) for the current full list):
 
 - ❌ **Notebook Execution** — no Python client for execution lifecycle management
 - ❌ **Routines v1/v2** — no Python client for scheduling/triggering
@@ -76,10 +76,15 @@ For these services, use REST calls directly via the `requests` library or System
 
 ### Public import paths
 
-Always import from the public top-level modules, not private `_module` paths:
+This skill uses two distinct Python SDK namespaces — be careful not to mix them:
+
+- **`nisystemlink.clients.*`** — the typed Python client (`nisystemlink-clients` package). Use public top-level imports.
+- **`systemlink.clients.nisysmgmt.*`** — a separate OpenAPI-generated SDK used only for Systems queries.
+
+For `nisystemlink.clients`, always import from the public top-level modules, not private `_module` paths:
 
 ```python
-# ✅ CORRECT: Public paths
+# ✅ CORRECT: Public paths (nisystemlink-clients)
 from nisystemlink.clients.file import FileClient
 from nisystemlink.clients.testmonitor import TestMonitorClient
 from nisystemlink.clients.testmonitor.models import CreateResultRequest, CreateStepRequest
@@ -87,6 +92,10 @@ from nisystemlink.clients.testmonitor.models import CreateResultRequest, CreateS
 # ❌ WRONG: Private module paths (may change or be removed)
 from nisystemlink.clients.testmonitor._test_monitor_client import TestMonitorClient
 from nisystemlink.clients.testmonitor.models._create_result_request import CreateResultRequest
+
+# Separate SDK — used only for Systems queries:
+from systemlink.clients.nisysmgmt.api.systems_api import SystemsApi
+from systemlink.clients.nisysmgmt.models.query_systems_request import QuerySystemsRequest
 ```
 
 ## Notebook Structure
@@ -280,7 +289,7 @@ from nisystemlink.clients.assetmanagement import AssetManagementClient
 import requests
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-headers = {"x-ni-api-key": config.api_keys[0]}
+headers = {"x-ni-api-key": config.api_keys["x-ni-api-key"]}
 ```
 
 ### Available Python client services

--- a/slcli/skills/systemlink-notebook/SKILL.md
+++ b/slcli/skills/systemlink-notebook/SKILL.md
@@ -20,6 +20,75 @@ argument-hint: 'Describe the notebook purpose and what data it should report on'
 - Creating a test data analysis notebook
 - Deploying a notebook to SystemLink via `slcli`
 
+## Important: Python Client Quirks
+
+The `nisystemlink-clients` Python package has a few ergonomics quirks to be aware of:
+
+### API naming inconsistency
+
+Client methods use Python `snake_case`, but request model fields use `camelCase`. This requires careful attention:
+
+```python
+# ❌ WRONG: Using Python snake_case (very intuitive but incorrect)
+CreateResultRequest(program_name="My Test", file_ids=[file_id])
+
+# ✅ CORRECT: Must use camelCase field names from the request model
+CreateResultRequest(programName="My Test", fileIds=[file_id])
+
+# Methods stay snake_case:
+client.create_results(request)  # This is correct
+client.create_steps(...)         # This is correct
+```
+
+Always check the request model constructor signature, not what "feels" Pythonic.
+
+### Partial-success responses
+
+Operations like `create_results()` and `create_steps()` return partial-success wrapper types
+(e.g., `CreateStepsPartialSuccess`) even when successful. These contain both success and failure data:
+
+```python
+from nisystemlink.clients.testmonitor import TestMonitorClient
+from nisystemlink.clients.testmonitor.models import CreateStepRequest
+
+client = TestMonitorClient()
+response = client.create_steps([CreateStepRequest(...)])
+
+# Success and failures are both in the response
+if response.failed:
+    print(f"Failed to create {len(response.failed)} steps")
+if response.created:
+    print(f"Successfully created {len(response.created)} steps")
+```
+
+### Limited service coverage
+
+The Python client covers **~52% of available SystemLink services**. The most important gaps for notebooks:
+
+- ❌ **Notebook Execution** — no Python client for execution lifecycle management
+- ❌ **Routines v1/v2** — no Python client for scheduling/triggering
+- ❌ **Systems State** — no Python client for system health queries
+- ❌ **Comments** — no Python client for resource annotations
+- ❌ **User Data** — no Python client for key-value stores
+- ❌ **Tag Historian** — no Python client for time-series history
+
+For these services, use REST calls directly via the `requests` library or SystemLink's OpenAPI SDKs.
+
+### Public import paths
+
+Always import from the public top-level modules, not private `_module` paths:
+
+```python
+# ✅ CORRECT: Public paths
+from nisystemlink.clients.file import FileClient
+from nisystemlink.clients.testmonitor import TestMonitorClient
+from nisystemlink.clients.testmonitor.models import CreateResultRequest, CreateStepRequest
+
+# ❌ WRONG: Private module paths (may change or be removed)
+from nisystemlink.clients.testmonitor._test_monitor_client import TestMonitorClient
+from nisystemlink.clients.testmonitor.models._create_result_request import CreateResultRequest
+```
+
 ## Notebook Structure
 
 Every SystemLink notebook follows this cell pattern:
@@ -199,33 +268,55 @@ import scrapbook as sb
 from systemlink.clients.nisysmgmt.api.systems_api import SystemsApi
 from systemlink.clients.nisysmgmt.models.query_systems_request import QuerySystemsRequest
 
-# Test results
+# Test results (remember: camelCase field names in request models)
 from nisystemlink.clients.testmonitor import TestMonitorClient
+from nisystemlink.clients.testmonitor.models import CreateResultRequest, CreateStepRequest
 from nisystemlink.clients.core import HttpConfigurationManager
 
 # Assets
 from nisystemlink.clients.assetmanagement import AssetManagementClient
 
-# Direct HTTP (when no typed client exists)
+# Direct HTTP (when no typed client exists or for missing services)
 import requests
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
 headers = {"x-ni-api-key": config.api_keys[0]}
 ```
 
+### Available Python client services
+
+The Python client covers these **15 main services**:
+- `alarm`, `artifact`, `assetmanagement`, `dataframe`, `feeds`, `file`, `notebook`,
+  `notification`, `product`, `spec`, `systems`, `tag`, `test_plan`, `testmonitor`, `work_item`
+
+### Missing services (use REST directly)
+
+If you need these services, call the REST API directly using `requests` and the OpenAPI docs:
+- **Notebook Execution** — execution lifecycle (use OpenAPI directly)
+- **Routines v1/v2** — scheduling/triggering (use OpenAPI directly)
+- **Systems State** — system health/connection status (use OpenAPI directly)
+- **Comments** — resource annotations (use OpenAPI directly)
+- **User Data** — key-value stores (use OpenAPI directly)
+- **Tag Historian** — time-series history (use OpenAPI directly)
+- **Auth**, **User**, and others — see full list in service-gaps documentation
+
 ## Client and API References
 
-- Prefer the official Python client libraries when they cover the target service:
+- **Python client repository** — full source and examples:
   https://github.com/ni/nisystemlink-clients-python
-- If a SystemLink service does not have a Python client yet, call the REST API
-  directly and use the hosted OpenAPI docs to discover endpoints and schemas:
+- **SystemLink OpenAPI docs** — for all services, including those without Python clients:
   https://demo-api.lifecyclesolutions.ni.com/niapis/
-- For notebook patterns and end-to-end examples, check the SystemLink Enterprise
-  examples repository:
+- **SystemLink Enterprise examples** — end-to-end patterns:
   https://github.com/ni/systemlink-enterprise-examples/
 
-When using direct HTTP, prefer the OpenAPI docs first to confirm the service base
-path, request body shape, and response schema before writing notebook code.
+When using the Python client:
+- Always check the request model constructor signature for camelCase field names (they won't match Python snake_case)
+- Expect `create_*` operations to return partial-success wrapper types; inspect `.created` and `.failed` attributes
+- Use public import paths from top-level modules, not private `_module` paths
+
+When a service lacks a Python client, use OpenAPI docs to discover the endpoint path,
+request body shape, and response schema before writing HTTP calls.
+
 ## Systems Query Pattern
 
 The `SystemsApi` uses a projection/filter pattern for querying:

--- a/slcli/skills/systemlink-notebook/references/interfaces.md
+++ b/slcli/skills/systemlink-notebook/references/interfaces.md
@@ -14,6 +14,17 @@ Prefer `create --interface ...` when you are creating a new notebook. Use
 `update --interface ...` for in-place interface changes on an existing notebook.
 Delete and re-create only if the server rejects the update.
 
+## Service Availability Note
+
+The Python client covers ~52% of SystemLink services. Key gaps that affect automation interfaces:
+
+- ❌ **Notebook Execution** — No Python client for checking execution status or logs
+- ❌ **Routines v1/v2** — No Python client for scheduling; use REST directly or `slcli routine` in scheduled shells
+- ❌ **Comments** — No Python client for adding resource annotations
+- ❌ **User** — No Python client for querying users/workspaces (use REST directly)
+
+For these services in notebooks, call the REST API directly via `requests` library and SystemLink's OpenAPI docs.
+
 ## Available Interfaces
 
 | Interface                    | Use Case                                                                                                                                                                                               |
@@ -56,7 +67,12 @@ Parameters typically include:
 ### Periodic Execution
 
 No special parameter requirements. Typically uses fixed configuration
-or reads from tags/files. Can be scheduled via routines:
+or reads from tags/files. Can be scheduled via routines (no Python client available).
+
+**Note:** The Python client does not have a Routines service. Use `slcli routine` to
+schedule notebooks, or call the Routines REST API directly.
+
+Create a scheduled routine via CLI:
 
 ```bash
 slcli routine create --api-version v1 \
@@ -64,6 +80,27 @@ slcli routine create --api-version v1 \
   --type SCHEDULED \
   --notebook-id <NOTEBOOK_ID> \
   --schedule '{"startTime":"2026-01-01T00:00:00Z","repeat":"DAY"}'
+```
+
+Or trigger via REST using `HttpConfigurationManager` and `requests`:
+
+```python
+import requests
+from nisystemlink.clients.core import HttpConfigurationManager
+
+config = HttpConfigurationManager.get_configuration()
+base_url = config.server_uri.rstrip("/")
+headers = {"x-ni-api-key": config.api_keys[0]}
+
+payload = {
+    "name": "Daily Report",
+    "type": "SCHEDULED",
+    "notebookId": "<NOTEBOOK_ID>",
+    "schedule": {"startTime":"2026-01-01T00:00:00Z", "repeat":"DAY"}
+}
+
+resp = requests.post(f"{base_url}/niapis/v1/routines", json=payload, headers=headers)
+resp.raise_for_status()
 ```
 
 ### Work Item Automations
@@ -80,3 +117,44 @@ Parameters are injected by the work item system:
 **Critical:** `work_item_ids` must be typed as `"string[]"` (not `"string"`),
 default to `[]` in both papermill and the code cell, and `systemlink.version`
 must be `1`. See the systemlink-notebook skill for the full metadata example.
+
+**Service note:** The Python client has `work_item` service for querying and updating
+work items, but does not have a `comments` service. If your automation needs to add
+comments or notes, call the Comments REST API directly via `requests` library.
+
+## Using REST When Python Clients Are Missing
+
+If a notebook needs a service without a Python client, use `requests` and the OpenAPI docs:
+
+```python
+import requests
+from nisystemlink.clients.core import HttpConfigurationManager
+
+config = HttpConfigurationManager.get_configuration()
+base_url = config.server_uri.rstrip("/")
+headers = {"x-ni-api-key": config.api_keys[0]}
+
+# Example: Add a comment to a work item (Comments service not available in Python)
+comment_payload = {
+    "resourceId": work_item_id,
+    "resourceType": "WorkItem",
+    "content": "Automated note from notebook"
+}
+
+resp = requests.post(
+    f"{base_url}/niapis/v1/comments",
+    json=comment_payload,
+    headers=headers
+)
+resp.raise_for_status()
+comment = resp.json()
+```
+
+Common missing services you might need:
+- **Comments** — `/niapis/v1/comments`
+- **Routines v1/v2** — `/niapis/v1/routines` or `/niapis/v2/routines`
+- **User** — `/niapis/v1/users`
+- **Systems State** — `/niapis/v1/systems-state`
+- **Tag Historian** — `/niapis/v1/tag-historian`
+
+Always check the OpenAPI docs to confirm the correct endpoint path and request schema before implementing REST calls.

--- a/slcli/skills/systemlink-notebook/references/interfaces.md
+++ b/slcli/skills/systemlink-notebook/references/interfaces.md
@@ -151,6 +151,7 @@ comment = resp.json()
 ```
 
 Common missing services you might need:
+
 - **Comments** — `/niapis/v1/comments`
 - **Routines v1/v2** — `/niapis/v1/routines` or `/niapis/v2/routines`
 - **User** — `/niapis/v1/users`

--- a/slcli/skills/systemlink-notebook/references/interfaces.md
+++ b/slcli/skills/systemlink-notebook/references/interfaces.md
@@ -16,14 +16,17 @@ Delete and re-create only if the server rejects the update.
 
 ## Service Availability Note
 
-The Python client covers ~52% of SystemLink services. Key gaps that affect automation interfaces:
+The Python client does not cover every SystemLink service. Key gaps that affect
+automation interfaces (see the `nisystemlink-clients` repository for the current
+service list):
 
 - ❌ **Notebook Execution** — No Python client for checking execution status or logs
 - ❌ **Routines v1/v2** — No Python client for scheduling; use REST directly or `slcli routine` in scheduled shells
 - ❌ **Comments** — No Python client for adding resource annotations
 - ❌ **User** — No Python client for querying users/workspaces (use REST directly)
 
-For these services in notebooks, call the REST API directly via `requests` library and SystemLink's OpenAPI docs.
+For these services in notebooks, call the REST API directly via the `requests`
+library and the service-specific SystemLink OpenAPI docs.
 
 ## Available Interfaces
 
@@ -90,7 +93,10 @@ from nisystemlink.clients.core import HttpConfigurationManager
 
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-api_key = config.api_keys["x-ni-api-key"]
+api_keys = getattr(config, "api_keys", {})
+api_key = api_keys.get("x-ni-api-key") if isinstance(api_keys, dict) else None
+if not api_key:
+    raise RuntimeError("Configure an x-ni-api-key before using REST fallbacks.")
 headers = {"x-ni-api-key": api_key}
 
 payload = {
@@ -100,7 +106,7 @@ payload = {
     "schedule": {"startTime": "<START_TIME_ISO8601>", "repeat": "DAY"}
 }
 
-resp = requests.post(f"{base_url}/niapis/v1/routines", json=payload, headers=headers)
+resp = requests.post(f"{base_url}/niroutine/v1/routines", json=payload, headers=headers)
 resp.raise_for_status()
 ```
 
@@ -133,7 +139,10 @@ from nisystemlink.clients.core import HttpConfigurationManager
 
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-api_key = config.api_keys["x-ni-api-key"]
+api_keys = getattr(config, "api_keys", {})
+api_key = api_keys.get("x-ni-api-key") if isinstance(api_keys, dict) else None
+if not api_key:
+    raise RuntimeError("Configure an x-ni-api-key before using REST fallbacks.")
 headers = {"x-ni-api-key": api_key}
 
 # Example: Add a comment to a work item (Comments service not available in Python)
@@ -144,7 +153,7 @@ comment_payload = {
 }
 
 resp = requests.post(
-    f"{base_url}/niapis/v1/comments",
+    f"{base_url}/nicomments/v1/comments",
     json=comment_payload,
     headers=headers
 )
@@ -154,10 +163,10 @@ comment = resp.json()
 
 Common missing services you might need:
 
-- **Comments** — `/niapis/v1/comments`
-- **Routines v1/v2** — `/niapis/v1/routines` or `/niapis/v2/routines`
-- **User** — `/niapis/v1/users`
-- **Systems State** — `/niapis/v1/systems-state`
-- **Tag Historian** — `/niapis/v1/tag-historian`
+- **Comments** — `/nicomments/v1/comments`
+- **Routines v1/v2** — `/niroutine/v1/routines` or `/niroutine/v2/routines`
+- **User** — `/niuser/v1/users` or `/niuser/v1/users/query`
+- **Systems State** — `/nisystemsstate/v1/states`
+- **Tag Historian** — check the service-specific OpenAPI docs instead of assuming `/niapis/...`
 
 Always check the OpenAPI docs to confirm the correct endpoint path and request schema before implementing REST calls.

--- a/slcli/skills/systemlink-notebook/references/interfaces.md
+++ b/slcli/skills/systemlink-notebook/references/interfaces.md
@@ -82,7 +82,7 @@ slcli routine create --api-version v1 \
   --schedule '{"startTime":"2026-01-01T00:00:00Z","repeat":"DAY"}'
 ```
 
-Or trigger via REST using `HttpConfigurationManager` and `requests`:
+Or create a scheduled routine via REST using `HttpConfigurationManager` and `requests`:
 
 ```python
 import requests
@@ -90,13 +90,14 @@ from nisystemlink.clients.core import HttpConfigurationManager
 
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-headers = {"x-ni-api-key": config.api_keys[0]}
+api_key = config.api_keys["x-ni-api-key"]
+headers = {"x-ni-api-key": api_key}
 
 payload = {
     "name": "Daily Report",
     "type": "SCHEDULED",
     "notebookId": "<NOTEBOOK_ID>",
-    "schedule": {"startTime":"2026-01-01T00:00:00Z", "repeat":"DAY"}
+    "schedule": {"startTime": "<START_TIME_ISO8601>", "repeat": "DAY"}
 }
 
 resp = requests.post(f"{base_url}/niapis/v1/routines", json=payload, headers=headers)
@@ -132,7 +133,8 @@ from nisystemlink.clients.core import HttpConfigurationManager
 
 config = HttpConfigurationManager.get_configuration()
 base_url = config.server_uri.rstrip("/")
-headers = {"x-ni-api-key": config.api_keys[0]}
+api_key = config.api_keys["x-ni-api-key"]
+headers = {"x-ni-api-key": api_key}
 
 # Example: Add a comment to a work item (Comments service not available in Python)
 comment_payload = {

--- a/slcli/skills/systemlink-notebook/references/notebook-patterns.md
+++ b/slcli/skills/systemlink-notebook/references/notebook-patterns.md
@@ -16,15 +16,19 @@ a `data_frame` output that the Systems Grid can display as a column.
 ### Full annotated example (Package Version)
 
 **Cell 1 — Imports description (markdown)**
+
 ```markdown
 ### Imports
+
 Import Python modules for executing the notebook.
- - Pandas is used for building and handling dataframes.
- - Scrapbook is used for recording data for the Notebook Execution Service.
- - SystemsApi is an NI provided package for communicating with the SystemLink Systems service.
+
+- Pandas is used for building and handling dataframes.
+- Scrapbook is used for recording data for the Notebook Execution Service.
+- SystemsApi is an NI provided package for communicating with the SystemLink Systems service.
 ```
 
 **Cell 2 — Imports (code)**
+
 ```python
 import re
 import pandas as pd
@@ -35,18 +39,21 @@ from systemlink.clients.nisysmgmt.models.query_systems_request import QuerySyste
 ```
 
 **Cell 3 — Parameters description (markdown)**
+
 ```markdown
 ### Parameters
- - `group_by`: The property by which data is grouped. For the data to appear
-   as a column in the Systems Grid, we must support 'System' here.
- - `package`: The Package Name of the software to display the version of.
- - `systems_filter`: A filter specifying which systems to query.
-   An empty filter matches all systems.
+
+- `group_by`: The property by which data is grouped. For the data to appear
+  as a column in the Systems Grid, we must support 'System' here.
+- `package`: The Package Name of the software to display the version of.
+- `systems_filter`: A filter specifying which systems to query.
+  An empty filter matches all systems.
 ```
 
 **Cell 4 — Parameters (code, with metadata)**
 
 The code cell declares variables with defaults:
+
 ```python
 group_by = "System"
 package = "ni-daqmx"
@@ -54,6 +61,7 @@ systems_filter = ""
 ```
 
 The cell metadata must include:
+
 ```json
 {
   "papermill": {
@@ -96,11 +104,13 @@ The cell metadata must include:
 ```
 
 **Cell 5 — Query description (markdown)**
+
 ```markdown
 ### Query for Systems with the specified package and get the Package Version
 ```
 
 **Cell 6 — Query (code)**
+
 ```python
 api = SystemsApi()
 
@@ -137,11 +147,13 @@ data = await query_result
 ```
 
 **Cell 7 — Dataframe description (markdown)**
+
 ```markdown
 ### Extract Package data from query results and create pandas dataframe
 ```
 
 **Cell 8 — Dataframe (code)**
+
 ```python
 pkg_version = { item['id'] : item['displayversion'] for item in data.data }
 df = pd.DataFrame.from_dict(pkg_version, orient='index', columns=['Package Version'])
@@ -149,11 +161,13 @@ df
 ```
 
 **Cell 9 — Output description (markdown)**
+
 ```markdown
 ### Convert dataframe to result format that the Systems Grid can interpret
 ```
 
 **Cell 10 — Output with sb.glue (code)**
+
 ```python
 df_dict = {
     'columns': ['minion id', 'package version'],
@@ -171,8 +185,10 @@ sb.glue('result', result)
 ```
 
 **Cell 11 — Usage instructions (markdown)**
+
 ```markdown
 ### View the output of this report in the Systems Grid
+
 1. Upload this notebook to the reports folder in SystemLink Jupyter
 2. From the Systems page, press the edit grid button
 3. Press '+ ADD' and select 'Notebook' as the data source
@@ -192,6 +208,7 @@ Constructor calls like `CreateResultRequest(programName="...", fileIds=[...])` a
 Using intuitive Python `snake_case` names will fail.
 
 **Parameters cell metadata:**
+
 ```json
 {
   "papermill": {
@@ -212,10 +229,22 @@ Using intuitive Python `snake_case` names will fail.
       }
     ],
     "parameters": [
-      {"display_name": "Group by", "id": "group_by", "type": "string"},
-      {"display_name": "Program Name", "id": "program_name", "type": "string"},
-      {"display_name": "Status Filter", "id": "status_filter", "type": "string"},
-      {"display_name": "Systems Filter", "id": "systems_filter", "type": "string"}
+      { "display_name": "Group by", "id": "group_by", "type": "string" },
+      {
+        "display_name": "Program Name",
+        "id": "program_name",
+        "type": "string"
+      },
+      {
+        "display_name": "Status Filter",
+        "id": "status_filter",
+        "type": "string"
+      },
+      {
+        "display_name": "Systems Filter",
+        "id": "systems_filter",
+        "type": "string"
+      }
     ],
     "version": 2
   },
@@ -224,6 +253,7 @@ Using intuitive Python `snake_case` names will fail.
 ```
 
 **Query pattern:**
+
 ```python
 from nisystemlink.clients.testmonitor import TestMonitorClient
 from nisystemlink.clients.core import HttpConfigurationManager
@@ -239,6 +269,7 @@ results = client.get_results(
 ```
 
 **Output pattern (same as Pattern 1):**
+
 ```python
 result = [{
     "display_name": "Test Summary",
@@ -259,6 +290,7 @@ sb.glue('result', result)
 When the notebook returns a single value instead of a table.
 
 **Output metadata:**
+
 ```json
 {
   "systemlink": {
@@ -274,6 +306,7 @@ When the notebook returns a single value instead of a table.
 ```
 
 **Output code:**
+
 ```python
 result = [{
     "display_name": "Total Count",

--- a/slcli/skills/systemlink-notebook/references/notebook-patterns.md
+++ b/slcli/skills/systemlink-notebook/references/notebook-patterns.md
@@ -2,6 +2,10 @@
 
 Annotated examples of common SystemLink notebook patterns.
 
+⚠️ **Important:** The Python client mixes Pythonic `snake_case` method names with `camelCase` request-model field names.
+See the main skill documentation for details on this quirk and other client ergonomics issues. Always verify the
+request model constructor signature before using — intuitive Python names will **not** work.
+
 ---
 
 ## Pattern 1: Systems Grid Column Report
@@ -182,6 +186,10 @@ sb.glue('result', result)
 ## Pattern 2: Test Data Analysis
 
 Query test results and return a summary. Uses `nisystemlink.clients.testmonitor`.
+
+**⚠️ API Quirk:** Request models in the TestMonitor client use camelCase field names.
+Constructor calls like `CreateResultRequest(programName="...", fileIds=[...])` are required.
+Using intuitive Python `snake_case` names will fail.
 
 **Parameters cell metadata:**
 ```json

--- a/slcli/skills/systemlink-webapp/SKILL.md
+++ b/slcli/skills/systemlink-webapp/SKILL.md
@@ -1,855 +1,188 @@
 ---
 name: systemlink-webapp
 description: >
-  Build, configure, and deploy custom web applications hosted inside NI SystemLink. Use this skill
-  whenever a user wants to create a frontend app that runs inside SystemLink (as a webapp), uses the
-  Nimble Angular design system (@ni/nimble-angular), calls any SystemLink REST API (tags, test
-  results, assets, systems, work items, etc.), or deploys a built web app to SystemLink with slcli.
-  Also use it when the user asks about using the @ni/systemlink-clients-ts TypeScript SDK, generating a
-  TypeScript API client from a SystemLink OpenAPI spec, troubleshooting CORS or CSP errors on a
-  SystemLink-hosted app, or configuring Angular routing for SystemLink's sub-path hosting.
+  Build, configure, troubleshoot, and deploy custom Angular web applications hosted inside NI SystemLink. Use this skill whenever a user wants a frontend app that runs inside SystemLink as a published webapp, uses @ni/nimble-angular, @ni/spright-angular, or @ni/ok-angular, calls SystemLink REST APIs or @ni/systemlink-clients-ts, needs SystemLink-specific Angular setup (hash routing, APP_BASE_HREF, CSP-safe builds, theme sync), or is packaging/publishing with slcli webapp commands. Also use it for troubleshooting hosted webapp issues like CORS/CSP errors, wrong SDK base URLs, theme-token problems, missing Angular wrapper modules, or iframe/sub-path routing failures.
 compatibility:
   models: [claude-sonnet-4-5, claude-opus-4, claude-3-7-sonnet]
-  tools: [run_in_terminal, create_file, replace_string_in_file, read_file]
+  tools: [read_file, run_in_terminal, apply_patch, create_file]
 ---
 
-# Building Custom WebApps for SystemLink
+# SystemLink WebApps
 
-SystemLink webapps are Angular Single-Page Applications built with the Nimble design system,
-connected to SystemLink REST APIs, and deployed via `slcli webapp publish`. This skill captures
-every gotcha learned from building and deploying real apps.
+SystemLink webapps are Angular SPAs hosted inside the SystemLink shell and iframe context. The main risks are not generic Angular problems; they are SystemLink-specific integration issues such as CSP, sub-path routing, theme token placement, Nimble wrapper usage, and service base URLs.
 
-If the user is starting from scratch, prefer `slcli webapp init <app-dir>` first.
-That command lays down the SystemLink starter layer (`.agents/skills/`, `PROMPTS.md`, and
-`START_HERE.md`) while Angular CLI remains responsible for generating the Angular workspace.
+Keep the main skill focused on workflow and decision points. Load reference files only when the current task needs that detail.
 
-When the user wants to package the app for Plugin Manager submission, prefer
-`slcli webapp manifest init <app-dir> ...` to generate `nipkg.config.json`
-with the current Plugin Manager field names, then use `slcli webapp pack --config ...`
-to build the `.nipkg` and generate the thin `manifest.json` with the artifact SHA-256.
+## Progressive loading
 
----
+Start here and read no more than one or two reference files until the task is blocked by missing detail.
 
-## Step 1: Understand what the user needs
+| Need | Read |
+| --- | --- |
+| Concise component inventory across Nimble, Spright, and OK Angular | [references/angular-ui-packages.md](./references/angular-ui-packages.md) |
+| Nimble Angular modules, wrapper usage, table/dialog/tab patterns | [references/nimble-angular.md](./references/nimble-angular.md) |
+| Page layout, spacing, split panes, drawers, accordions | [references/layout-patterns.md](./references/layout-patterns.md) |
+| SystemLink SDK base URLs, auth modes, LINQ query patterns | [references/systemlink-services.md](./references/systemlink-services.md) |
+| Build, publish, Plugin Manager packaging commands | [references/deployment.md](./references/deployment.md) |
+| Hosted validation, console triage, theme checks, recurring failures | [references/troubleshooting.md](./references/troubleshooting.md) |
 
-Ask before generating any code:
+If the user only wants planning or a first implementation slice, stay in this file.
 
-1. **Goal** — What should the app show or let the user do? (e.g., "browse live tag values", "review test results", "approve work orders")
-2. **Services** — Which SystemLink services will it call? (tags, test monitor, asset management, systems, work items, feeds, notebooks…)
-3. **Starting point** — Fresh Angular project, or do they have existing code?
-4. **Auth context** — Will the app run on the same SystemLink instance it calls (same-origin cookie auth), or does it need an API key for a remote server?
+## First response checklist
 
-You do NOT need to ask about Angular version or Nimble versions — always use Angular 20 and the latest compatible `@ni/nimble-angular`.
+Before generating code, clarify only the details that change the implementation:
 
----
+1. Goal: what the app should show or let the user do.
+2. Services: which SystemLink resources it must read or mutate.
+3. Starting point: new app, `slcli webapp init` starter, or existing Angular codebase.
+4. Auth context: same-origin hosted app versus remote/dev API-key flow.
+5. Deployment target: ordinary hosted webapp only, or Plugin Manager package as well.
 
-## Step 2: Bootstrap the Angular workspace
+Do not ask about Angular or Nimble versions unless the user is constrained by an existing project. Default to Angular 20 and the latest compatible `@ni/nimble-angular`.
 
-When the project was created with `slcli webapp init`, generate Angular in the existing starter
-directory so the starter files and bundled skills remain at the project root.
+For new SystemLink apps, recommend installing the NI Angular UI packages together unless the user is intentionally minimizing dependencies. `@ni/nimble-angular` remains the default foundation, `@ni/spright-angular` adds Spright chat and icon components, and `@ni/ok-angular` adds OK-specific controls such as accordion items and search input.
+
+## Recommended workflow
+
+### 1. Bootstrap the right project shape
+
+For a new SystemLink app, prefer:
+
+```bash
+slcli webapp init <app-dir>
+```
+
+Then generate Angular in that starter directory so the SystemLink scaffolding stays at the project root:
 
 ```bash
 npx -y @angular/cli@20 new <app-name> --directory . --routing --style=scss --skip-git --no-standalone --defaults --force
-npm install @ni/nimble-angular
+npm install @ni/nimble-angular @ni/spright-angular @ni/ok-angular @ni/systemlink-clients-ts
 ```
 
-> Use `--no-standalone` to generate an NgModule-based app. SystemLink webapps work best with
-> NgModule because it makes it easy to register all Nimble modules in one place.
+Prefer NgModule-based apps for this workflow. The Nimble Angular wrapper modules fit naturally into a centralized `AppModule`, which reduces template surprises and keeps imports explicit.
 
-If the user has not run `slcli webapp init` yet and they want a new SystemLink webapp, tell them
-to do that first unless they explicitly want a manual setup.
+Recommend installing `@ni/spright-angular` and `@ni/ok-angular` early even if the first slice only uses Nimble. That avoids dependency churn later when the UI needs chat surfaces, product-specific icons, accordion items, or the OK search input.
 
-### Starter shell expectations
+If the user has not run `slcli webapp init` and explicitly wants a SystemLink-hosted webapp, recommend it first unless they want a manual setup.
 
-Before building feature-specific pages, establish a reusable shell that is aligned with other
-SystemLink apps:
-
-- Root `nimble-theme-provider` that mirrors the host shell theme
-- Responsive page header with title, summary text, and an action area
-- Shared loading, error, and empty states instead of one-off page-specific handling
-- Route-backed top-level navigation only when the app truly has multiple views
-- Reusable API helpers and service-layer code rather than fetch logic embedded in templates
-
-Use Nimble layout tokens and spacing rules consistently across the shell and feature pages:
-
-- Prefer Nimble spacing tokens over ad-hoc pixel values: `smallPadding` for tight inline gaps,
-  `mediumPadding` for default control spacing, `standardPadding` for section padding, and
-  `largePadding` between major content regions.
-- Stack controls vertically with a column layout, `mediumPadding` gap, and `standardPadding`
-  around the control group.
-- Use `mediumPadding` or `standardPadding` gaps for side-by-side controls; prefer CSS grid for
-  aligned multi-column layouts.
-- Inside accordion panels, keep a column layout with `mediumPadding` gaps and
-  `standardPadding` bottom padding.
-- In dense side panels with tabs, use `15px 30px 30px 15px` on the tab container,
-  `20px 0 0 15px` on the active tab panel, let the panel own scrolling, and avoid forcing nested
-  content blocks to `height: 100%`.
-- Treat `controlHeight` (32px), `controlSlimHeight` (24px), and `labelHeight` (16px) as the
-  baseline sizing tokens for controls and labels.
-- Separate major sections with `largePadding` and subsections with `standardPadding`.
-
-See [references/layout-patterns.md](references/layout-patterns.md) for the detailed layout guide.
-
----
-
-## Step 3: Add the SystemLink TypeScript SDK
-
-**Always use [@ni/systemlink-clients-ts](https://github.com/ni-kismet/nisystemlink-clients-ts) as the first choice** for any SystemLink API call. It ships pre-built, typed SDKs for every major SystemLink service (tags, test monitor, file ingestion, asset management, work items, etc.) so you don't need to generate anything.
-
-### Install
-
-```bash
-npm install @ni/systemlink-clients-ts
-```
-
-### Available services (import paths)
-
-| Service | Import path | Client `baseUrl` |
-|---------|-------------|------------------|
-| Feeds | `@ni/systemlink-clients-ts/feeds` | `window.location.origin` |
-| Tags | `@ni/systemlink-clients-ts/tags` | `window.location.origin + '/nitag'` |
-| User / Workspaces | `@ni/systemlink-clients-ts/user` | `window.location.origin + '/niuser/v1'` |
-| Web Application | `@ni/systemlink-clients-ts/web-application` | `window.location.origin + '/niapp/v1'` |
-| File Ingestion | `@ni/systemlink-clients-ts/file-ingestion` | `window.location.origin + '/nifile'` |
-| Test Monitor | `@ni/systemlink-clients-ts/test-monitor` | `window.location.origin + '/nitestmonitor'` |
-| Asset Management | `@ni/systemlink-clients-ts/asset-management` | `window.location.origin` |
-| Work Items | `@ni/systemlink-clients-ts/work-item` | `window.location.origin` |
-| Work Orders | `@ni/systemlink-clients-ts/work-order` | `window.location.origin` |
-| Systems Management | `@ni/systemlink-clients-ts/systems-management` | `window.location.origin` |
-| Notebooks | `@ni/systemlink-clients-ts/notebook` | `window.location.origin` |
-
-The client factory for each service lives at `@ni/systemlink-clients-ts/<service>/client`.
-
-> **Base URL gotcha:** Verify the generated operation URLs, not just the service name. In the published `@ni/systemlink-clients-ts` package, `tags` uses `/v2/...` with `baseUrl: origin + '/nitag'`, `user` uses `/users` and `/workspaces` with `baseUrl: origin + '/niuser/v1'`, `web-application` uses `/webapps/...` with `baseUrl: origin + '/niapp/v1'`, `file-ingestion` uses `/v1/...` with `baseUrl: origin + '/nifile'`, and `test-monitor` uses `/v2/...` with `baseUrl: origin + '/nitestmonitor'`. Services like `feeds`, `asset-management`, `systems-management`, `work-item`, `work-order`, and `notebook` already include `/nifeed`, `/niapm`, `/nisysmgmt`, `/niworkitem`, `/niworkorder`, or `/ninotebook` in each operation path, so those clients should use `baseUrl: window.location.origin`.
-
-> **SDK type mismatch fallback:** If a generated SDK function causes `InputFieldValidationError`, verify the actual request body the server expects with a raw `curl` POST. Sometimes the generated types wrap the body in a `{ request: { ... } }` envelope that the server does not accept (or expect a flat body the type shows as nested). Use direct `fetch` with a manually constructed body as a reliable fallback when the SDK types are wrong.
-
-### Fallback: generate a custom SDK
-
-Only generate a new SDK if the required service is **not** in `@ni/systemlink-clients-ts`. Use [hey-api/openapi-ts](https://github.com/hey-api/openapi-ts):
-
-```bash
-npm install -D @hey-api/openapi-ts
-```
-
-```typescript
-// openapi-ts.config.ts
-import { defineConfig } from '@hey-api/openapi-ts';
-
-export default defineConfig({
-  input: 'https://<server>/swagger/v2/<service>.yaml',
-  output: { path: 'src/app/api', format: 'prettier' },
-  plugins: ['@hey-api/typescript', { name: '@hey-api/sdk' }],
-});
-```
-
-```bash
-npx openapi-ts
-```
-
----
-
-## Step 4: Wire up AppModule
-
-```typescript
-// src/app/app.module.ts
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
-import { APP_BASE_HREF } from '@angular/common';
-
-// Most Nimble component modules are exported from the main `@ni/nimble-angular` barrel.
-// Icon modules (e.g. NimbleIconMagnifyingGlassModule) are ONLY in the main barrel —
-// sub-paths like `@ni/nimble-angular/icons/magnifying-glass` do NOT exist.
-// Do NOT add `@ni/nimble-components` or register raw custom elements just to make
-// Angular templates compile. If a Nimble element is unknown, import the missing
-// Angular module from `@ni/nimble-angular` instead.
-import {
-  NimbleThemeProviderModule,
-  NimbleButtonModule,
-  NimbleAnchorButtonModule,
-  NimbleAnchorTabsModule,
-  NimbleAnchorTabModule,
-  NimbleTextFieldModule,
-  NimbleSelectModule,
-  NimbleListOptionModule,
-  NimbleDrawerModule,
-  NimbleDialogModule,
-  NimbleSpinnerModule,
-  NimbleBannerModule,
-  NimbleTableModule,
-  NimbleTableColumnTextModule,
-  NimbleIconMagnifyingGlassModule,  // icons always from main barrel
-} from '@ni/nimble-angular';
-// Label providers and Card have dedicated sub-path exports
-import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
-import { NimbleCardModule } from '@ni/nimble-angular/card';
-
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
-import { MyFeatureComponent } from './my-feature/my-feature.component';
-
-@NgModule({
-  declarations: [AppComponent, MyFeatureComponent],
-  imports: [
-    BrowserModule,
-    FormsModule,
-    AppRoutingModule,
-    NimbleThemeProviderModule,
-    NimbleLabelProviderCoreModule,
-    NimbleTableModule,
-    NimbleTableColumnTextModule,
-    NimbleButtonModule,
-    NimbleTextFieldModule,
-    NimbleSelectModule,
-    NimbleListOptionModule,
-    NimbleDrawerModule,
-    NimbleSpinnerModule,
-    NimbleBannerModule,
-  ],
-  providers: [
-    { provide: APP_BASE_HREF, useValue: '/' },   // ← REQUIRED — do not use a <base> tag
-  ],
-  // Note: do NOT add provideHttpClient() — @ni/systemlink-clients-ts uses the native fetch API,
-  // not Angular's HttpClient. No HTTP DI wiring is needed.
-  bootstrap: [AppComponent],
-})
-export class AppModule {}
-```
-
-When using `@ni/nimble-angular`, prefer the Angular wrappers end-to-end:
-
-- Do **not** add `@ni/nimble-components` as a direct dependency just to register icons or other raw custom elements.
-- Do **not** use `CUSTOM_ELEMENTS_SCHEMA` as a workaround for unknown Nimble elements. In this codebase that is usually a sign that the corresponding Nimble Angular module import is missing, and `CUSTOM_ELEMENTS_SCHEMA` suppresses valuable template checking.
-- If Angular reports an unknown Nimble tag, fix the module imports first.
-
-For Nimble form controls (`nimble-text-field`, `nimble-select`, etc.), bind with Angular forms APIs (`[(ngModel)]`, `[formControl]`, or `formControlName`) and use `(ngModelChange)` for value-change reactions. Avoid native control bindings like `[value]`, `(input)`, or `(change)` on Nimble elements.
-
-For control labels, prefer Nimble's built-in label pattern by slotting text content inside the control instead of pairing the control with a separate HTML `<label>` element for the primary label:
-
-```html
-<nimble-select [(ngModel)]="selectedWorkspace">
-  Workspace
-  <nimble-list-option *ngFor="let ws of workspaces" [value]="ws.id">
-    {{ ws.name }}
-  </nimble-list-option>
-</nimble-select>
-```
-
-**Critical:** Provide `APP_BASE_HREF` via DI and **remove the `<base href="/">` tag from `index.html`**. SystemLink enforces a `base-uri 'self'` CSP directive; the `<base>` element violates it.
-
----
-
-## Step 5: Configure routing for SystemLink sub-path hosting
-
-```typescript
-// src/app/app-routing.module.ts
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { MyFeatureComponent } from './my-feature/my-feature.component';
-
-const routes: Routes = [{ path: '', component: MyFeatureComponent }];
-
-@NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: true })],  // ← REQUIRED
-  exports: [RouterModule],
-})
-export class AppRoutingModule {}
-```
-
-**Why `useHash: true`?** SystemLink serves your app at a sub-path like `/ni/webapps/<id>/`. Angular's default `PathLocationStrategy` tries to match the path against the route table and fails with NG04002. Hash routing (`/#/`) sidesteps this entirely.
-
----
-
-## Step 6: Fix the CSP inline-script issue
-
-In `angular.json`, disable critical CSS inlining (the Beasties optimizer injects `onload` handlers that violate CSP `script-src 'unsafe-inline'`):
-
-```json
-"configurations": {
-  "production": {
-    "optimization": {
-      "scripts": true,
-      "styles": {
-        "minify": true,
-        "inlineCritical": false
-      },
-      "fonts": true
-    }
-  }
-}
-```
-
----
-
-## Step 7: Configure fonts and styling with Nimble tokens
-
-Nimble fonts (Source Sans Pro, Noto Serif) must be explicitly imported in your global styles. Split your styling tokens into two groups:
-
-1. Theme-independent aliases such as fonts and spacing belong in `src/styles.scss` on `:root`
-2. Theme-aware aliases such as colors and shadows must be defined on `nimble-theme-provider`, because Nimble resolves its theme tokens there rather than on `:root`
-
-### Import Nimble fonts (required)
-
-```scss
-/* src/styles.scss */
-
-/* Import Nimble fonts (Source Sans Pro, Noto Serif) */
-@use '@ni/nimble-angular/styles/fonts' as *;
-
-/* Theme-independent aliases only. */
-:root {
-  /* Typography - map to Nimble's named font tokens */
-  --sl-app-font-body: var(--ni-nimble-body-font);
-  --sl-app-font-body-emphasized: var(--ni-nimble-body-emphasized-font);
-  --sl-app-font-title: var(--ni-nimble-title-font);
-  --sl-app-font-title-plus-1: var(--ni-nimble-title-plus-1-font);
-  --sl-app-font-control-label: var(--ni-nimble-control-label-font);
-  --sl-app-font-group-header: var(--ni-nimble-group-header-font);
-
-  --sl-app-space-1: var(--ni-nimble-small-padding, 4px);
-  --sl-app-space-2: var(--ni-nimble-medium-padding, 8px);
-  --sl-app-space-3: calc(var(--ni-nimble-small-padding, 4px) * 3);
-  --sl-app-space-4: var(--ni-nimble-standard-padding, 16px);
-  --sl-app-space-6: var(--ni-nimble-large-padding, 24px);
-}
-
-/* Apply body defaults */
-html,
-body {
-  margin: 0;
-  min-height: 100%;
-  font: var(--sl-app-font-body);
-}
-
-h1 { font: var(--sl-app-font-title-plus-1); }
-h2 { font: var(--sl-app-font-title); }
-h3, h4, h5, h6 { font: var(--sl-app-font-body-emphasized); }
-```
-
-Define theme-aware aliases on the root `nimble-theme-provider` instead of `:root`:
-
-```scss
-/* src/app/app.component.scss */
-
-:host {
-  display: block;
-  height: 100vh;
-}
-
-nimble-theme-provider {
-  display: block;
-  height: 100%;
-  background: var(--ni-nimble-application-background-color);
-  color: var(--ni-nimble-body-font-color);
-
-  --sl-app-color-bg: var(--ni-nimble-application-background-color);
-  --sl-app-color-surface: var(--ni-nimble-section-background-color);
-  --sl-app-color-surface-alt: var(--ni-nimble-header-background-color);
-  --sl-app-color-border: var(--ni-nimble-divider-background-color);  /* use for dividers and section separators */
-  --sl-app-color-border-strong: var(--ni-nimble-popup-border-color);
-  --sl-app-color-text: var(--ni-nimble-body-font-color);
-  --sl-app-color-text-muted: var(--ni-nimble-placeholder-font-color);
-  --sl-app-color-accent: var(--ni-nimble-button-fill-primary-color);
-  --sl-app-color-accent-contrast: var(--ni-nimble-button-primary-font-color);
-  --sl-app-color-success: var(--ni-nimble-pass-color);
-  --sl-app-shadow-1: var(--ni-nimble-elevation-1-box-shadow);
-  --sl-app-shadow-2: var(--ni-nimble-elevation-2-box-shadow);
-}
-```
-
-Do not add literal color fallbacks to theme-aware aliases. If you write `var(--ni-nimble-application-background-color, #fff)` into your app token layer, you make it too easy to miss a broken theme hookup and accidentally freeze the palette to a light-only fallback.
-
-### Use semantic tokens in component SCSS
-
-Instead of hard-coded colors/sizes, reference the semantic `--sl-app-*` variables:
-
-```scss
-// src/app/my-feature/my-feature.component.scss
-
-// Clickable card — use Nimble card-specific tokens directly (more specific than --sl-app-color-border)
-.card {
-  padding: var(--sl-app-space-4);
-  border: 1px solid var(--ni-nimble-card-border-color);
-  background: var(--ni-nimble-section-background-color);
-  border-radius: var(--sl-app-space-1);
-  cursor: pointer;
-  transition: box-shadow var(--ni-nimble-medium-delay, 0.15s) ease,
-              border-color var(--ni-nimble-medium-delay, 0.15s) ease;
-
-  &:hover {
-    box-shadow: var(--ni-nimble-elevation-2-box-shadow, 0 2px 8px rgba(0, 0, 0, 0.12));
-    border-color: var(--ni-nimble-border-hover-color);
-  }
-}
-
-.card-title {
-  font: var(--sl-app-font-body-emphasized);
-  color: var(--sl-app-color-text);
-}
-
-.card-meta {
-  font: var(--sl-app-font-control-label);
-  color: var(--sl-app-color-text-muted);
-}
-```
-
-If you want compile-time token values in SCSS, you can also import Nimble's token variables:
-
-```scss
-@use '@ni/nimble-angular/styles/tokens' as *;
-
-.my-element {
-  color: $ni-nimble-body-font-color;
-}
-```
-
-### Tabs in dense side panels
-
-When placing Nimble tabs inside a dense side panel or details pane, use the tab wrapper and panel
-as the layout primitives instead of forcing inner content blocks to fill the available height.
-
-```scss
-.details-tabs {
-  padding: 15px 30px 30px 15px;
-}
-
-.details-tab-panel {
-  padding: 20px 0 0 15px;
-  overflow: auto;
-}
-
-.details-tab-content {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ni-nimble-medium-padding, 8px);
-}
-```
-
-- Use `padding: 15px 30px 30px 15px` on the tab control container.
-- Use `padding: 20px 0 0 15px` on the active tab panel content region.
-- Let the tab panel container handle scrolling.
-- Do not force nested form blocks or content stacks to `height: 100%`; that tends to stretch the
-  layout and creates inconsistent vertical spacing between controls.
-- Inside the active tab panel, keep stacked controls on an `8px` gap via
-  `var(--ni-nimble-medium-padding, 8px)` unless a tighter layout is explicitly needed.
-
-### Why this pattern?
-
-1. **Themability** — All colors flow through Nimble's theme-aware tokens. If Nimble changes color ramps or adds dark mode, your app automatically inherits it.
-2. **Consistency** — Using Nimble's canonical fonts (Source Sans Pro for UI, Noto Serif for headings) ensures your app feels native to SystemLink.
-3. **Typography scales** — Nimble defines font sizes, weights, and line heights per role (body, titles, labels, headings). Reuse them rather than inventing your own.
-4. **Correct token resolution** — Color and shadow aliases must live on `nimble-theme-provider`; defining them on `:root` can leave a hosted app stuck on the wrong palette even when the provider's `theme` attribute changes.
-5. **Responsive spacing** — Nimble's padding tokens scale predictably; build layouts that adapt to different screen sizes by composing space variables.
-
-### Available Nimble tokens
-
-See [Nimble's theme-aware tokens documentation](https://nimble.ni.dev/storybook/index.html?path=/docs/tokens-theme-aware-tokens--docs) for a complete token reference (colors, dimensions, shadows, delays, etc.).
-
----
-
-## Step 8: Call SystemLink APIs
-
-### Configure the client at runtime
-
-Every `@ni/systemlink-clients-ts` service exposes `createClient` and `createConfig` from its `/client` subpath. Always create a configured client at call-site (or lazily inside a helper) using values from `window.location.origin` and optionally `localStorage` — never rely on the package's default `baseUrl`.
-
-```typescript
-import { createClient, createConfig } from '@ni/systemlink-clients-ts/file-ingestion/client';
-import { queryFilesLinq } from '@ni/systemlink-clients-ts/file-ingestion';
-
-function buildClient() {
-  const baseUrl = localStorage.getItem('sl_api_url') ?? `${window.location.origin}/nifile`;
-  const apiKey  = localStorage.getItem('sl_api_key');
-  return createClient(createConfig({
-    baseUrl,
-    headers:     apiKey ? { 'x-ni-api-key': apiKey } : {},
-    credentials: apiKey ? 'omit' : 'include',   // cookie auth when no API key
-  }));
-}
-
-// Use in a component method:
-const { data, error } = await queryFilesLinq({ client: buildClient(), body: { take: 100 } });
-```
-
-For **ad-hoc POST calls** to endpoints not yet covered by an SDK function, use the client directly:
-
-```typescript
-const { data, error } = await buildClient().post<MyResponse, unknown>({
-  url: '/v1/service-groups/Default/search-files',
-  body: { filter: 'name:("*report*")', take: 100 },
-  headers: { 'Content-Type': 'application/json' },
-});
-```
-
-### Base URL reference
-
-Always compute the base URL from `window.location.origin` — never hardcode a hostname:
-
-```typescript
-const tagsBaseUrl = `${window.location.origin}/nitag`;                // tags.js -> /v2/...
-const userBaseUrl = `${window.location.origin}/niuser/v1`;            // user.js -> /users, /workspaces
-const webAppBaseUrl = `${window.location.origin}/niapp/v1`;           // web-application.js -> /webapps/...
-const fileIngestionBaseUrl = `${window.location.origin}/nifile`;      // file-ingestion.js -> /v1/...
-const testMonitorBaseUrl = `${window.location.origin}/nitestmonitor`; // test-monitor.js -> /v2/...
-
-const feedsBaseUrl = window.location.origin;                          // feeds.js -> /nifeed/v1/...
-const assetBaseUrl = window.location.origin;                          // asset-management.js -> /niapm/v1/...
-const systemsBaseUrl = window.location.origin;                        // systems-management.js -> /nisysmgmt/v1/...
-const workItemBaseUrl = window.location.origin;                       // work-item.js -> /niworkitem/v1/...
-const workOrderBaseUrl = window.location.origin;                      // work-order.js -> /niworkorder/v1/...
-const notebookBaseUrl = window.location.origin;                       // notebook.js -> /ninotebook/v1/...
-```
-
-### Authentication
-
-- **Same-origin** (app and API on the same server): use `credentials: 'include'` — session cookies are sent automatically, no API key needed.
-- **Remote / dev**: read an API key from `localStorage` and pass it as `x-ni-api-key` header. Set `credentials: 'omit'` when using an API key.
-- Never hardcode credentials in source code.
-
-### Querying
-
-- Build queries as typed objects matching the SDK models — don't construct raw URL strings
-- For LINQ filter strings (tags, files), keep filters simple: `path = "..."`, `type = "..."`, `name:("*pattern*")`
-- Avoid `projection` parameters unless you fully understand how they reshape the response — they often flatten nested objects and break your mapping logic
-
----
-
-## Step 9: App template pattern
-
-```typescript
-// src/app/app.component.ts
-import { Component, OnDestroy, OnInit } from '@angular/core';
-
-@Component({
-  selector: 'app-root',
-  template: `
-    <nimble-theme-provider [theme]="currentTheme">
-      <nimble-label-provider-core withDefaults></nimble-label-provider-core>
-      <router-outlet></router-outlet>
-    </nimble-theme-provider>
-  `,
-})
-export class AppComponent implements OnInit, OnDestroy {
-  currentTheme: 'light' | 'dark' = 'light';
-  private themeObserver: MutationObserver | null = null;
-
-  ngOnInit(): void {
-    this.currentTheme = this.detectInitialTheme();
-    this.watchParentTheme();
-  }
-
-  ngOnDestroy(): void {
-    this.themeObserver?.disconnect();
-  }
-
-  private detectInitialTheme(): 'light' | 'dark' {
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const queryTheme = params.get('theme');
-      if (queryTheme === 'light' || queryTheme === 'dark') return queryTheme;
-    } catch {}
-
-    try {
-      if (window.parent !== window) {
-        const parentProvider = window.parent.document.querySelector('nimble-theme-provider');
-        const parentTheme = parentProvider?.getAttribute('theme');
-        if (parentTheme === 'light' || parentTheme === 'dark') return parentTheme;
-      }
-    } catch {}
-
-    try {
-      const savedTheme = localStorage.getItem('sl_app_theme');
-      if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
-    } catch {}
-
-    try {
-      if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) return 'dark';
-    } catch {}
-
-    return 'light';
-  }
-
-  private watchParentTheme(): void {
-    try {
-      if (window.parent === window) return;
-      const parentProvider = window.parent.document.querySelector('nimble-theme-provider');
-      if (!parentProvider) return;
-
-      this.themeObserver = new MutationObserver(() => {
-        const parentTheme = parentProvider.getAttribute('theme');
-        if (parentTheme === 'light' || parentTheme === 'dark') {
-          this.currentTheme = parentTheme;
-        }
-      });
-
-      this.themeObserver.observe(parentProvider, {
-        attributes: true,
-        attributeFilter: ['theme'],
-      });
-    } catch {}
-  }
-}
-```
-
-### How theme sync works
-
-SystemLink's Web Apps shell renders each webapp inside a **same-origin `<iframe>`**. Because host and child share the same origin, the iframe's JavaScript can read and observe the parent document's DOM.
-
-#### Initial detection — priority cascade
-
-`detectInitialTheme()` resolves the starting theme by checking sources in order:
-
-| Priority | Source | Why |
-|----------|--------|-----|
-| 1 | `?theme=dark` URL query parameter | Easy override for dev/testing without needing the full shell |
-| 2 | Parent frame's `nimble-theme-provider[theme]` attribute | SystemLink's shell owns a `<nimble-theme-provider>` element; reading its `theme` attribute gives the exact theme the shell is currently displaying |
-| 3 | `localStorage.getItem('sl_app_theme')` | Remembers a previously chosen preference when running standalone (outside the shell) |
-| 4 | `window.matchMedia('(prefers-color-scheme: dark)')` | OS-level dark mode when no other signal is available |
-| 5 | `'light'` | Safe default |
-
-Each priority block is wrapped in its own `try/catch` so a failure in one (e.g. cross-origin access, missing API) does not prevent the lower priorities from being evaluated.
-
-#### Dynamic updates — MutationObserver on the parent provider
-
-`watchParentTheme()` installs a `MutationObserver` on the parent document's `nimble-theme-provider` element:
-
-```typescript
-this.themeObserver = new MutationObserver(() => {
-  const t = parentProvider.getAttribute('theme');
-  if (t === 'light' || t === 'dark') this.currentTheme = t;
-});
-this.themeObserver.observe(parentProvider, {
-  attributes: true,
-  attributeFilter: ['theme'],   // only fires when the `theme` attribute mutates
-});
-```
-
-When the SystemLink user toggles the theme in the shell, the shell updates its `nimble-theme-provider theme="dark|light"` attribute. The `MutationObserver` callback fires immediately (synchronously in the microtask queue), Angular's change detection picks up the new `currentTheme` value, and `<nimble-theme-provider [theme]="currentTheme">` re-renders with the correct token set. The transition happens with no perceptible lag.
-
-#### Template binding
-
-The root component template must bind `currentTheme` directly to the `<nimble-theme-provider>` element that wraps all app content:
-
-```html
-<nimble-theme-provider [theme]="currentTheme">
-  <nimble-label-provider-core withDefaults></nimble-label-provider-core>
-  <!-- all app content here -->
-  <router-outlet></router-outlet>
-</nimble-theme-provider>
-```
-
-Nimble's theme provider resolves its design tokens (colors, shadows, etc.) based on its own `theme` property. Every `--ni-nimble-*` CSS variable inside the provider's subtree updates when the property changes.
-
-#### Cleanup in `ngOnDestroy`
-
-The observer holds a reference to the parent DOM element. Always disconnect it when the component is destroyed to prevent memory leaks:
-
-```typescript
-ngOnDestroy(): void {
-  this.themeObserver?.disconnect();
-}
-```
-
-#### Cross-origin and standalone safety
-
-All `window.parent.document` access is wrapped in `try/catch`. If the app is:
-- opened directly in a browser tab (`window.parent === window`) → the guard `if (window.parent === window) return;` exits early
-- embedded in a cross-origin frame → accessing `window.parent.document` throws a `SecurityError`; the `catch {}` silently swallows it and the app falls through to localStorage / system preference
-- embedded same-origin (production SystemLink) → fully works
-
-This pattern requires zero configuration — the same binary works correctly in all three contexts.
-
-### nimble-anchor-tabs navigation
-
-For top-level navigation, use `<nimble-anchor-tabs>` with `[activeid]` and `nimbleRouterLink` on each tab. Track the active tab by subscribing to Angular's `NavigationEnd` events:
-
-```html
-<nimble-anchor-tabs [activeid]="activeTabId">
-  <nimble-anchor-tab id="catalog" nimbleRouterLink="/catalog">Catalog</nimble-anchor-tab>
-  <nimble-anchor-tab id="installed" nimbleRouterLink="/installed">Installed</nimble-anchor-tab>
-  <nimble-anchor-tab id="settings" nimbleRouterLink="/settings">Settings</nimble-anchor-tab>
-</nimble-anchor-tabs>
-```
-
-```typescript
-import { Router, NavigationEnd } from '@angular/router';
-import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
-
-export class AppComponent implements OnInit, OnDestroy {
-  activeTabId = 'catalog';
-  private routerSub?: Subscription;
-
-  constructor(private router: Router) {}
-
-  ngOnInit(): void {
-    this.activeTabId = this.tabIdFromUrl(this.router.url);
-    this.routerSub = this.router.events.pipe(
-      filter(e => e instanceof NavigationEnd)
-    ).subscribe(e => {
-      this.activeTabId = this.tabIdFromUrl((e as NavigationEnd).urlAfterRedirects);
-    });
-  }
-
-  ngOnDestroy(): void { this.routerSub?.unsubscribe(); }
-
-  private tabIdFromUrl(url: string): string {
-    if (url.startsWith('/installed')) return 'installed';
-    if (url.startsWith('/settings')) return 'settings';
-    return 'catalog';
-  }
-}
-```
-
-Required modules: `NimbleAnchorTabsModule`, `NimbleAnchorTabModule` — both from `@ni/nimble-angular`.
-
----
-
-## Step 10: Build
-
-```bash
-node_modules/.bin/ng build --configuration production --output-path dist/<app-name>
-```
-
-- Do **not** pass `--base-href` — that would re-introduce the `<base>` element
-- Output goes to `dist/<app-name>/browser/` (Angular 20)
-
-If you hit budget errors, increase limits in `angular.json`:
-
-```json
-"budgets": [
-  { "type": "initial", "maximumWarning": "1MB", "maximumError": "2MB" },
-  { "type": "anyComponentStyle", "maximumWarning": "2KB", "maximumError": "4KB" }
-]
-```
-
----
-
-## Step 11: Deploy with slcli
-
-```bash
-# First deploy — no existing webapp ID
-slcli webapp publish dist/<app-name>/browser/ -w <workspace-name>
-
-# Update existing webapp
-slcli webapp publish dist/<app-name>/browser/ -w <workspace-name> -i <webapp-id>
-
-# Open in browser
-slcli webapp open -i <webapp-id>
-```
-
-Save the returned webapp ID — you'll need it for every subsequent redeploy.
-
----
-
-## Troubleshooting quick-reference
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| CSP `base-uri` error | `<base href="/">` in index.html | Remove `<base>` tag; provide `APP_BASE_HREF` via DI |
-| NG04002 / white screen | PathLocationStrategy can't resolve sub-path | `useHash: true` in RouterModule |
-| CSP `unsafe-inline` error | Beasties injects `onload` in style tags | `inlineCritical: false` in angular.json optimization |
-| App stays light inside dark SystemLink shell | Theme-aware aliases defined on `:root` or embedded app not watching host provider | Define color/shadow aliases on `nimble-theme-provider`; sync `currentTheme` from parent provider |
-| `theme="dark"` is set but colors still look light | Checked the attribute only, not the resolved tokens | Inspect `getComputedStyle(themeProvider).getPropertyValue('--ni-nimble-application-background-color')` in the hosted iframe |
-| CORS / status 0 | `baseUrl` points to the wrong origin or wrong service root | Match the generated client: for example `test-monitor` uses `${window.location.origin}/nitestmonitor`, while `work-item` uses `window.location.origin` |
-| 404 on API calls | Wrong `baseUrl` for the selected client | Only `tags`, `user`, `web-application`, `file-ingestion`, and `test-monitor` need a prefixed `baseUrl`. `feeds`, `asset-management`, `systems-management`, `work-item`, `work-order`, and `notebook` use bare origin because their operation URLs already include the service prefix |
-| `InputFieldValidationError` on API call | SDK-generated request body has wrong shape | Inspect raw API; the generated type may add or omit a `request: {}` wrapper. Use direct `fetch` with manually constructed body |
-| nimble-dialog does not open | `*ngIf` destroys element before `ViewChild` can resolve | Remove `*ngIf` from the dialog element; use `@ViewChild` + `ElementRef` and call `nativeElement.show()` / `nativeElement.close()` |
-| Icon module import fails | Icon sub-path `@ni/nimble-angular/icons/...` does not exist | Import icon modules from the main `@ni/nimble-angular` barrel only |
-| Angular says a Nimble tag is unknown | Missing `@ni/nimble-angular` module import | Import the missing wrapper module instead of adding `CUSTOM_ELEMENTS_SCHEMA` or registering raw `@ni/nimble-components` elements |
-| Nimble form control label looks detached or duplicated | Used a separate HTML `<label>` for the primary control label | Slot the label text inside `nimble-text-field`, `nimble-select`, and similar controls |
-| Table rows empty despite correct response | `projection` flattens nested objects | Remove `projection` from query body |
-| `TableRecord` type error | Row type missing index signature | Add `[key: string]: FieldValue \| undefined` |
-| Button appearance invalid | Wrong value for `appearance` attr | Use `appearance="block" appearance-variant="accent"` |
-| `ng build` exits 130 / truncated | Terminal heredoc issue in VS Code | Run build as background process: `nohup ng build ... > /tmp/build.log 2>&1 &` |
-
-### Hosted theme validation recipe
-
-When validating a deployed SystemLink webapp, prefer checking the hosted instance rather than only local dev:
-
-1. Open the webapp inside SystemLink so you can inspect the shell and embedded iframe together
-2. Verify both parent and iframe expose a `nimble-theme-provider`
-3. Compare resolved token values, not just attributes, for example `--ni-nimble-application-background-color`, `--ni-nimble-header-background-color`, and `--ni-nimble-body-font-color`
-4. Scan component SCSS for hard-coded color literals and replace them with Nimble tokens or local semantic aliases
-
-If the host and iframe are same-origin, Playwright or DevTools can inspect `iframe.contentDocument` directly.
-
----
-
-## Known SystemLink client base URLs
-
-| Service | Client `baseUrl` |
-|---------|------------------|
-| Tag Historian | `window.location.origin + '/nitaghistorian'` |
-| Tags | `window.location.origin + '/nitag'` |
-| User / Workspaces | `window.location.origin + '/niuser/v1'` |
-| Web Application | `window.location.origin + '/niapp/v1'` |
-| File Ingestion | `window.location.origin + '/nifile'` |
-| Test Monitor | `window.location.origin + '/nitestmonitor'` |
-| Asset Management | `window.location.origin` |
-| Systems Management | `window.location.origin` |
-| Work Items | `window.location.origin` |
-| Work Orders | `window.location.origin` |
-| Feeds (Package Manager) | `window.location.origin` |
-| Notebooks | `window.location.origin` |
-
-See `references/systemlink-services.md` for full API details.
-
----
-
-## nimble-dialog — imperative pattern
-
-Do NOT use `*ngIf` on a `nimble-dialog`. When `*ngIf` is false the element is removed from the DOM, so `@ViewChild` cannot resolve it and `.show()` will never be called.
-
-```html
-<!-- Always keep the dialog in the DOM; never *ngIf it -->
-<nimble-dialog #myDialog>
-  <span slot="title">Dialog Title</span>
-  <span slot="subtitle">Optional subtitle or instruction</span>
-
-  <!-- dialog body content -->
-  <nimble-select #mySelect filter-mode="standard" [(ngModel)]="selectedValue">
-    <nimble-list-option *ngFor="let opt of options" [value]="opt.id">{{ opt.name }}</nimble-list-option>
-  </nimble-select>
-
-  <nimble-button slot="footer" (click)="closeDialog()">Cancel</nimble-button>
-  <nimble-button slot="footer" (click)="applyDialog()" [disabled]="applying">Apply</nimble-button>
-</nimble-dialog>
-```
-
-```typescript
-import { ElementRef, ViewChild } from '@angular/core';
-
-@ViewChild('myDialog') private dialogEl?: ElementRef;
-@ViewChild('mySelect') private selectEl?: ElementRef;
-
-openDialog(): void {
-  this.dialogEl?.nativeElement.show();
-}
-
-closeDialog(): void {
-  this.dialogEl?.nativeElement.close();
-}
-```
-
-**Slot summary:** `slot="title"` (required), `slot="subtitle"` (optional), `slot="footer"` (buttons — can have multiple).
-
-Required module: `NimbleDialogModule` from `@ni/nimble-angular`.
-
----
-
-## Key imports reference
-
-| Item | Import path |
-|------|-------------|
-| Most component modules (theme provider, buttons, anchor-buttons, anchor-tabs, anchor-tab, tabs, tab, tab-panel, dialog, drawer, inputs, select, list-option, spinner, banner, toolbar, menu, table) | `@ni/nimble-angular` |
-| **Icon modules** (e.g. `NimbleIconMagnifyingGlassModule`) | `@ni/nimble-angular` — **must use main barrel; icon sub-paths do not exist** |
-| Label provider core module | `@ni/nimble-angular/label-provider/core` |
-| Label provider rich text module | `@ni/nimble-angular/label-provider/rich-text` |
-| Label provider table module | `@ni/nimble-angular/label-provider/table` |
-| Card module | `@ni/nimble-angular/card` |
-| Fonts styles entrypoint (`@use`) | `@ni/nimble-angular/styles/fonts` |
-| Tokens styles entrypoint (`@use`) | `@ni/nimble-angular/styles/tokens` |
-
-See `references/nimble-angular.md` for template usage of each component.
+### 2. Lock in the non-negotiables early
+
+These decisions prevent the most common hosted-webapp failures:
+
+- Provide `APP_BASE_HREF` via DI and remove any `<base>` tag from `index.html`.
+- Use hash routing with `RouterModule.forRoot(..., { useHash: true })`.
+- Disable critical CSS inlining in production with `inlineCritical: false`.
+- Use `@ni/nimble-angular` wrapper modules, not raw `@ni/nimble-components`, as the default integration path.
+- Do not add `CUSTOM_ELEMENTS_SCHEMA` just to silence missing Nimble module imports.
+- Put theme-aware color and shadow aliases on `nimble-theme-provider`, not on `:root`.
+- Import `@angular/localize/init` in Angular polyfills for both build and test paths.
+
+If you need the exact module patterns or template wiring, load [references/nimble-angular.md](./references/nimble-angular.md).
+If you need a concise package-level inventory before choosing components, load [references/angular-ui-packages.md](./references/angular-ui-packages.md).
+
+### 3. Choose the default UI patterns
+
+Use SystemLink-appropriate layout defaults instead of inventing page structure from scratch:
+
+- Use `nimble-table` for primary list/browse/search datasets.
+- Keep list/detail views visible together with a split-pane when selection drives preview.
+- Use drawers or collapsible side panels for settings and filters.
+- Use accordions for grouped fields and advanced configuration.
+- Use cards sparingly for summaries, not as the default editing or data layout.
+
+Load [references/layout-patterns.md](./references/layout-patterns.md) when the task turns into page composition, spacing, or shell layout work.
+
+### 4. Integrate SystemLink APIs the low-risk way
+
+Always prefer `@ni/systemlink-clients-ts` first. Only generate a new client when the needed service is not already covered.
+
+Default rules:
+
+- Build clients at runtime from `window.location.origin`.
+- For same-origin hosted apps, use cookie auth with `credentials: 'include'`.
+- For remote/dev flows, collect an API key from the user and send it as `x-ni-api-key`.
+- Never hardcode hostnames or credentials in source code.
+- Treat generated SDK request shapes as fallible; if the SDK body shape is wrong, fall back to direct `fetch`.
+
+Load [references/systemlink-services.md](./references/systemlink-services.md) when you need actual base URLs, request bodies, or auth examples.
+
+### 5. Build the smallest useful vertical slice first
+
+When the user asks for implementation, prefer one working slice over a full app shell rewrite:
+
+- one route
+- one data query
+- one table or detail view
+- one loading state
+- one error banner
+- one settings/control path only if required
+
+This keeps context narrow and usually reveals the real integration blockers faster than broad scaffolding.
+
+### 6. Publish or package only after the hosted constraints are covered
+
+For ordinary hosted deployment, build and publish after the routing, CSP, theme, and client setup are in place.
+
+For Plugin Manager packaging, use `slcli webapp manifest init` to generate `nipkg.config.json`, then `slcli webapp pack` to create the `.nipkg`.
+
+Load [references/deployment.md](./references/deployment.md) when the task reaches build, publish, redeploy, or packaging.
+
+### 7. Validate in the hosted environment, not only local dev
+
+Local Angular dev mode does not reproduce the SystemLink shell, iframe, auth, or theme propagation behavior. Hosted validation is required.
+
+Always verify:
+
+- the app renders without layout breakage
+- the browser console is clear of blocking errors
+- the correct SystemLink data loads
+- light/dark theme switching updates the app in real time
+
+Load [references/troubleshooting.md](./references/troubleshooting.md) for the hosted validation flow and symptom-based fixes.
+
+## Minimal implementation checklist
+
+Before you consider a SystemLink webapp slice correct, confirm all of the following:
+
+- Angular 20 workspace created in the intended starter directory.
+- `AppModule` provides `APP_BASE_HREF`.
+- `index.html` does not contain a `<base>` element.
+- Router uses `useHash: true`.
+- Production build disables `inlineCritical`.
+- Nimble Angular modules are imported explicitly.
+- No hardcoded colors in component SCSS.
+- Theme-aware aliases live on `nimble-theme-provider`.
+- API client uses the correct SystemLink service base URL.
+- Hosted deployment is validated after publish.
+
+## Default implementation stance
+
+Use these defaults unless the user asks for a different tradeoff:
+
+- Angular 20
+- NgModule-based app
+- `@ni/nimble-angular`
+- `@ni/spright-angular`
+- `@ni/ok-angular`
+- `@ni/systemlink-clients-ts`
+- table-first data presentation
+- same-origin cookie auth
+- long-form CLI flags in examples and commands
+
+## Common mistakes to prevent up front
+
+- Treating the app like a normal root-hosted Angular SPA instead of an iframe/sub-path app.
+- Checking only the `theme` attribute instead of verifying resolved Nimble tokens.
+- Putting theme-aware aliases on `:root`.
+- Overriding SDK base URLs with incomplete service prefixes.
+- Using raw HTML controls where Nimble primitives should define the interaction model.
+- Loading too much reference material before the task requires it.
+
+## When to escalate into the references
+
+- The user asks which components are available across the NI Angular UI packages: load [references/angular-ui-packages.md](./references/angular-ui-packages.md).
+- The user asks for exact Angular module imports or Nimble template syntax: load [references/nimble-angular.md](./references/nimble-angular.md).
+- The user asks for layout or interaction structure: load [references/layout-patterns.md](./references/layout-patterns.md).
+- The task depends on a specific SystemLink API request shape or service root: load [references/systemlink-services.md](./references/systemlink-services.md).
+- The task reaches build, publish, redeploy, or packaging: load [references/deployment.md](./references/deployment.md).
+- The hosted app is already broken or needs final verification: load [references/troubleshooting.md](./references/troubleshooting.md).

--- a/slcli/skills/systemlink-webapp/references/angular-ui-packages.md
+++ b/slcli/skills/systemlink-webapp/references/angular-ui-packages.md
@@ -25,52 +25,52 @@ Use Nimble as the default foundation, then pull in Spright and OK Angular when t
 Use this as a starting point when a SystemLink webapp needs components from all three packages. Trim the imports down to only the modules the feature actually uses.
 
 ```typescript
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
-import { APP_BASE_HREF } from '@angular/common';
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { FormsModule } from "@angular/forms";
+import { APP_BASE_HREF } from "@angular/common";
 
 import {
-	NimbleThemeProviderModule,
-	NimbleButtonModule,
-	NimbleBannerModule,
-	NimbleDrawerModule,
-	NimbleTableModule,
-	NimbleTableColumnTextModule,
-} from '@ni/nimble-angular';
-import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
+  NimbleThemeProviderModule,
+  NimbleButtonModule,
+  NimbleBannerModule,
+  NimbleDrawerModule,
+  NimbleTableModule,
+  NimbleTableColumnTextModule,
+} from "@ni/nimble-angular";
+import { NimbleLabelProviderCoreModule } from "@ni/nimble-angular/label-provider/core";
 
-import { SprightChatConversationModule } from '@ni/spright-angular/chat/conversation';
-import { SprightChatInputModule } from '@ni/spright-angular/chat/input';
-import { SprightChatMessageInboundModule } from '@ni/spright-angular/chat/message/inbound';
-import { SprightChatMessageOutboundModule } from '@ni/spright-angular/chat/message/outbound';
+import { SprightChatConversationModule } from "@ni/spright-angular/chat/conversation";
+import { SprightChatInputModule } from "@ni/spright-angular/chat/input";
+import { SprightChatMessageInboundModule } from "@ni/spright-angular/chat/message/inbound";
+import { SprightChatMessageOutboundModule } from "@ni/spright-angular/chat/message/outbound";
 
-import { OkFvAccordionItemModule } from '@ni/ok-angular/fv/accordion-item';
-import { OkFvSearchInputModule } from '@ni/ok-angular/fv/search-input';
+import { OkFvAccordionItemModule } from "@ni/ok-angular/fv/accordion-item";
+import { OkFvSearchInputModule } from "@ni/ok-angular/fv/search-input";
 
-import { AppComponent } from './app.component';
+import { AppComponent } from "./app.component";
 
 @NgModule({
-	declarations: [AppComponent],
-	imports: [
-		BrowserModule,
-		FormsModule,
-		NimbleThemeProviderModule,
-		NimbleLabelProviderCoreModule,
-		NimbleButtonModule,
-		NimbleBannerModule,
-		NimbleDrawerModule,
-		NimbleTableModule,
-		NimbleTableColumnTextModule,
-		SprightChatConversationModule,
-		SprightChatInputModule,
-		SprightChatMessageInboundModule,
-		SprightChatMessageOutboundModule,
-		OkFvAccordionItemModule,
-		OkFvSearchInputModule,
-	],
-	providers: [{ provide: APP_BASE_HREF, useValue: '/' }],
-	bootstrap: [AppComponent],
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    NimbleThemeProviderModule,
+    NimbleLabelProviderCoreModule,
+    NimbleButtonModule,
+    NimbleBannerModule,
+    NimbleDrawerModule,
+    NimbleTableModule,
+    NimbleTableColumnTextModule,
+    SprightChatConversationModule,
+    SprightChatInputModule,
+    SprightChatMessageInboundModule,
+    SprightChatMessageOutboundModule,
+    OkFvAccordionItemModule,
+    OkFvSearchInputModule,
+  ],
+  providers: [{ provide: APP_BASE_HREF, useValue: "/" }],
+  bootstrap: [AppComponent],
 })
 export class AppModule {}
 ```
@@ -128,18 +128,18 @@ Published Spright icon directives currently include:
 
 Published Angular wrappers in `@ni/ok-angular@2.4.0` currently include:
 
-| Tag                           | Angular symbol                   | Import path                               | Use                                          |
-| ----------------------------- | -------------------------------- | ----------------------------------------- | -------------------------------------------- |
-| `ok-ex-button`                | `OkExButtonModule`               | `@ni/ok-angular/ex/button`                | OK button primitive                          |
-| `ok-fv-accordion-item`        | `OkFvAccordionItemModule`        | `@ni/ok-angular/fv/accordion-item`        | OK accordion item for grouped content        |
-| `ok-fv-card`                  | `OkFvCardModule`                 | `@ni/ok-angular/fv/card`                  | OK card surface with title and description   |
-| `ok-fv-chip-selector`         | `OkFvChipSelectorModule`         | `@ni/ok-angular/fv/chip-selector`         | Multi-value chip selector control            |
-| `ok-fv-context-help`          | `OkFvContextHelpModule`          | `@ni/ok-angular/fv/context-help`          | Inline context-help or severity help content |
-| `ok-fv-search-input`          | `OkFvSearchInputModule`          | `@ni/ok-angular/fv/search-input`          | OK search input control                      |
-| `ok-fv-split-button`          | `OkFvSplitButtonModule`          | `@ni/ok-angular/fv/split-button`          | Split button with primary and menu actions   |
-| `ok-fv-split-button-anchor`   | `OkFvSplitButtonAnchorModule`    | `@ni/ok-angular/fv/split-button-anchor`   | Anchor-style split button                    |
-| `ok-fv-summary-panel`         | `OkFvSummaryPanelModule`         | `@ni/ok-angular/fv/summary-panel`         | Summary panel container                      |
-| `ok-fv-summary-panel-tile`    | `OkFvSummaryPanelTileModule`     | `@ni/ok-angular/fv/summary-panel-tile`    | Summary panel metric or status tile          |
+| Tag                         | Angular symbol                | Import path                             | Use                                          |
+| --------------------------- | ----------------------------- | --------------------------------------- | -------------------------------------------- |
+| `ok-ex-button`              | `OkExButtonModule`            | `@ni/ok-angular/ex/button`              | OK button primitive                          |
+| `ok-fv-accordion-item`      | `OkFvAccordionItemModule`     | `@ni/ok-angular/fv/accordion-item`      | OK accordion item for grouped content        |
+| `ok-fv-card`                | `OkFvCardModule`              | `@ni/ok-angular/fv/card`                | OK card surface with title and description   |
+| `ok-fv-chip-selector`       | `OkFvChipSelectorModule`      | `@ni/ok-angular/fv/chip-selector`       | Multi-value chip selector control            |
+| `ok-fv-context-help`        | `OkFvContextHelpModule`       | `@ni/ok-angular/fv/context-help`        | Inline context-help or severity help content |
+| `ok-fv-search-input`        | `OkFvSearchInputModule`       | `@ni/ok-angular/fv/search-input`        | OK search input control                      |
+| `ok-fv-split-button`        | `OkFvSplitButtonModule`       | `@ni/ok-angular/fv/split-button`        | Split button with primary and menu actions   |
+| `ok-fv-split-button-anchor` | `OkFvSplitButtonAnchorModule` | `@ni/ok-angular/fv/split-button-anchor` | Anchor-style split button                    |
+| `ok-fv-summary-panel`       | `OkFvSummaryPanelModule`      | `@ni/ok-angular/fv/summary-panel`       | Summary panel container                      |
+| `ok-fv-summary-panel-tile`  | `OkFvSummaryPanelTileModule`  | `@ni/ok-angular/fv/summary-panel-tile`  | Summary panel metric or status tile          |
 
 ## Selection guidance
 

--- a/slcli/skills/systemlink-webapp/references/angular-ui-packages.md
+++ b/slcli/skills/systemlink-webapp/references/angular-ui-packages.md
@@ -1,0 +1,154 @@
+# Angular UI Packages — Concise Component Reference
+
+Use this file when you need a quick package-level inventory before choosing components. Load `nimble-angular.md` only after you know which Nimble components you actually need.
+
+## Install recommendation
+
+For new SystemLink webapps, prefer installing the NI Angular UI packages together:
+
+```bash
+npm install @ni/nimble-angular @ni/spright-angular @ni/ok-angular
+```
+
+Use Nimble as the default foundation, then pull in Spright and OK Angular when the app needs their specialized components.
+
+## Package roles
+
+| Package               | Primary role                                           | When to reach for it                                                                                                       |
+| --------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `@ni/nimble-angular`  | Core SystemLink-aligned component foundation           | Use for the default app shell, tables, buttons, inputs, drawers, banners, dialogs, navigation, and most day-to-day UI work |
+| `@ni/spright-angular` | Spright chat, rectangle, and NI-specific icon wrappers | Use for chat experiences, AI/copilot surfaces, and Spright-specific iconography                                            |
+| `@ni/ok-angular`      | OK-specific interaction components                     | Use when the design needs OK accordion items, OK search input, or OK button primitives                                     |
+
+## Recommended AppModule example
+
+Use this as a starting point when a SystemLink webapp needs components from all three packages. Trim the imports down to only the modules the feature actually uses.
+
+```typescript
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { APP_BASE_HREF } from '@angular/common';
+
+import {
+	NimbleThemeProviderModule,
+	NimbleButtonModule,
+	NimbleBannerModule,
+	NimbleDrawerModule,
+	NimbleTableModule,
+	NimbleTableColumnTextModule,
+} from '@ni/nimble-angular';
+import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
+
+import { SprightChatConversationModule } from '@ni/spright-angular/chat/conversation';
+import { SprightChatInputModule } from '@ni/spright-angular/chat/input';
+import { SprightChatMessageInboundModule } from '@ni/spright-angular/chat/message/inbound';
+import { SprightChatMessageOutboundModule } from '@ni/spright-angular/chat/message/outbound';
+
+import { OkFvAccordionItemModule } from '@ni/ok-angular/fv/accordion-item';
+import { OkFvSearchInputModule } from '@ni/ok-angular/fv/search-input';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+	declarations: [AppComponent],
+	imports: [
+		BrowserModule,
+		FormsModule,
+		NimbleThemeProviderModule,
+		NimbleLabelProviderCoreModule,
+		NimbleButtonModule,
+		NimbleBannerModule,
+		NimbleDrawerModule,
+		NimbleTableModule,
+		NimbleTableColumnTextModule,
+		SprightChatConversationModule,
+		SprightChatInputModule,
+		SprightChatMessageInboundModule,
+		SprightChatMessageOutboundModule,
+		OkFvAccordionItemModule,
+		OkFvSearchInputModule,
+	],
+	providers: [{ provide: APP_BASE_HREF, useValue: '/' }],
+	bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+Keep imports explicit. Do not use `CUSTOM_ELEMENTS_SCHEMA` as a substitute for importing the right Angular wrapper modules.
+
+## Concise inventory
+
+### `@ni/nimble-angular`
+
+This package is the default baseline. The detailed usage reference lives in [nimble-angular.md](./nimble-angular.md).
+
+Representative components already documented there include:
+
+- `nimble-theme-provider`
+- `nimble-table`
+- `nimble-table-column-text`
+- `nimble-button`
+- `nimble-anchor-tabs`
+- `nimble-anchor-tab`
+- `nimble-text-field`
+- `nimble-select`
+- `nimble-list-option`
+- `nimble-drawer`
+- `nimble-spinner`
+- `nimble-banner`
+- `nimble-dialog`
+
+### `@ni/spright-angular`
+
+Published Angular wrappers currently include:
+
+| Tag                             | Angular symbol                     | Import path                                 | Use                                                                       |
+| ------------------------------- | ---------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------- |
+| `spright-chat-conversation`     | `SprightChatConversationModule`    | `@ni/spright-angular/chat/conversation`     | Container for chat transcripts                                            |
+| `spright-chat-input`            | `SprightChatInputModule`           | `@ni/spright-angular/chat/input`            | Chat composer with send, stop, and error states                           |
+| `spright-chat-message`          | `SprightChatMessageModule`         | `@ni/spright-angular/chat/message`          | Generic chat message wrapper; prefer specific message types when possible |
+| `spright-chat-message-inbound`  | `SprightChatMessageInboundModule`  | `@ni/spright-angular/chat/message/inbound`  | Inbound assistant or service message block                                |
+| `spright-chat-message-outbound` | `SprightChatMessageOutboundModule` | `@ni/spright-angular/chat/message/outbound` | Outbound user message block                                               |
+| `spright-chat-message-system`   | `SprightChatMessageSystemModule`   | `@ni/spright-angular/chat/message/system`   | Neutral or system-status message block                                    |
+| `spright-chat-message-welcome`  | `SprightChatMessageWelcomeModule`  | `@ni/spright-angular/chat/message/welcome`  | Welcome or zero-state chat surface                                        |
+| `spright-rectangle`             | `SprightRectangleModule`           | `@ni/spright-angular/rectangle`             | Basic Spright rectangle primitive                                         |
+
+Published Spright icon directives currently include:
+
+- `spright-icon-nigel-chat` from `@ni/spright-angular/icons/nigel-chat`
+- `spright-icon-work-item-calendar-week` from `@ni/spright-angular/icons/work-item-calendar-week`
+- `spright-icon-work-item-calipers` from `@ni/spright-angular/icons/work-item-calipers`
+- `spright-icon-work-item-forklift` from `@ni/spright-angular/icons/work-item-forklift`
+- `spright-icon-work-item-rectangle-check-lines` from `@ni/spright-angular/icons/work-item-rectangle-check-lines`
+- `spright-icon-work-item-user-helmet-safety` from `@ni/spright-angular/icons/work-item-user-helmet-safety`
+- `spright-icon-work-item-wrench-hammer` from `@ni/spright-angular/icons/work-item-wrench-hammer`
+
+### `@ni/ok-angular`
+
+Published Angular wrappers in `@ni/ok-angular@2.4.0` currently include:
+
+| Tag                           | Angular symbol                   | Import path                               | Use                                          |
+| ----------------------------- | -------------------------------- | ----------------------------------------- | -------------------------------------------- |
+| `ok-ex-button`                | `OkExButtonModule`               | `@ni/ok-angular/ex/button`                | OK button primitive                          |
+| `ok-fv-accordion-item`        | `OkFvAccordionItemModule`        | `@ni/ok-angular/fv/accordion-item`        | OK accordion item for grouped content        |
+| `ok-fv-card`                  | `OkFvCardModule`                 | `@ni/ok-angular/fv/card`                  | OK card surface with title and description   |
+| `ok-fv-chip-selector`         | `OkFvChipSelectorModule`         | `@ni/ok-angular/fv/chip-selector`         | Multi-value chip selector control            |
+| `ok-fv-context-help`          | `OkFvContextHelpModule`          | `@ni/ok-angular/fv/context-help`          | Inline context-help or severity help content |
+| `ok-fv-search-input`          | `OkFvSearchInputModule`          | `@ni/ok-angular/fv/search-input`          | OK search input control                      |
+| `ok-fv-split-button`          | `OkFvSplitButtonModule`          | `@ni/ok-angular/fv/split-button`          | Split button with primary and menu actions   |
+| `ok-fv-split-button-anchor`   | `OkFvSplitButtonAnchorModule`    | `@ni/ok-angular/fv/split-button-anchor`   | Anchor-style split button                    |
+| `ok-fv-summary-panel`         | `OkFvSummaryPanelModule`         | `@ni/ok-angular/fv/summary-panel`         | Summary panel container                      |
+| `ok-fv-summary-panel-tile`    | `OkFvSummaryPanelTileModule`     | `@ni/ok-angular/fv/summary-panel-tile`    | Summary panel metric or status tile          |
+
+## Selection guidance
+
+- Start with Nimble for the app shell and the majority of controls.
+- Add Spright when the app needs chat UI or Spright-specific iconography.
+- Add OK Angular when the design specifically benefits from its accordion item, search input, chip selector, split button, summary panel, card, or OK button components.
+- Keep imports explicit at the module level; do not use `CUSTOM_ELEMENTS_SCHEMA` as a shortcut for missing wrappers.
+
+## Next step references
+
+- Need exact Nimble templates and patterns: read [nimble-angular.md](./nimble-angular.md)
+- Need layout guidance after choosing components: read [layout-patterns.md](./layout-patterns.md)

--- a/slcli/skills/systemlink-webapp/references/deployment.md
+++ b/slcli/skills/systemlink-webapp/references/deployment.md
@@ -33,12 +33,13 @@ tail -f /tmp/ng-build.log
 ## First deploy (no existing webapp)
 
 ```bash
-slcli webapp publish dist/<app-name>/browser/ -w <workspace-name>
+slcli webapp publish dist/<app-name>/browser/ --workspace <workspace-name>
 ```
 
 The command prints the new webapp ID. **Save it** — you need it for every future redeploy and for `slcli webapp open`.
 
 Example output:
+
 ```
 Created webapp: 3727d9ac-86e1-4d6e-820e-d2630c1b28e9
 ```
@@ -48,7 +49,7 @@ Created webapp: 3727d9ac-86e1-4d6e-820e-d2630c1b28e9
 ## Redeploy (update existing webapp)
 
 ```bash
-slcli webapp publish dist/<app-name>/browser/ -w <workspace-name> -i <webapp-id>
+slcli webapp publish dist/<app-name>/browser/ --workspace <workspace-name> --id <webapp-id>
 ```
 
 ---
@@ -56,7 +57,7 @@ slcli webapp publish dist/<app-name>/browser/ -w <workspace-name> -i <webapp-id>
 ## Open in browser
 
 ```bash
-slcli webapp open -i <webapp-id>
+slcli webapp open --id <webapp-id>
 ```
 
 ---
@@ -64,7 +65,7 @@ slcli webapp open -i <webapp-id>
 ## List webapps
 
 ```bash
-slcli webapp list -w <workspace-name>
+slcli webapp list --workspace <workspace-name>
 ```
 
 ---
@@ -72,7 +73,7 @@ slcli webapp list -w <workspace-name>
 ## Delete a webapp
 
 ```bash
-slcli webapp delete -i <webapp-id>
+slcli webapp delete --id <webapp-id>
 ```
 
 ---
@@ -116,6 +117,7 @@ Before publishing, verify:
 ### "Budget exceeded" build error
 
 Increase error limits in `angular.json`:
+
 ```json
 "budgets": [
   { "type": "initial", "maximumWarning": "1MB", "maximumError": "2MB" }

--- a/slcli/skills/systemlink-webapp/references/nimble-angular.md
+++ b/slcli/skills/systemlink-webapp/references/nimble-angular.md
@@ -1,5 +1,7 @@
 # Nimble Angular — Template & Usage Reference
 
+If you need a quick inventory across `@ni/nimble-angular`, `@ni/spright-angular`, and `@ni/ok-angular` before picking components, read [angular-ui-packages.md](./angular-ui-packages.md) first. This file stays focused on Nimble-specific usage patterns once you already know you need Nimble components.
+
 ## Wrapper-first rule
 
 When building Angular apps with Nimble, use `@ni/nimble-angular` wrapper modules as the default integration path.

--- a/slcli/skills/systemlink-webapp/references/troubleshooting.md
+++ b/slcli/skills/systemlink-webapp/references/troubleshooting.md
@@ -1,0 +1,100 @@
+# Troubleshooting and Hosted Validation
+
+Use this reference only when the task reaches hosted validation or when the deployed app is already failing.
+
+## Hosted validation flow
+
+Validate the published webapp in the hosted SystemLink environment, not just local Angular dev.
+
+1. Open the app in SystemLink and authenticate if prompted.
+2. Inspect the page for missing Nimble styling, broken layout, or blank-screen behavior.
+3. Check the browser console for blocking runtime errors.
+4. Verify the app loads real data and the main interaction path works.
+5. Switch the SystemLink shell between light and dark themes and confirm the app updates immediately.
+
+## Required sign-off checks
+
+- App loads in the hosted shell.
+- No critical console errors.
+- Nimble components render with the expected styling.
+- Theme changes propagate to the app in real time.
+- Core workflow succeeds with live data.
+
+## Theme validation
+
+Confirm both the attribute and the resolved token values.
+
+```javascript
+const provider = document.querySelector("nimble-theme-provider");
+const bg = getComputedStyle(provider).getPropertyValue(
+  "--ni-nimble-application-background-color",
+);
+const text = getComputedStyle(provider).getPropertyValue(
+  "--ni-nimble-body-font-color",
+);
+console.log({ bg, text });
+```
+
+If the `theme` attribute changes but the colors do not:
+
+- verify theme-aware aliases are defined on `nimble-theme-provider`, not `:root`
+- verify the app updates its `[theme]` binding when the parent provider changes
+- verify the provider actually wraps the rendered app shell
+
+## High-value console errors
+
+| Error or symptom                          | Likely cause                                          | Fix                                                                              |
+| ----------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `$localize is not defined`                | Angular localize polyfill missing                     | Add `@angular/localize/init` to Angular polyfills                                |
+| NG04002 or blank screen                   | Path routing under SystemLink sub-path                | Use hash routing                                                                 |
+| CSP `base-uri` error                      | `<base>` tag present                                  | Remove `<base>` and provide `APP_BASE_HREF` via DI                               |
+| CSP `unsafe-inline` error from styles     | Critical CSS inlining injected handlers               | Set `inlineCritical: false`                                                      |
+| CORS error or status `0`                  | Wrong origin or service base URL                      | Recompute base URL from `window.location.origin` plus the correct service prefix |
+| 404 on API call                           | Wrong client base URL for the chosen service          | Match the SDK's expected service root                                            |
+| Unknown `nimble-*` element                | Missing Angular wrapper module import                 | Import the matching `@ni/nimble-angular` module                                  |
+| Theme stays light in dark shell           | Theme aliases on `:root` or missing parent-theme sync | Move aliases to `nimble-theme-provider` and verify theme observer logic          |
+| Table data appears empty                  | Query projection flattened the response               | Remove `projection` or update the mapping code                                   |
+| `InputFieldValidationError` from SDK call | Generated request body shape is wrong                 | Inspect the raw API shape and use direct `fetch` if needed                       |
+
+## Symptom-based quick fixes
+
+### App renders but looks unstyled
+
+- confirm `nimble-theme-provider` is present
+- confirm the required Nimble Angular modules are imported
+- confirm the app uses Nimble components instead of native HTML controls for primary interactions
+
+### App follows the shell theme attribute but colors still look wrong
+
+- inspect resolved token values with `getComputedStyle`
+- remove hardcoded colors from component SCSS
+- define theme-aware aliases on `nimble-theme-provider`
+
+### SDK client compiles but calls fail at runtime
+
+- verify the actual service base URL
+- verify cookie auth versus API-key mode
+- verify the generated request body shape matches the real API
+
+### Dialogs or advanced overlays do not open
+
+- do not gate `nimble-dialog` with `*ngIf`
+- keep the dialog in the DOM and open it imperatively through `ViewChild`
+
+## Pre-publish review checklist
+
+Before publishing or redeploying, verify:
+
+- no hardcoded colors remain in component styles
+- Nimble primitives are used for the main controls and data views
+- `APP_BASE_HREF` is provided and no `<base>` tag exists
+- routing uses `useHash: true`
+- production build disables `inlineCritical`
+- `@angular/localize/init` is present in polyfills
+- the build succeeds cleanly
+
+## When to load other references from here
+
+- Need exact Nimble imports or table/dialog examples: read [nimble-angular.md](./nimble-angular.md)
+- Need service URL or request-body details: read [systemlink-services.md](./systemlink-services.md)
+- Need build, publish, or packaging commands: read [deployment.md](./deployment.md)


### PR DESCRIPTION
## Summary

- expand the `systemlink-notebook` skill and notebook reference docs with Python client quirks, public import guidance, REST fallback patterns for missing services, and repo-aligned service endpoint examples
- update the repo `slcli` skill to prefer long-form option names in generated commands and examples
- refactor the `systemlink-webapp` skill for progressive disclosure, add concise Angular UI package and troubleshooting references, and update webapp command examples to long-form flags
- move the `example` command from the "Validate & Plan" rich-click group to the "Configure" group
- adjust the site `.step::after` connector spacing and include the matching Towncrier fragment

## Testing

- not run (documentation, CLI help grouping, and site CSS changes only)

## Release Notes

- `doc` — enrich the notebook and webapp skills, prefer long-form CLI flags in skill examples, and move `example` into the Configure help group
