### PR TITLE
docs: improve routine skill guidance

### DIFF
--- a/newsfragments/146.doc.md
+++ b/newsfragments/146.doc.md
@@ -1,0 +1,1 @@
+Improve `slcli routine` skill documentation and trigger guidance.

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -327,7 +327,7 @@ Concrete v2 example from an existing `TAG` routine:
         "displayName": "CPU temp on <alarm_channel>",
         "severity": 3,
         "dynamicRecipientList": [
-          "alex.starche@emerson.com"
+          "user@example.com"
         ]
       }
     }

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -175,37 +175,14 @@ Use `--api-version v1` for notebook-execution routines. These map to the
 Routine Manager API and use `--type`, `--notebook-id`, plus either `--trigger`
 or `--schedule`.
 
-For `TRIGGERED` notebook routines, the `trigger` JSON uses this shape:
-
-```json
-{
-  "source": "FILES",
-  "events": ["CREATED"],
-  "filter": "extension=\".xml\""
-}
-```
-
 Notes for v1 triggers:
 
 - `trigger.filter` is required by the v1 API schema for triggered routines.
 - The only trigger `source` documented by the swagger is `FILES`.
 - The documented `events` values are `CREATED` and `UPDATED`.
-- The swagger includes `extension = ".csv"` as the canonical filter example; for XML uploads use `extension=".xml"`.
+- The simplest documented filter is `extension=".xml"`, but observed live examples also combine `workspace = ...` and `name.Contains(...)` checks.
 - Treat the filter string as service-owned syntax, not LINQ or OData. Do not rewrite it as `--filter` CLI syntax.
 - When working with an existing v1 routine, prefer `slcli routine get --api-version v1 <ID>` because the default API version is v2.
-
-Example:
-
-```bash
-slcli routine create \
-  --api-version v1 \
-  --name "ATML XML File Import" \
-  --workspace <WORKSPACE_ID> \
-  --type TRIGGERED \
-  --notebook-id <NOTEBOOK_ID> \
-  --trigger '{"source":"FILES","events":["CREATED"],"filter":"extension=\".xml\""}' \
-  --enabled
-```
 
 #### v2 event-action routines
 
@@ -227,115 +204,11 @@ Notes for v2 triggers:
 - When documenting v2 routines, show the exact JSON shape and note that valid configuration keys depend on the event type.
 - Live survey on the demo environment found these v2 event types in use: `TAG`, `TESTRESULTCHANGED`, and `WORKITEMCHANGED`.
 - Live survey on the demo environment found these v2 action types in use: `ALARM` and `NOTEBOOK`.
