### PR TITLE
Improve Towncrier CI for dependency bot PRs

### DIFF
--- a/.github/workflows/bot-towncrier-fragment.yml
+++ b/.github/workflows/bot-towncrier-fragment.yml
@@ -15,6 +15,7 @@ jobs:
       github.repository == 'ni-kismet/systemlink-cli' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
+        github.event.pull_request.user.login == 'renovate' ||
         github.event.pull_request.user.login == 'renovate[bot]' ||
         github.event.pull_request.user.login == 'dependabot[bot]'
       )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,27 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
+      - name: Generate fallback Towncrier fragment for dependency bot PRs
+        if: >
+          github.event_name == 'pull_request' &&
+          (
+            github.event.pull_request.user.login == 'renovate' ||
+            github.event.pull_request.user.login == 'renovate[bot]' ||
+            github.event.pull_request.user.login == 'dependabot[bot]'
+          )
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if git diff --name-only origin/${BASE_REF}...HEAD -- newsfragments | grep -q '^newsfragments/'; then
+            echo "Newsfragment already present on PR branch."
+            exit 0
+          fi
+
+          branch_topic="${HEAD_REF#*/}"
+          poetry run python scripts/write_renovate_towncrier_fragment.py --pr-title "$PR_TITLE" "$branch_topic"
+
       - name: Require Towncrier news fragment
         if: ${{ github.event_name == 'pull_request' }}
         run: poetry run towncrier check --compare-with origin/${{ github.base_ref }}

--- a/newsfragments/towncrier-ci-bot-prs.misc.md
+++ b/newsfragments/towncrier-ci-bot-prs.misc.md
@@ -1,0 +1,1 @@
+Improve CI handling of Towncrier fragments for dependency bot pull requests.

--- a/scripts/write_renovate_towncrier_fragment.py
+++ b/scripts/write_renovate_towncrier_fragment.py
@@ -40,7 +40,7 @@ def build_fragment_content_from_title(pr_title: str) -> str:
             break
 
     if not content:
-        return "Update dependencies"
+        return "Update dependencies."
 
     if content[-1] not in ".!?":
         content = f"{content}."
@@ -170,11 +170,23 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         Parsed arguments.
     """
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("data_file", nargs="?", type=Path)
-    parser.add_argument("branch_topic")
+    parser.add_argument("first_arg")
+    parser.add_argument("second_arg", nargs="?")
     parser.add_argument("--pr-title")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.pr_title is not None:
+        args.branch_topic = args.first_arg
+        args.data_file = Path(args.second_arg) if args.second_arg is not None else None
+        return args
+
+    if args.second_arg is None:
+        parser.error("data_file and branch_topic are required unless --pr-title is provided")
+
+    args.data_file = Path(args.first_arg)
+    args.branch_topic = args.second_arg
+    return args
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/write_renovate_towncrier_fragment.py
+++ b/scripts/write_renovate_towncrier_fragment.py
@@ -24,6 +24,30 @@ def sanitize_fragment_stem(branch_topic: str) -> str:
     return sanitized or "dependencies"
 
 
+def build_fragment_content_from_title(pr_title: str) -> str:
+    """Build fragment content directly from a dependency PR title.
+
+    Args:
+        pr_title: Pull request title.
+
+    Returns:
+        A concise Towncrier fragment sentence.
+    """
+    content = pr_title.strip()
+    for prefix in ("chore(deps): ", "chore: "):
+        if content.startswith(prefix):
+            content = content[len(prefix) :]
+            break
+
+    if not content:
+        return "Update dependencies"
+
+    if content[-1] not in ".!?":
+        content = f"{content}."
+
+    return content
+
+
 def _join_entries(entries: Sequence[str]) -> str:
     """Join dependency entries into a natural-language list.
 
@@ -118,6 +142,24 @@ def write_fragment(data_file: Path, branch_topic: str, repo_root: Path) -> Path:
     return fragment_path
 
 
