### PR TITLE
Fix Windows SBOM RECORD lookup in release tests

### DIFF
--- a/newsfragments/windows-sbom-record-paths.patch.md
+++ b/newsfragments/windows-sbom-record-paths.patch.md
@@ -1,0 +1,1 @@
+Normalize SBOM RECORD path matching so release-time metadata extraction works on Windows runners.

--- a/scripts/enrich_sbom.py
+++ b/scripts/enrich_sbom.py
@@ -78,7 +78,8 @@ def normalize_license(raw: Optional[str]) -> Optional[str]:
 def find_record_file(dist: importlib.metadata.Distribution) -> Optional[Path]:
     """Locate the dist-info RECORD file via the public distribution API."""
     for package_path in dist.files or []:
-        if str(package_path).endswith(".dist-info/RECORD"):
+        package_path_str = str(package_path).replace("\\", "/")
+        if package_path_str.endswith(".dist-info/RECORD"):
             located = Path(str(dist.locate_file(package_path)))
             if located.exists():
                 return located

--- a/tests/unit/test_enrich_sbom.py
+++ b/tests/unit/test_enrich_sbom.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from pathlib import Path
+from pathlib import Path, PurePath, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import pytest
@@ -43,7 +43,7 @@ class FakeMetadata:
 class FakeDistribution:
     """Test double exposing only the public distribution API used by the script."""
 
-    def __init__(self, record_relative_path: Path, record_location: Path) -> None:
+    def __init__(self, record_relative_path: PurePath, record_location: Path) -> None:
         """Create a fake distribution with a locatable RECORD file."""
         self.metadata = FakeMetadata(
             {
@@ -57,7 +57,7 @@ class FakeDistribution:
         self.files = [record_relative_path]
         self._record_location = record_location
 
-    def locate_file(self, path: Path) -> Path:
+    def locate_file(self, path: PurePath) -> Path:
         """Resolve a relative package path to the fake RECORD file."""
         assert path == self.files[0]
         return self._record_location
@@ -114,3 +114,26 @@ def test_get_package_metadata_uses_public_record_lookup(
             "hashes": [{"alg": "SHA-256", "content": digest_hex}],
         }
     }
+
+
+def test_get_package_metadata_accepts_windows_style_record_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Package metadata extraction should handle Windows-style RECORD paths."""
+    record_relative_path = PureWindowsPath("demo_package-1.0.0.dist-info/RECORD")
+    record_location = tmp_path / "demo_package-1.0.0.dist-info" / "RECORD"
+    record_location.parent.mkdir(parents=True)
+
+    digest_hex = "ef" * 32
+    digest_b64 = base64.urlsafe_b64encode(bytes.fromhex(digest_hex)).decode("ascii")
+    record_location.write_text(
+        f"demo_package/__init__.py,sha256={digest_b64},123\n",
+        encoding="utf-8",
+    )
+
+    fake_dist = FakeDistribution(record_relative_path, record_location)
+    monkeypatch.setattr("importlib.metadata.distributions", lambda: [fake_dist])
+
+    metadata = get_package_metadata()
+
+    assert metadata["demo-package"]["hashes"] == [{"alg": "SHA-256", "content": digest_hex}]


### PR DESCRIPTION
## Summary
- normalize dist-info RECORD path matching so Windows-style separators are handled during SBOM metadata extraction
- add a regression test covering Windows-style RECORD paths in importlib metadata
- add a patch Towncrier fragment for the release fix

## Testing
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run towncrier build --draft`
- `poetry run pytest tests/unit`
- `poetry run pytest`

## Release Notes
- `patch`: fix Windows SBOM RECORD path matching used during release-time metadata enrichment