-
-Minimal v2 shape:
-
-```json
-{
-  "type": "<event-type>",
-  "triggers": [
-    {
-      "name": "<condition-name>",
-      "configuration": {
-        "<provider-specific-key>": "<value>"
-      }
-    }
-  ]
-}
-```
-
-Concrete v2 example from an existing `WORKITEMCHANGED` routine:
-
-```json
-{
-  "event": {
-    "type": "WORKITEMCHANGED",
-    "triggers": [
-      {
-        "name": "8f4db567-9686-4e4b-ac2c-31345cb01691",
-        "configuration": {
-          "filter": "(before.assignedTo != after.assignedTo) && (after.assignedTo = \"a69caa22-7e24-445f-8e9f-084ed98ff6e3\")"
-        }
-      }
-    ]
-  },
-  "actions": [
-    {
-      "type": "NOTEBOOK",
-      "triggers": [
-        "8f4db567-9686-4e4b-ac2c-31345cb01691"
-      ],
-      "configuration": {
-        "notebookId": "81d8df26-aeba-4b87-a1eb-d21a10684db2",
-        "parameters": {},
-        "resourceProfile": "DEFAULT",
-        "priority": "LOW",
-        "serviceAccount": "87022613-0b32-4ca9-8cf9-f0291cb0a4d3"
-      }
-    }
-  ]
-}
-```
-
-This example is useful because it shows the important v2 distinction: the filter lives under `event.triggers[].configuration.filter`, and the notebook execution details live under `actions[].configuration`.
-
-Concrete v2 example from an existing `TESTRESULTCHANGED` routine:
-
-```json
-{
-  "event": {
-    "type": "TESTRESULTCHANGED",
-    "triggers": [
-      {
-        "configuration": {
-          "filter": "(before.status != after.status) && (after.programName = \"...\")"
-        }
-      }
-    ]
-  }
-}
-```
-
-This shows that `TESTRESULTCHANGED`, like `WORKITEMCHANGED`, uses a provider-specific string filter under `event.triggers[].configuration.filter`.
-
-Concrete v2 example from an existing `TAG` routine:
-
-```json
-{
-  "event": {
-    "type": "TAG",
-    "triggers": [
-      {
-        "name": "97c1967e-0eea-4276-863a-2b65083e2bd5",
-        "configuration": {
-          "comparator": "GREATER_THAN",
-          "deadband": 2,
-          "path": "*.Health.Temperature.Reading.CPU Core *",
-          "thresholds": ["50"],
-          "type": "DOUBLE"
-        }
-      }
-    ]
-  },
-  "actions": [
-    {
-      "type": "ALARM",
-      "triggers": [
-        "97c1967e-0eea-4276-863a-2b65083e2bd5"
-      ],
-      "configuration": {
-        "displayName": "CPU temp on <alarm_channel>",
-        "severity": 3,
-        "dynamicRecipientList": [
-          "user@example.com"
-        ]
-      }
-    }
-  ]
-}
-```
-
-This second example shows the other common v2 pattern: provider-specific structured trigger fields, with no `configuration.filter` at all.
+- Observed TAG routines also use comparator-driven configurations such as `IN_RANGE`, `NOT_EQUAL`, and `GREATER_THAN_OR_EQUAL`.
+- Observed `TESTRESULTCHANGED` and `WORKITEMCHANGED` filters use provider-specific expression syntax such as nested field comparisons, `after.properties["key"]`, `DateTime.parse(...)`, `.Any(...)`, and `!Contains(...)`.
+- Common NOTEBOOK action fields in v2 are `notebookId`, `parameters`, `resourceProfile`, `priority`, and `serviceAccount`.
+- ALARM-producing routines need the clear/reset action that uses trigger `nisystemlink_no_triggers_breached`.
+- Load [routine-examples.md](./references/routine-examples.md) for sanitized live examples of compound v1 FILES filters and advanced v2 configurations.
 
 ## Reference docs
 
@@ -344,6 +217,7 @@ Consult these for detailed guidance. Load only what you need for the current tas
 | Topic                       | File                                                        | When to load                                                  |
 | --------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------- |
 | CLI command reference       | [commands.md](./references/commands.md)                     | Looking up command syntax, options, or examples               |
