### PR TITLE
Automate Towncrier fragments for dependency bot PRs

### DIFF
--- a/.github/workflows/bot-towncrier-fragment.yml
+++ b/.github/workflows/bot-towncrier-fragment.yml
@@ -13,6 +13,7 @@ jobs:
   add-towncrier-fragment:
     if: >
       github.repository == 'ni-kismet/systemlink-cli' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
         github.event.pull_request.user.login == 'renovate[bot]' ||
         github.event.pull_request.user.login == 'dependabot[bot]'
@@ -22,24 +23,31 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Create Towncrier fragment
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           git fetch origin "${BASE_REF}" --depth=1
-          if git diff --name-only FETCH_HEAD...HEAD -- 'newsfragments/*.patch.md' | grep -q .; then
+          if git diff --name-only FETCH_HEAD...HEAD -- newsfragments | grep -q '^newsfragments/'; then
             echo "Newsfragment already present on PR branch."
             exit 0
           fi
 
-          fragment="newsfragments/${PR_NUMBER}.patch.md"
+          branch_topic="${HEAD_REF#*/}"
+          fragment_stem=$(printf '%s' "$branch_topic" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+          if [[ -z "$fragment_stem" ]]; then
+            fragment_stem="dependencies"
+          fi
+
+          fragment="newsfragments/deps-${fragment_stem}.patch.md"
           content="$PR_TITLE"
           content="${content#chore(deps): }"
           content="${content#chore: }"
@@ -64,6 +72,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "newsfragments/${PR_NUMBER}.patch.md"
+          git add newsfragments
           git commit -m "chore(ci): add towncrier fragment for PR #${PR_NUMBER}"
           git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/bot-towncrier-fragment.yml
+++ b/.github/workflows/bot-towncrier-fragment.yml
@@ -1,0 +1,69 @@
+name: Add Towncrier Fragment For Bot PRs
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  add-towncrier-fragment:
+    if: >
+      github.repository == 'ni-kismet/systemlink-cli' &&
+      (
+        github.event.pull_request.user.login == 'renovate[bot]' ||
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Create Towncrier fragment
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          git fetch origin "${BASE_REF}" --depth=1
+          if git diff --name-only FETCH_HEAD...HEAD -- 'newsfragments/*.patch.md' | grep -q .; then
+            echo "Newsfragment already present on PR branch."
+            exit 0
+          fi
+
+          fragment="newsfragments/${PR_NUMBER}.patch.md"
+          content="$PR_TITLE"
+          content="${content#chore(deps): }"
+          content="${content#chore: }"
+
+          case "$content" in
+            *[.!?]) ;;
+            *) content="${content}." ;;
+          esac
+
+          printf '%s\n' "$content" > "$fragment"
+
+      - name: Commit Towncrier fragment
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet --exit-code -- newsfragments; then
+            echo "No fragment changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "newsfragments/${PR_NUMBER}.patch.md"
+          git commit -m "chore(ci): add towncrier fragment for PR #${PR_NUMBER}"
+          git push origin "HEAD:${HEAD_REF}"

--- a/newsfragments/dependency-bot-towncrier.misc.md
+++ b/newsfragments/dependency-bot-towncrier.misc.md
@@ -1,0 +1,1 @@
+Automate Towncrier fragment handling for dependency bot pull requests.

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,20 @@
   "commitMessagePrefix": "chore(deps):",
   "schedule": ["before 7am on Monday"],
   "prConcurrentLimit": 5,