+def write_title_fragment(pr_title: str, branch_topic: str, repo_root: Path) -> Path:
+    """Write a fragment derived from a dependency PR title.
+
+    Args:
+        pr_title: Pull request title.
+        branch_topic: Branch topic used for deterministic naming.
+        repo_root: Repository root directory.
+
+    Returns:
+        The path to the generated fragment.
+    """
+    content = build_fragment_content_from_title(pr_title)
+    fragment_name = f"deps-{sanitize_fragment_stem(branch_topic)}.patch.md"
+    fragment_path = repo_root / "newsfragments" / fragment_name
+    fragment_path.write_text(f"{content}\n", encoding="utf-8")
+    return fragment_path
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments.
 
@@ -128,8 +170,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         Parsed arguments.
     """
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("data_file", type=Path)
+    parser.add_argument("data_file", nargs="?", type=Path)
     parser.add_argument("branch_topic")
+    parser.add_argument("--pr-title")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     return parser.parse_args(argv)
 
@@ -144,7 +187,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         Process exit code.
     """
     args = parse_args(argv)
-    fragment_path = write_fragment(args.data_file, args.branch_topic, args.repo_root)
+    if args.pr_title is not None:
+        fragment_path = write_title_fragment(args.pr_title, args.branch_topic, args.repo_root)
+    else:
+        if args.data_file is None:
+            raise ValueError("data_file is required unless --pr-title is provided")
+        fragment_path = write_fragment(args.data_file, args.branch_topic, args.repo_root)
     print(fragment_path)
     return 0
 

--- a/tests/unit/test_write_renovate_towncrier_fragment.py
+++ b/tests/unit/test_write_renovate_towncrier_fragment.py
@@ -3,9 +3,12 @@
 import json
 from pathlib import Path
 
+import pytest
 from scripts.write_renovate_towncrier_fragment import (
     build_fragment_content,
     build_fragment_content_from_title,
+    main,
+    parse_args,
     sanitize_fragment_stem,
     write_fragment,
     write_title_fragment,
@@ -45,6 +48,11 @@ def test_build_fragment_content_from_title_normalizes_dependency_pr_title() -> N
     )
 
 
+def test_build_fragment_content_from_title_handles_empty_title() -> None:
+    """Empty dependency PR titles should still produce a punctuated fragment."""
+    assert build_fragment_content_from_title("   ") == "Update dependencies."
+
+
 def test_write_fragment_creates_deterministic_patch_file(tmp_path: Path) -> None:
     """The helper should write a patch fragment under newsfragments/."""
     repo_root = tmp_path
@@ -78,6 +86,57 @@ def test_write_title_fragment_creates_deterministic_patch_file(tmp_path: Path) -
     assert (
         fragment_path == repo_root / "newsfragments" / "deps-python-multipart-0-x-lockfile.patch.md"
     )
