### PR TITLE
Fix Windows webapp dry-run preview paths

### DIFF
--- a/newsfragments/windows-webapp-dry-run-paths.patch.md
+++ b/newsfragments/windows-webapp-dry-run-paths.patch.md
@@ -1,0 +1,1 @@
+Normalize webapp dry-run file paths so preview output uses forward slashes on Windows.

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -126,7 +126,9 @@ def _ensure_supported_webapp_template(template: str) -> None:
 def _template_relative_file_list(template_dir: Path) -> List[str]:
     """Return the relative file list for a bundled template."""
     return sorted(
-        str(path.relative_to(template_dir)) for path in template_dir.rglob("*") if path.is_file()
+        path.relative_to(template_dir).as_posix()
+        for path in template_dir.rglob("*")
+        if path.is_file()
     )
 
 

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -4,7 +4,7 @@ import io
 import tarfile
 from hashlib import sha256
 from json import dumps, loads
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List
 from unittest.mock import patch
 
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 from pytest import MonkeyPatch
 
+from slcli import webapp_bootstrap
 from slcli.main import cli
 from slcli.utils import ExitCodes
 from .test_utils import patch_keyring
@@ -430,6 +431,31 @@ def test_webapp_new_dry_run_does_not_write_files(tmp_path: Path, monkeypatch: Mo
     assert "Package list:" in result.output
     assert "Config mutations:" in result.output
     assert "src/app/app.module.ts" in result.output
+
+
+def test_template_relative_file_list_normalizes_windows_paths(monkeypatch: MonkeyPatch) -> None:
+    class FakeWindowsFile:
+        def __init__(self, raw_path: str) -> None:
+            self._path = PureWindowsPath(raw_path)
+
+        def is_file(self) -> bool:
+            return True
+
+        def relative_to(self, other: Path) -> PureWindowsPath:
+            return self._path.relative_to(PureWindowsPath(str(other)))
+
+    def fake_rglob(_self: Path, _pattern: str) -> list[FakeWindowsFile]:
+        return [
+            FakeWindowsFile("C:/template/src/app/app.module.ts"),
+            FakeWindowsFile("C:/template/src/styles.scss"),
+        ]
+
+    monkeypatch.setattr(Path, "rglob", fake_rglob)
+
+    assert webapp_bootstrap._template_relative_file_list(Path("C:/template")) == [
+        "src/app/app.module.ts",
+        "src/styles.scss",
+    ]
 
 
 def test_webapp_new_plugin_manager_writes_packaging_metadata(


### PR DESCRIPTION
## Summary
- normalize webapp dry-run template paths to forward-slash output across platforms
- add a regression test covering Windows-style relative paths

## Testing
- poetry run ni-python-styleguide lint slcli tests scripts
- poetry run mypy slcli tests
- poetry run pytest -q
- poetry run towncrier check --compare-with origin/main

## Release Notes
- patch: normalize Windows webapp dry-run preview path output

## Notes
- scanned for the same relative-path string formatting pattern elsewhere in slcli and did not find another match