+  "gitIgnoredAuthors": [
+    "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "python scripts/write_renovate_towncrier_fragment.py \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\" \"{{{branchTopic}}}\""
+    ],
+    "dataFileTemplate": "[{{#each upgrades}}{\"depName\":\"{{{depName}}}\",\"newValue\":\"{{{newValue}}}\"}{{#unless @last}},{{/unless}}{{/each}}]",
+    "executionMode": "branch",
+    "fileFilters": ["newsfragments/deps-*.patch.md"],
+    "installTools": {
+      "python": {}
+    }
+  },
   "labels": ["dependencies"],
   "packageRules": [
     {

--- a/scripts/write_renovate_towncrier_fragment.py
+++ b/scripts/write_renovate_towncrier_fragment.py
@@ -1,0 +1,152 @@
+"""Generate a Towncrier fragment for Renovate update branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+MAX_LISTED_UPGRADES = 3
+
+
+def sanitize_fragment_stem(branch_topic: str) -> str:
+    """Convert a Renovate branch topic into a stable fragment stem.
+
+    Args:
+        branch_topic: The branch topic supplied by Renovate.
+
+    Returns:
+        A filesystem-safe fragment stem.
+    """
+    sanitized = re.sub(r"[^a-z0-9]+", "-", branch_topic.lower()).strip("-")
+    return sanitized or "dependencies"
+
+
+def _join_entries(entries: Sequence[str]) -> str:
+    """Join dependency entries into a natural-language list.
+
+    Args:
+        entries: Dependency update entries.
+
+    Returns:
+        A human-readable list string.
+    """
+    if len(entries) == 1:
+        return entries[0]
+    if len(entries) == 2:
+        return f"{entries[0]} and {entries[1]}"
+    return f"{', '.join(entries[:-1])}, and {entries[-1]}"
+
+
+def build_fragment_content(upgrades: Sequence[Mapping[str, Any]]) -> str:
+    """Build fragment content from Renovate upgrade metadata.
+
+    Args:
+        upgrades: Upgrade objects from Renovate's data file.
+
+    Returns:
+        A concise Towncrier fragment sentence.
+    """
+    entries: list[str] = []
+    seen_entries: set[str] = set()
+
+    for upgrade in upgrades:
+        dep_name = str(upgrade.get("depName", "")).strip()
+        new_value = str(upgrade.get("newValue", "")).strip()
+        if not dep_name:
+            continue
+
+        entry = dep_name if not new_value else f"{dep_name} to {new_value}"
+        if entry in seen_entries:
+            continue
+
+        seen_entries.add(entry)
+        entries.append(entry)
+
+    if not entries:
+        return "Update dependencies"
+
+    if len(entries) == 1:
+        return f"Update dependency {entries[0]}"
+
+    if len(entries) <= MAX_LISTED_UPGRADES:
+        return f"Update dependencies {_join_entries(entries)}"
+
+    listed_entries = entries[:MAX_LISTED_UPGRADES]
+    remaining = len(entries) - MAX_LISTED_UPGRADES
+    return f"Update dependencies {', '.join(listed_entries)}, and {remaining} others"
+
+
+def load_upgrades(data_file: Path) -> list[dict[str, Any]]:
+    """Load upgrade metadata written by Renovate.
+
+    Args:
+        data_file: Path to Renovate's JSON data file.
+
+    Returns:
+        Parsed upgrade objects.
+    """
+    with data_file.open(encoding="utf-8") as handle:
+        raw_data = json.load(handle)
+
+    if not isinstance(raw_data, list):
+        raise ValueError("Expected Renovate post-upgrade data to be a JSON array")
+
+    return [item for item in raw_data if isinstance(item, dict)]
+
+
+def write_fragment(data_file: Path, branch_topic: str, repo_root: Path) -> Path:
+    """Write the generated fragment into newsfragments/.
+
+    Args:
+        data_file: Path to Renovate's JSON data file.
+        branch_topic: Renovate branch topic used for deterministic naming.
+        repo_root: Repository root directory.
+
+    Returns:
+        The path to the generated fragment.
+    """
+    upgrades = load_upgrades(data_file)
+    content = build_fragment_content(upgrades)
+
+    fragment_name = f"deps-{sanitize_fragment_stem(branch_topic)}.patch.md"
+    fragment_path = repo_root / "newsfragments" / fragment_name
+    fragment_path.write_text(f"{content}\n", encoding="utf-8")
+    return fragment_path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional command-line arguments.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("data_file", type=Path)
+    parser.add_argument("branch_topic")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate a deterministic Towncrier fragment for a Renovate branch.
+
+    Args:
+        argv: Optional command-line arguments.
+
+    Returns:
+        Process exit code.
+    """
+    args = parse_args(argv)
+    fragment_path = write_fragment(args.data_file, args.branch_topic, args.repo_root)
+    print(fragment_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_renovate_towncrier_fragment.py
+++ b/scripts/write_renovate_towncrier_fragment.py
@@ -76,7 +76,8 @@ def build_fragment_content(upgrades: Sequence[Mapping[str, Any]]) -> str:
 
     listed_entries = entries[:MAX_LISTED_UPGRADES]
     remaining = len(entries) - MAX_LISTED_UPGRADES
-    return f"Update dependencies {', '.join(listed_entries)}, and {remaining} others"
+    other_label = "other" if remaining == 1 else "others"
+    return f"Update dependencies {', '.join(listed_entries)}, and {remaining} {other_label}"
 
 
 def load_upgrades(data_file: Path) -> list[dict[str, Any]]:

--- a/tests/unit/test_write_renovate_towncrier_fragment.py
+++ b/tests/unit/test_write_renovate_towncrier_fragment.py
@@ -1,0 +1,52 @@
+"""Tests for Renovate Towncrier fragment generation."""
+
+import json
+from pathlib import Path
+
+from scripts.write_renovate_towncrier_fragment import (
+    build_fragment_content,
+    sanitize_fragment_stem,
+    write_fragment,
+)
+
+
+def test_sanitize_fragment_stem_normalizes_branch_topic() -> None:
+    """Branch topics should become stable, filesystem-safe stems."""
+    assert sanitize_fragment_stem("Python Runtime Dependencies") == "python-runtime-dependencies"
+    assert sanitize_fragment_stem("renovate/github-actions") == "renovate-github-actions"
+    assert sanitize_fragment_stem("!!!") == "dependencies"
+
+
+def test_build_fragment_content_summarizes_grouped_updates() -> None:
+    """Grouped updates should produce a concise summary sentence."""
+    content = build_fragment_content(
+        [
+            {"depName": "click", "newValue": "8.1.8"},
+            {"depName": "rich", "newValue": "14.1.0"},
+            {"depName": "requests", "newValue": "2.32.4"},
+            {"depName": "urllib3", "newValue": "2.5.0"},
+        ]
+    )
+
+    assert content == (
+        "Update dependencies click to 8.1.8, rich to 14.1.0, requests to 2.32.4, and 1 others"
+    )
+
+
+def test_write_fragment_creates_deterministic_patch_file(tmp_path: Path) -> None:
+    """The helper should write a patch fragment under newsfragments/."""
+    repo_root = tmp_path
+    (repo_root / "newsfragments").mkdir()
+
+    data_file = repo_root / "upgrades.json"
+    data_file.write_text(
+        json.dumps([{"depName": "rich", "newValue": "15.0.0"}]),
+        encoding="utf-8",
+    )
+
+    fragment_path = write_fragment(data_file, "python-runtime-dependencies", repo_root)
+
+    assert (
+        fragment_path == repo_root / "newsfragments" / "deps-python-runtime-dependencies.patch.md"
+    )
+    assert fragment_path.read_text(encoding="utf-8") == "Update dependency rich to 15.0.0\n"

--- a/tests/unit/test_write_renovate_towncrier_fragment.py
+++ b/tests/unit/test_write_renovate_towncrier_fragment.py
@@ -29,7 +29,7 @@ def test_build_fragment_content_summarizes_grouped_updates() -> None:
     )
 
     assert content == (
-        "Update dependencies click to 8.1.8, rich to 14.1.0, requests to 2.32.4, and 1 others"
+        "Update dependencies click to 8.1.8, rich to 14.1.0, requests to 2.32.4, and 1 other"
     )
 
 


### PR DESCRIPTION
## Summary
- add a Renovate `postUpgradeTasks` helper that writes deterministic Towncrier fragments before dependency PRs are opened
- keep the GitHub Actions workflow as a fallback when a bot PR still arrives without a fragment

## Testing
- `poetry run towncrier check --compare-with origin/main`
- `poetry run pytest tests/unit/test_write_renovate_towncrier_fragment.py -q`
- `poetry run mypy scripts/write_renovate_towncrier_fragment.py tests/unit/test_write_renovate_towncrier_fragment.py`

## Release Notes
- `misc`: automate Towncrier fragment handling for dependency bot pull requests

## Notes
- split out from the existing Renovate `rich` update branch so PR #146 stays focused on the dependency change