+| Routine examples            | [routine-examples.md](./references/routine-examples.md)     | Provider-specific v1/v2 payload shapes and sanitized live examples |
 | Datasheet-to-specs workflow | [datasheet-workflow.md](./references/datasheet-workflow.md) | Importing specs from PDF, CSV, or structured text             |
 | Filtering guide             | [filtering.md](./references/filtering.md)                   | Advanced LINQ expressions, parameterized queries              |
 | Analysis recipes            | [analysis-recipes.md](./references/analysis-recipes.md)     | Multi-step analysis: yield, calibration, operator performance |

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -164,6 +164,179 @@ slcli example install <EXAMPLE_ID> [--workspace NAME]    # Provision example res
 slcli example delete <EXAMPLE_ID> [--workspace NAME]     # Remove provisioned resources
 ```
 
+### routine — Routine management
+
+`slcli routine` spans two different services with different trigger payload shapes.
+Document the API version and trigger schema explicitly when generating commands.
+
+#### v1 notebook routines
+
+Use `--api-version v1` for notebook-execution routines. These map to the
+Routine Manager API and use `--type`, `--notebook-id`, plus either `--trigger`
+or `--schedule`.
+
+For `TRIGGERED` notebook routines, the `trigger` JSON uses this shape:
+
+```json
+{
+  "source": "FILES",
+  "events": ["CREATED"],
+  "filter": "extension=\".xml\""
+}
+```
+
+Notes for v1 triggers:
+
+- `trigger.filter` is required by the v1 API schema for triggered routines.
+- The only trigger `source` documented by the swagger is `FILES`.
+- The documented `events` values are `CREATED` and `UPDATED`.
+- The swagger includes `extension = ".csv"` as the canonical filter example; for XML uploads use `extension=".xml"`.
+- Treat the filter string as service-owned syntax, not LINQ or OData. Do not rewrite it as `--filter` CLI syntax.
+- When working with an existing v1 routine, prefer `slcli routine get --api-version v1 <ID>` because the default API version is v2.
+
+Example:
+
+```bash
+slcli routine create \
+  --api-version v1 \
+  --name "ATML XML File Import" \
+  --workspace <WORKSPACE_ID> \
+  --type TRIGGERED \
+  --notebook-id <NOTEBOOK_ID> \
+  --trigger '{"source":"FILES","events":["CREATED"],"filter":"extension=\".xml\""}' \
+  --enabled
+```
+
+#### v2 event-action routines
+
+Use the default `v2` API for event-action routines. These map to the newer
+Routine Service and use `--event` plus `--actions`.
+
+For v2 routines, there is no top-level `filter` field in the create/update
+request. Filtering is event-type-specific and lives inside
+`event.triggers[].configuration`.
+
+Notes for v2 triggers:
+
+- `event.type` selects the event provider/plugin.
+- `event.triggers[]` contains one or more named conditions.
+- Each trigger's `configuration` object is provider-specific; the v2 swagger does not enumerate a universal set of filter keys.
+- Some v2 providers do use a `configuration.filter` field, but it is part of the provider-specific trigger configuration, not a top-level routine field.
+- Other v2 providers use structured condition fields such as `path`, `type`, `comparator`, `thresholds`, and `deadband` instead of a `filter` string.
+- Do not assume the v1 file-trigger filter string syntax applies to v2 routines.
+- When documenting v2 routines, show the exact JSON shape and note that valid configuration keys depend on the event type.
+- Live survey on the demo environment found these v2 event types in use: `TAG`, `TESTRESULTCHANGED`, and `WORKITEMCHANGED`.
+- Live survey on the demo environment found these v2 action types in use: `ALARM` and `NOTEBOOK`.
+
+Minimal v2 shape:
+
+```json
+{
+  "type": "<event-type>",
+  "triggers": [
+    {
+      "name": "<condition-name>",
+      "configuration": {
+        "<provider-specific-key>": "<value>"
+      }
+    }
+  ]
+}
+```
+
+Concrete v2 example from an existing `WORKITEMCHANGED` routine:
+
+```json
+{
+  "event": {
+    "type": "WORKITEMCHANGED",
+    "triggers": [
+      {
+        "name": "8f4db567-9686-4e4b-ac2c-31345cb01691",
+        "configuration": {
+          "filter": "(before.assignedTo != after.assignedTo) && (after.assignedTo = \"a69caa22-7e24-445f-8e9f-084ed98ff6e3\")"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "NOTEBOOK",
+      "triggers": [
+        "8f4db567-9686-4e4b-ac2c-31345cb01691"
+      ],
+      "configuration": {
+        "notebookId": "81d8df26-aeba-4b87-a1eb-d21a10684db2",
+        "parameters": {},
+        "resourceProfile": "DEFAULT",
+        "priority": "LOW",
+        "serviceAccount": "87022613-0b32-4ca9-8cf9-f0291cb0a4d3"
+      }
+    }
+  ]
+}
+```
+
+This example is useful because it shows the important v2 distinction: the filter lives under `event.triggers[].configuration.filter`, and the notebook execution details live under `actions[].configuration`.
+
+Concrete v2 example from an existing `TESTRESULTCHANGED` routine:
+
+```json
+{
+  "event": {
+    "type": "TESTRESULTCHANGED",
+    "triggers": [
+      {
+        "configuration": {
+          "filter": "(before.status != after.status) && (after.programName = \"...\")"
+        }
+      }
+    ]
+  }
+}
+```
+
+This shows that `TESTRESULTCHANGED`, like `WORKITEMCHANGED`, uses a provider-specific string filter under `event.triggers[].configuration.filter`.
+
+Concrete v2 example from an existing `TAG` routine:
+
+```json
+{
+  "event": {
+    "type": "TAG",
+    "triggers": [
+      {
+        "name": "97c1967e-0eea-4276-863a-2b65083e2bd5",
+        "configuration": {
+          "comparator": "GREATER_THAN",
+          "deadband": 2,
+          "path": "*.Health.Temperature.Reading.CPU Core *",
+          "thresholds": ["50"],
+          "type": "DOUBLE"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "ALARM",
+      "triggers": [
+        "97c1967e-0eea-4276-863a-2b65083e2bd5"
+      ],
+      "configuration": {
+        "displayName": "CPU temp on <alarm_channel>",
+        "severity": 3,
+        "dynamicRecipientList": [
+          "alex.starche@emerson.com"
+        ]
+      }
+    }
+  ]
+}
+```
+
+This second example shows the other common v2 pattern: provider-specific structured trigger fields, with no `configuration.filter` at all.
+
 ## Reference docs
 
 Consult these for detailed guidance. Load only what you need for the current task.

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -358,6 +358,11 @@ Two API versions are supported:
 - **v2** (default): General event-action routines — monitor tags, work-item changes, and more; trigger alarms, emails, or notebook executions.
 - **v1**: Notebook-execution routines with SCHEDULED or TRIGGERED types.
 
+Observed on the demo environment:
+
+- v2 event types: `TAG`, `TESTRESULTCHANGED`, `WORKITEMCHANGED`
+- v2 action types: `ALARM`, `NOTEBOOK`
+
 ```bash
 # List routines
 slcli routine list [OPTIONS]
@@ -374,6 +379,9 @@ slcli routine list [OPTIONS]
 
 # Get a single routine by ID
 slcli routine get <ROUTINE_ID> [--api-version v1|v2] [-f json]
+
+# Note: the default API version is v2. Use --api-version v1 when reading or
+# updating notebook routines created through the older Routine Manager service.
 
 # Create a v2 event-action routine
 # --event: JSON object with `type` and `triggers` array
@@ -401,7 +409,7 @@ slcli routine create --api-version v1 \
   --name "On Upload" \
   --type TRIGGERED \
   --notebook-id <NOTEBOOK_ID> \
-  --trigger '{"source":"FILES","events":["CREATED"],"filter":"extension=\".csv\""}'
+  --trigger '{"source":"FILES","events":["CREATED"],"filter":"extension=\".xml\""}'
 
 # Update a routine (only supplied fields are changed)
 slcli routine update <ROUTINE_ID> [--api-version v1|v2] \
@@ -419,6 +427,10 @@ slcli routine delete <ROUTINE_ID> [--api-version v1|v2] [-y]
 ```
 
 ### v2 event JSON structure
+
+For v2 routines, there is no top-level routine `filter` field. Filtering is
+provider-specific and belongs inside `event.triggers[].configuration` when the
+provider supports it.
 
 ```json
 {
@@ -439,6 +451,38 @@ slcli routine delete <ROUTINE_ID> [--api-version v1|v2] [-y]
 
 Supported TAG comparators: `GREATER_THAN`, `LESS_THAN`, `EQUAL`, `NOT_EQUAL`.
 Tag data types: `DOUBLE`, `INT32`, `U_INT64`, `STRING`, `BOOLEAN`.
+
+Some v2 providers use a string filter inside trigger configuration instead of
+structured comparator/path fields. Example from a `WORKITEMCHANGED` routine:
+
+```json
+{
+  "type": "WORKITEMCHANGED",
+  "triggers": [
+    {
+      "name": "8f4db567-9686-4e4b-ac2c-31345cb01691",
+      "configuration": {
+        "filter": "(before.assignedTo != after.assignedTo) && (after.assignedTo = \"a69caa22-7e24-445f-8e9f-084ed98ff6e3\")"
+      }
+    }
+  ]
+}
+```
+
+Another observed string-filter provider is `TESTRESULTCHANGED`:
+
+```json
+{
+  "type": "TESTRESULTCHANGED",
+  "triggers": [
+    {
+      "configuration": {
+        "filter": "(before.status != after.status) && (after.programName = \"...\")"
+      }
+    }
+  ]
+}
+```
 
 ### v2 actions JSON structure
 
@@ -464,6 +508,80 @@ Tag data types: `DOUBLE`, `INT32`, `U_INT64`, `STRING`, `BOOLEAN`.
 ```
 
 The second ALARM entry with trigger `nisystemlink_no_triggers_breached` is required by the API — it handles the alarm clear/reset state. Email notifications are delivered via `dynamicRecipientList` inside the ALARM action configuration. Severity levels: 1 (low) – 4 (critical).
+
+Observed NOTEBOOK action shape in v2 routines:
+
+```json
+[
+  {
+    "type": "NOTEBOOK",
+    "triggers": ["8f4db567-9686-4e4b-ac2c-31345cb01691"],
+    "configuration": {
+      "notebookId": "81d8df26-aeba-4b87-a1eb-d21a10684db2",
+      "parameters": {},
+      "resourceProfile": "DEFAULT",
+      "priority": "LOW",
+      "serviceAccount": "87022613-0b32-4ca9-8cf9-f0291cb0a4d3"
+    }
+  }
+]
+```
+
+Observed ALARM action shape in v2 TAG routines:
+
+```json
+[
+  {
+    "type": "ALARM",
+    "triggers": ["97c1967e-0eea-4276-863a-2b65083e2bd5"],
+    "configuration": {
+      "displayName": "CPU temp on <alarm_channel>",
+      "description": "CPU is kind of hot.",
+      "severity": 3,
+      "condition": "Greater than: 50",
+      "dynamicRecipientList": [
+        "alex.starche@emerson.com",
+        "23835d45.emerson.onmicrosoft.com@amer.teams.ms"
+      ]
+    }
+  },
+  {
+    "type": "ALARM",
+    "triggers": ["nisystemlink_no_triggers_breached"],
+    "configuration": null
+  }
+]
+```
+
+### Full example: v2 work item change triggers notebook execution
+
+```bash
+slcli routine create \
+  --name "Work Item Assigned To Me" \
+  --description "Run a notebook when a work item is assigned to me" \
+  --workspace <WORKSPACE_ID> \
+  --enabled \
+  --event '{
+    "type": "WORKITEMCHANGED",
+    "triggers": [{
+      "name": "8f4db567-9686-4e4b-ac2c-31345cb01691",
+      "configuration": {
+        "filter": "(before.assignedTo != after.assignedTo) && (after.assignedTo = \"<USER_ID>\")"
+      }
+    }]
+  }' \
+  --actions '[{
+    "type": "NOTEBOOK",
+    "triggers": ["8f4db567-9686-4e4b-ac2c-31345cb01691"],
+    "configuration": {
+      "notebookId": "<NOTEBOOK_ID>",
+      "parameters": {},
+      "resourceProfile": "DEFAULT",
+      "priority": "LOW",
+      "serviceAccount": "<SERVICE_ACCOUNT_ID>"
+    }
+  }]'
+```
 
 ### Full example: tag threshold monitor with alarm + email
 

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -411,6 +411,9 @@ slcli routine create --api-version v1 \
   --notebook-id <NOTEBOOK_ID> \
   --trigger '{"source":"FILES","events":["CREATED"],"filter":"extension=\".xml\""}'
 
+# For compound FILES filters and provider-specific live examples, load
+# routine-examples.md in this folder.
+
 # Update a routine (only supplied fields are changed)
 slcli routine update <ROUTINE_ID> [--api-version v1|v2] \
   [--name TEXT] [--description TEXT] [--workspace TEXT] \
@@ -449,7 +452,7 @@ provider supports it.
 }
 ```
 
-Supported TAG comparators: `GREATER_THAN`, `LESS_THAN`, `EQUAL`, `NOT_EQUAL`.
+Observed TAG comparators include `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `EQUAL`, `NOT_EQUAL`, and `IN_RANGE`.
 Tag data types: `DOUBLE`, `INT32`, `U_INT64`, `STRING`, `BOOLEAN`.
 
 Some v2 providers use a string filter inside trigger configuration instead of
@@ -509,118 +512,13 @@ Another observed string-filter provider is `TESTRESULTCHANGED`:
 
 The second ALARM entry with trigger `nisystemlink_no_triggers_breached` is required by the API — it handles the alarm clear/reset state. Email notifications are delivered via `dynamicRecipientList` inside the ALARM action configuration. Severity levels: 1 (low) – 4 (critical).
 
-Observed NOTEBOOK action shape in v2 routines:
+Load [routine-examples.md](./routine-examples.md) for sanitized live examples covering:
 
-```json
-[
-  {
-    "type": "NOTEBOOK",
-    "triggers": ["8f4db567-9686-4e4b-ac2c-31345cb01691"],
-    "configuration": {
-      "notebookId": "81d8df26-aeba-4b87-a1eb-d21a10684db2",
-      "parameters": {},
-      "resourceProfile": "DEFAULT",
-      "priority": "LOW",
-      "serviceAccount": "87022613-0b32-4ca9-8cf9-f0291cb0a4d3"
-    }
-  }
-]
-```
-
-Observed ALARM action shape in v2 TAG routines:
-
-```json
-[
-  {
-    "type": "ALARM",
-    "triggers": ["97c1967e-0eea-4276-863a-2b65083e2bd5"],
-    "configuration": {
-      "displayName": "CPU temp on <alarm_channel>",
-      "description": "CPU is kind of hot.",
-      "severity": 3,
-      "condition": "Greater than: 50",
-      "dynamicRecipientList": [
-        "user@example.com",
-        "team-notifications@example.com"
-      ]
-    }
-  },
-  {
-    "type": "ALARM",
-    "triggers": ["nisystemlink_no_triggers_breached"],
-    "configuration": null
-  }
-]
-```
-
-### Full example: v2 work item change triggers notebook execution
-
-```bash
-slcli routine create \
-  --name "Work Item Assigned To Me" \
-  --description "Run a notebook when a work item is assigned to me" \
-  --workspace <WORKSPACE_ID> \
-  --enabled \
-  --event '{
-    "type": "WORKITEMCHANGED",
-    "triggers": [{
-      "name": "8f4db567-9686-4e4b-ac2c-31345cb01691",
-      "configuration": {
-        "filter": "(before.assignedTo != after.assignedTo) && (after.assignedTo = \"<USER_ID>\")"
-      }
-    }]
-  }' \
-  --actions '[{
-    "type": "NOTEBOOK",
-    "triggers": ["8f4db567-9686-4e4b-ac2c-31345cb01691"],
-    "configuration": {
-      "notebookId": "<NOTEBOOK_ID>",
-      "parameters": {},
-      "resourceProfile": "DEFAULT",
-      "priority": "LOW",
-      "serviceAccount": "<SERVICE_ACCOUNT_ID>"
-    }
-  }]'
-```
-
-### Full example: tag threshold monitor with alarm + email
-
-```bash
-slcli routine create \
-  --name "Fred Tag Monitor" \
-  --description "Alert when fred.test.* exceeds 10.2" \
-  --enabled \
-  --event '{
-    "type": "TAG",
-    "triggers": [{
-      "name": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "configuration": {
-        "comparator": "GREATER_THAN",
-        "path": "fred.test.*",
-        "thresholds": ["10.2"],
-        "type": "DOUBLE"
-      }
-    }]
-  }' \
-  --actions '[
-    {
-      "type": "ALARM",
-      "triggers": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
-      "configuration": {
-        "displayName": "Fred Test Tag Alarm",
-        "description": "Tag fred.test.* exceeded 10.2",
-        "severity": 4,
-        "condition": "Greater than: 10.2",
-        "dynamicRecipientList": ["fred.visser@emerson.com"]
-      }
-    },
-    {
-      "type": "ALARM",
-      "triggers": ["nisystemlink_no_triggers_breached"],
-      "configuration": null
-    }
-  ]'
-```
+- v1 FILES filters that combine workspace checks, `name.Contains(...)`, and extension matching
+- v2 TAG routines using `IN_RANGE`, `NOT_EQUAL`, and `GREATER_THAN_OR_EQUAL`
+- v2 `TESTRESULTCHANGED` filters with nested field checks, indexed property access, and `DateTime.parse(...)`
+- v2 `WORKITEMCHANGED` filters with `.Any(...)` and `!Contains(...)`
+- Representative NOTEBOOK and ALARM action payloads
 
 ## comment — Resource comments
 

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -540,8 +540,8 @@ Observed ALARM action shape in v2 TAG routines:
       "severity": 3,
       "condition": "Greater than: 50",
       "dynamicRecipientList": [
-        "alex.starche@emerson.com",
-        "23835d45.emerson.onmicrosoft.com@amer.teams.ms"
+        "user@example.com",
+        "team-notifications@example.com"
       ]
     }
   },

--- a/slcli/skills/slcli/references/routine-examples.md
+++ b/slcli/skills/slcli/references/routine-examples.md
@@ -1,0 +1,186 @@
+# Routine Configuration Examples
+
+Load this file when you need sanitized live examples for provider-specific
+routine payloads beyond the minimal syntax in `commands.md`.
+
+## v1 notebook routines
+
+### Scheduled notebook execution
+
+```bash
+slcli routine create --api-version v1 \
+  --name "Daily Notebook" \
+  --type SCHEDULED \
+  --notebook-id <NOTEBOOK_ID> \
+  --schedule '{"startTime":"2026-01-01T00:00:00Z","repeat":"DAY"}'
+```
+
+### FILES trigger with compound filter
+
+Observed v1 routines use the service-owned `trigger.filter` string directly.
+This can be more expressive than the simple `extension=".xml"` example.
+
+```json
+{
+  "trigger": {
+    "source": "FILES",
+    "events": ["CREATED"],
+    "filter": "workspace = \"<WORKSPACE_ID>\" && (name.Contains(\"Specs\") && extension = \"xlsx\")"
+  },
+  "execution": {
+    "type": "NOTEBOOK",
+    "definition": {
+      "notebookId": "<NOTEBOOK_ID>"
+    }
+  }
+}
+```
+
+Notes:
+
+- Keep the v1 filter string in the service's own syntax.
+- Observed FILES filters can combine workspace checks, `name.Contains(...)`, and extension checks.
+
+## v2 event-action routines
+
+### TAG alarm with structured trigger fields
+
+Observed TAG routines can use comparator-driven configuration instead of a
+string `filter`.
+
+```json
+{
+  "event": {
+    "type": "TAG",
+    "triggers": [
+      {
+        "configuration": {
+          "comparator": "IN_RANGE",
+          "deadband": 2,
+          "path": "*.path.to.tag",
+          "thresholds": ["1", "12"],
+          "type": "INT"
+        }
+      },
+      {
+        "configuration": {
+          "comparator": "NOT_EQUAL",
+          "path": "*.path.to.tag",
+          "thresholds": ["3"],
+          "type": "INT"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "ALARM",
+      "configuration": {
+        "displayName": "Alarm Name",
+        "severity": 4,
+        "condition": "In range: [1, 12]",
+        "dynamicRecipientList": ["user@example.com"]
+      }
+    }
+  ]
+}
+```
+
+### TAG health monitor with threshold alarm
+
+```json
+{
+  "event": {
+    "type": "TAG",
+    "triggers": [
+      {
+        "configuration": {
+          "comparator": "GREATER_THAN_OR_EQUAL",
+          "deadband": 5,
+          "path": "*.Health.Memory.UsePercentage",
+          "thresholds": ["80"],
+          "type": "DOUBLE"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "ALARM",
+      "configuration": {
+        "displayName": "High memory usage on <system>",
+        "severity": 3,
+        "condition": "Greater than or equal: 80"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- Observed TAG comparators include `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `NOT_EQUAL`, and `IN_RANGE`.
+- Alarm-producing TAG routines still need the clear/reset action that uses trigger `nisystemlink_no_triggers_breached`.
+
+### TESTRESULTCHANGED filter with nested fields and time parsing
+
+```json
+{
+  "event": {
+    "type": "TESTRESULTCHANGED",
+    "triggers": [
+      {
+        "configuration": {
+          "filter": "(before.partNumber != after.partNumber) && ((after.status.statusType = \"Done\" && after.hostName = \"<HOST_NAME>\" && after.operator = \"<OPERATOR>\" && after.properties[\"key\"] = \"value\" || after.programName = \"Test Name\" && DateTime(after.updatedAt) > DateTime.parse(\"2026-05-14T19:23:15.275Z\")))"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "NOTEBOOK",
+      "configuration": {
+        "notebookId": "<NOTEBOOK_ID>",
+        "resourceProfile": "LOW",
+        "priority": "MEDIUM",
+        "serviceAccount": "<SERVICE_ACCOUNT_ID>"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- Observed filters can combine before/after comparisons, nested status fields, indexed property lookups, and `DateTime.parse(...)`.
+
+### WORKITEMCHANGED filter with collection predicates
+
+```json
+{
+  "event": {
+    "type": "WORKITEMCHANGED",
+    "triggers": [
+      {
+        "configuration": {
+          "filter": "(before.assignedTo != after.assignedTo) && (after.resources.assets.selections.Any(s => s.id == \"<ASSET_ID>\") && !after.description.Contains(\"description\") && after.templateId = \"123\")"
+        }
+      }
+    ]
+  },
+  "actions": [
+    {
+      "type": "NOTEBOOK",
+      "configuration": {
+        "resourceProfile": "HIGH",
+        "priority": "HIGH"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- Observed `WORKITEMCHANGED` filters can use `.Any(...)`, negated string checks, and exact template matching.
+- Common NOTEBOOK action fields across v2 examples are `notebookId`, `parameters`, `resourceProfile`, `priority`, and `serviceAccount`.


### PR DESCRIPTION
## Summary
- expand the `slcli routine` skill documentation with clearer routine-management guidance
- document trigger-related details in the routine command reference
- add a Towncrier doc fragment for the documentation update

## Testing
- `poetry run towncrier build --draft --version 1.2.3`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- `doc`: improve `slcli routine` skill documentation and trigger guidance