+    assert (
+        fragment_path.read_text(encoding="utf-8")
+        == "Update dependency python-multipart to v0.0.29.\n"
+    )
+
+
+def test_parse_args_accepts_data_file_and_branch_topic() -> None:
+    """CLI should preserve the existing Renovate invocation order."""
+    args = parse_args(["upgrades.json", "python-runtime-dependencies"])
+
+    assert args.data_file == Path("upgrades.json")
+    assert args.branch_topic == "python-runtime-dependencies"
+    assert args.pr_title is None
+
+
+def test_parse_args_accepts_pr_title_without_data_file() -> None:
+    """CLI should accept PR-title fallback mode with only a branch topic."""
+    args = parse_args(["--pr-title", "chore(deps): Update rich", "python-runtime-dependencies"])
+
+    assert args.data_file is None
+    assert args.branch_topic == "python-runtime-dependencies"
+    assert args.pr_title == "chore(deps): Update rich"
+
+
+def test_parse_args_requires_branch_topic_without_pr_title() -> None:
+    """CLI should reject data-file mode when branch topic is missing."""
+    with pytest.raises(SystemExit):
+        parse_args(["upgrades.json"])
+
+
+def test_main_writes_title_fragment_and_prints_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI entrypoint should write a fragment in PR-title fallback mode."""
+    (tmp_path / "newsfragments").mkdir()
+
+    exit_code = main(
+        [
+            "--pr-title",
+            "chore(deps): Update dependency python-multipart to v0.0.29",
+            "python-multipart-0.x-lockfile",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+
+    fragment_path = tmp_path / "newsfragments" / "deps-python-multipart-0-x-lockfile.patch.md"
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.strip() == str(fragment_path)
     assert (
         fragment_path.read_text(encoding="utf-8")
         == "Update dependency python-multipart to v0.0.29.\n"

--- a/tests/unit/test_write_renovate_towncrier_fragment.py
+++ b/tests/unit/test_write_renovate_towncrier_fragment.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 from scripts.write_renovate_towncrier_fragment import (
     build_fragment_content,
+    build_fragment_content_from_title,
     sanitize_fragment_stem,
     write_fragment,
+    write_title_fragment,
 )
 
 
@@ -33,6 +35,16 @@ def test_build_fragment_content_summarizes_grouped_updates() -> None:
     )
 
 
+def test_build_fragment_content_from_title_normalizes_dependency_pr_title() -> None:
+    """Dependency PR titles should become valid fragment text."""
+    assert (
+        build_fragment_content_from_title(
+            "chore(deps): Update dependency python-multipart to v0.0.29"
+        )
+        == "Update dependency python-multipart to v0.0.29."
+    )
+
+
 def test_write_fragment_creates_deterministic_patch_file(tmp_path: Path) -> None:
     """The helper should write a patch fragment under newsfragments/."""
     repo_root = tmp_path
@@ -50,3 +62,23 @@ def test_write_fragment_creates_deterministic_patch_file(tmp_path: Path) -> None
         fragment_path == repo_root / "newsfragments" / "deps-python-runtime-dependencies.patch.md"
     )
     assert fragment_path.read_text(encoding="utf-8") == "Update dependency rich to 15.0.0\n"
+
+
+def test_write_title_fragment_creates_deterministic_patch_file(tmp_path: Path) -> None:
+    """PR-title fallback should write the same deterministic patch file pattern."""
+    repo_root = tmp_path
+    (repo_root / "newsfragments").mkdir()
+
+    fragment_path = write_title_fragment(
+        "chore(deps): Update dependency python-multipart to v0.0.29",
+        "python-multipart-0.x-lockfile",
+        repo_root,
+    )
+
+    assert (
+        fragment_path == repo_root / "newsfragments" / "deps-python-multipart-0-x-lockfile.patch.md"
+    )
+    assert (
+        fragment_path.read_text(encoding="utf-8")
+        == "Update dependency python-multipart to v0.0.29.\n"
+    )


### PR DESCRIPTION
## Summary
- generate a deterministic fallback Towncrier fragment in CI for Renovate and Dependabot pull requests before the PR fragment check runs
- allow the bot fragment workflow to handle the `renovate` actor in addition to existing bot identities
- add helper coverage for PR-title-based fragment generation

## Testing
- `poetry run pytest tests/unit/test_write_renovate_towncrier_fragment.py -q`
- `poetry run mypy scripts/write_renovate_towncrier_fragment.py tests/unit/test_write_renovate_towncrier_fragment.py`
- `poetry run ni-python-styleguide lint scripts/write_renovate_towncrier_fragment.py tests/unit/test_write_renovate_towncrier_fragment.py`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/bot-towncrier-fragment.yml`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- `misc`: improve CI handling of Towncrier fragments for dependency bot pull requests

## Notes
- includes `newsfragments/towncrier-ci-bot-prs.misc.md`
- excludes the local Test Monitor changes from the mixed main worktree
