### PR TITLE
Fix customfield export/create linked-resource round trips

### DIFF
--- a/newsfragments/fix-customfield-linked-resource-roundtrip.patch.md
+++ b/newsfragments/fix-customfield-linked-resource-roundtrip.patch.md
@@ -1,0 +1,1 @@
+Fix custom field export/create round-trips for linked-resource DFFs by accepting exported field type values and writing importable export payloads.

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -49,6 +49,16 @@ VALID_FIELD_TYPES = [
     "LinkedResource",
 ]
 
+_FIELD_TYPE_CANONICAL_MAP = {
+    "text": "TEXT",
+    "number": "NUMBER",
+    "boolean": "BOOLEAN",
+    "enum": "ENUM",
+    "datetime": "DATE_TIME",
+    "table": "TABLE",
+    "linkedresource": "LINKED_RESOURCE",
+}
+
 # Help text for resource type parameter
 RESOURCE_TYPE_HELP = f"Resource type. Valid values: {', '.join(VALID_RESOURCE_TYPES)}"
 
@@ -162,11 +172,70 @@ def validate_field_type(field_type: str) -> None:
     Raises:
         click.ClickException: If the field type is not valid
     """
-    if field_type not in VALID_FIELD_TYPES:
+    normalized_field_type = "".join(ch for ch in field_type if ch.isalnum()).lower()
+    if normalized_field_type not in _FIELD_TYPE_CANONICAL_MAP:
         valid_types_str = ", ".join(VALID_FIELD_TYPES)
         raise click.ClickException(
             f"Invalid field type: '{field_type}'. " f"Valid types are: {valid_types_str}"
         )
+
+
+def _canonicalize_field_type(field_type: str) -> str:
+    """Convert user-facing or exported field type values to API enum values."""
+    validate_field_type(field_type)
+    normalized_field_type = "".join(ch for ch in field_type if ch.isalnum()).lower()
+    return _FIELD_TYPE_CANONICAL_MAP[normalized_field_type]
+
+
+def _coerce_dff_payload_to_import_format(data: Any) -> Dict[str, Any]:
+    """Normalize imported/exported DFF payloads into the create/update envelope."""
+    if isinstance(data, list):
+        return {"configurations": data}
+
+    if isinstance(data, dict):
+        if "configuration" in data and "configurations" not in data:
+            configuration = data.get("configuration")
+            return {
+                "configurations": [configuration] if configuration else [],
+                "groups": data.get("groups", []),
+                "fields": data.get("fields", []),
+            }
+
+        if "configurations" not in data:
+            return {"configurations": [data]}
+
+        return data
+
+    return {"configurations": [data]}
+
+
+def _normalize_dff_payload_for_write(data: Any) -> Dict[str, Any]:
+    """Prepare DFF create/update payloads for API submission."""
+    normalized_data = _coerce_dff_payload_to_import_format(data)
+
+    configurations = normalized_data.get("configurations", [])
+    for i, config in enumerate(configurations):
+        if isinstance(config, dict):
+            resource_type = config.get("resourceType")
+            if resource_type:
+                try:
+                    validate_resource_type(resource_type)
+                except click.ClickException as e:
+                    raise click.ClickException(
+                        f"Invalid resource type in configuration {i + 1}: {e.message}"
+                    )
+
+    fields = normalized_data.get("fields", [])
+    for i, field in enumerate(fields):
+        if isinstance(field, dict):
+            field_type = field.get("type")
+            if field_type:
+                try:
+                    field["type"] = _canonicalize_field_type(field_type)
+                except click.ClickException as e:
+                    raise click.ClickException(f"Invalid field type in field {i + 1}: {e.message}")
+
+    return normalized_data
 
 
 def _query_all_groups(
@@ -441,41 +510,7 @@ def register_dff_commands(cli: Any) -> None:
         url = f"{get_base_url()}/nidynamicformfields/v1/configurations"
 
         try:
-            data = load_json_file(input_file)
-
-            # Ensure data is in the expected format
-            if isinstance(data, dict) and "configurations" not in data:
-                # Wrap single configuration
-                data = {"configurations": [data]}
-            elif isinstance(data, list):
-                # Wrap list of configurations
-                data = {"configurations": data}
-
-            # Validate resource types in configurations
-            configurations = data.get("configurations", [])
-            for i, config in enumerate(configurations):
-                if isinstance(config, dict):
-                    resource_type = config.get("resourceType")
-                    if resource_type:
-                        try:
-                            validate_resource_type(resource_type)
-                        except click.ClickException as e:
-                            raise click.ClickException(
-                                f"Invalid resource type in configuration {i + 1}: {e.message}"
-                            )
-
-            # Validate field types in fields
-            fields = data.get("fields", [])
-            for i, field in enumerate(fields):
-                if isinstance(field, dict):
-                    field_type = field.get("type")
-                    if field_type:
-                        try:
-                            validate_field_type(field_type)
-                        except click.ClickException as e:
-                            raise click.ClickException(
-                                f"Invalid field type in field {i + 1}: {e.message}"
-                            )
+            data = _normalize_dff_payload_for_write(load_json_file(input_file))
 
             # Make API request without automatic error handling to parse validation errors
             resp = make_api_request("POST", url, data, handle_errors=False)
@@ -563,13 +598,7 @@ def register_dff_commands(cli: Any) -> None:
         url = f"{get_base_url()}/nidynamicformfields/v1/update-configurations"
 
         try:
-            data = load_json_file(input_file)
-
-            # Ensure data is in the expected format
-            if isinstance(data, dict) and "configurations" not in data:
-                data = {"configurations": [data]}
-            elif isinstance(data, list):
-                data = {"configurations": data}
+            data = _normalize_dff_payload_for_write(load_json_file(input_file))
 
             resp = make_api_request("POST", url, data, handle_errors=False)
             response_data = resp.json() if resp.text.strip() else {}
@@ -774,11 +803,16 @@ def register_dff_commands(cli: Any) -> None:
             full_url = f"{url}?{query_string}"
 
             resp = make_api_request("GET", full_url)
-            data = resp.json()
+            data = _coerce_dff_payload_to_import_format(resp.json())
 
             # Generate output filename if not provided
             if not output:
-                config_name = data.get("configuration", {}).get("name", f"config-{config_id}")
+                configurations = data.get("configurations", [])
+                config_name = (
+                    configurations[0].get("name", f"config-{config_id}")
+                    if configurations
+                    else f"config-{config_id}"
+                )
                 safe_name = sanitize_filename(config_name, f"config-{config_id}")
                 output = f"{safe_name}.json"
 

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -201,7 +201,7 @@ def _coerce_dff_payload_to_import_format(data: Any) -> Dict[str, Any]:
         if "configuration" in data and "configurations" not in data:
             configuration = data.get("configuration")
             return {
-                "configurations": [configuration] if configuration else [],
+                "configurations": [configuration] if configuration is not None else [],
                 "groups": data.get("groups", []),
                 "fields": data.get("fields", []),
             }

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -172,6 +172,11 @@ def validate_field_type(field_type: str) -> None:
     Raises:
         click.ClickException: If the field type is not valid
     """
+    if not isinstance(field_type, str):
+        raise click.ClickException(
+            f"Invalid field type: '{field_type}'. Field type must be a string."
+        )
+
     normalized_field_type = "".join(ch for ch in field_type if ch.isalnum()).lower()
     if normalized_field_type not in _FIELD_TYPE_CANONICAL_MAP:
         valid_types_str = ", ".join(VALID_FIELD_TYPES)
@@ -206,7 +211,9 @@ def _coerce_dff_payload_to_import_format(data: Any) -> Dict[str, Any]:
 
         return data
 
-    return {"configurations": [data]}
+    raise click.ClickException(
+        "Invalid custom field payload: root JSON value must be an object or array."
+    )
 
 
 def _normalize_dff_payload_for_write(data: Any) -> Dict[str, Any]:
@@ -558,6 +565,9 @@ def register_dff_commands(cli: Any) -> None:
 
                     sys.exit(ExitCodes.GENERAL_ERROR)
 
+        except click.ClickException as exc:
+            click.echo(f"✗ {exc.message}", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
         except requests.RequestException as exc:
             # Handle HTTP errors with detailed validation error parsing
             if hasattr(exc, "response") and exc.response is not None:
@@ -642,6 +652,9 @@ def register_dff_commands(cli: Any) -> None:
                                 f"  - {config.get('name', 'Unknown')}: {config.get('id', '')}"
                             )
 
+        except click.ClickException as exc:
+            click.echo(f"✗ {exc.message}", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
         except requests.RequestException as exc:
             # Handle HTTP errors with detailed validation error parsing
             if hasattr(exc, "response") and exc.response is not None:

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -10,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 
 from slcli.dff_click import register_dff_commands
+from slcli.utils import ExitCodes
 from .test_utils import patch_keyring
 
 
@@ -431,6 +432,67 @@ def test_dff_config_create_accepts_exported_linked_resource_payload(
         assert captured_request["data"]["configurations"][0]["name"] == "Exported Configuration"
         assert captured_request["data"]["groups"][0]["key"] == "group1"
         assert captured_request["data"]["fields"][0]["type"] == "LINKED_RESOURCE"
+    finally:
+        Path(input_file).unlink()
+
+
+def test_dff_config_create_rejects_non_string_field_type(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test create fails cleanly when a field type is not a string."""
+    patch_keyring(monkeypatch)
+
+    cli = make_cli()
+    invalid_config = {
+        "configuration": {
+            "id": "config1",
+            "name": "Exported Configuration",
+            "workspace": "ws1",
+            "resourceType": "system:system",
+        },
+        "fields": [
+            {
+                "key": "field1",
+                "workspace": "ws1",
+                "displayText": "Linked System",
+                "type": 123,
+                "mandatory": False,
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(invalid_config, f)
+        input_file = f.name
+
+    try:
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
+
+        assert result.exit_code == ExitCodes.INVALID_INPUT
+        assert "Invalid field type in field 1" in result.output
+        assert "Field type must be a string" in result.output
+    finally:
+        Path(input_file).unlink()
+
+
+def test_dff_config_create_rejects_invalid_root_payload(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test create rejects unsupported JSON root payload types."""
+    patch_keyring(monkeypatch)
+
+    cli = make_cli()
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump("not-a-dff-payload", f)
+        input_file = f.name
+
+    try:
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
+
+        assert result.exit_code == ExitCodes.INVALID_INPUT
+        assert "Invalid custom field payload" in result.output
+        assert "root JSON value must be an object or array" in result.output
     finally:
         Path(input_file).unlink()
 

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -497,6 +497,54 @@ def test_dff_config_create_rejects_invalid_root_payload(
         Path(input_file).unlink()
 
 
+def test_dff_config_create_preserves_empty_export_configuration(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test create preserves an explicit empty export-shaped configuration object."""
+    patch_keyring(monkeypatch)
+
+    captured_request: dict[str, Any] = {}
+
+    def mock_post(method: str, url: str, data: Any, *args: Any, **kwargs: Any) -> Any:
+        captured_request["method"] = method
+        captured_request["url"] = url
+        captured_request["data"] = data
+
+        class R:
+            def __init__(self) -> None:
+                self.status_code = 201
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return {"configurations": [{"id": "new-config-id", "name": "Unknown"}]}
+
+            @property
+            def text(self) -> str:
+                return json.dumps(self.json())
+
+        return R()
+
+    monkeypatch.setattr("slcli.dff_click.make_api_request", mock_post)
+
+    cli = make_cli()
+    exported_config: dict[str, Any] = {"configuration": {}, "groups": [], "fields": []}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(exported_config, f)
+        input_file = f.name
+
+    try:
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
+
+        assert result.exit_code == 0
+        assert captured_request["method"] == "POST"
+        assert captured_request["data"]["configurations"] == [{}]
+    finally:
+        Path(input_file).unlink()
+
+
 def test_dff_config_export_success(monkeypatch: Any, runner: CliRunner) -> None:
     """Test exporting a DFF configuration."""
     patch_keyring(monkeypatch)

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -358,6 +358,83 @@ def test_dff_config_create_validation_error(monkeypatch: Any, runner: CliRunner)
         Path(input_file).unlink()
 
 
+def test_dff_config_create_accepts_exported_linked_resource_payload(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Test create accepts export-shaped payloads with linked-resource field types."""
+    patch_keyring(monkeypatch)
+
+    captured_request: dict[str, Any] = {}
+
+    def mock_post(method: str, url: str, data: Any, *args: Any, **kwargs: Any) -> Any:
+        captured_request["method"] = method
+        captured_request["url"] = url
+        captured_request["data"] = data
+
+        class R:
+            def __init__(self) -> None:
+                self.status_code = 201
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return {
+                    "configurations": [{"id": "new-config-id", "name": "Exported Configuration"}]
+                }
+
+            @property
+            def text(self) -> str:
+                return json.dumps(self.json())
+
+        return R()
+
+    monkeypatch.setattr("slcli.dff_click.make_api_request", mock_post)
+
+    cli = make_cli()
+
+    exported_config = {
+        "configuration": {
+            "id": "config1",
+            "name": "Exported Configuration",
+            "workspace": "ws1",
+            "resourceType": "system:system",
+        },
+        "groups": [
+            {
+                "key": "group1",
+                "workspace": "ws1",
+                "displayText": "Group 1",
+                "fields": ["field1"],
+            }
+        ],
+        "fields": [
+            {
+                "key": "field1",
+                "workspace": "ws1",
+                "displayText": "Linked System",
+                "type": "LINKED_RESOURCE",
+                "mandatory": False,
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(exported_config, f)
+        input_file = f.name
+
+    try:
+        result = runner.invoke(cli, ["customfield", "create", "--file", input_file])
+
+        assert result.exit_code == 0
+        assert captured_request["method"] == "POST"
+        assert captured_request["data"]["configurations"][0]["name"] == "Exported Configuration"
+        assert captured_request["data"]["groups"][0]["key"] == "group1"
+        assert captured_request["data"]["fields"][0]["type"] == "LINKED_RESOURCE"
+    finally:
+        Path(input_file).unlink()
+
+
 def test_dff_config_export_success(monkeypatch: Any, runner: CliRunner) -> None:
     """Test exporting a DFF configuration."""
     patch_keyring(monkeypatch)
@@ -399,7 +476,92 @@ def test_dff_config_export_success(monkeypatch: Any, runner: CliRunner) -> None:
         with open(output_file) as f:
             exported_data = json.load(f)
 
-        assert exported_data["configuration"]["name"] == "Test Configuration"
+        assert len(exported_data["configurations"]) == 1
+        assert exported_data["configurations"][0]["name"] == "Test Configuration"
+
+
+def test_dff_config_export_create_round_trip(monkeypatch: Any, runner: CliRunner) -> None:
+    """Test export output can be fed directly back into create."""
+    patch_keyring(monkeypatch)
+
+    exported_response = {
+        "configuration": {
+            "id": "config1",
+            "name": "Round Trip Configuration",
+            "workspace": "ws1",
+            "resourceType": "system:system",
+        },
+        "groups": [
+            {
+                "key": "group1",
+                "workspace": "ws1",
+                "displayText": "Group 1",
+                "fields": ["field1"],
+            }
+        ],
+        "fields": [
+            {
+                "key": "field1",
+                "workspace": "ws1",
+                "displayText": "Linked System",
+                "type": "LinkedResource",
+                "mandatory": False,
+            }
+        ],
+    }
+    captured_request: dict[str, Any] = {}
+
+    def mock_make_api_request(method: str, url: str, *args: Any, **kwargs: Any) -> Any:
+        if method == "GET":
+
+            class GetResponse:
+                def raise_for_status(self) -> None:
+                    pass
+
+                def json(self) -> Any:
+                    return exported_response
+
+            return GetResponse()
+
+        data = args[0] if args else kwargs.get("payload")
+        captured_request["method"] = method
+        captured_request["url"] = url
+        captured_request["data"] = data
+
+        class PostResponse:
+            def __init__(self) -> None:
+                self.status_code = 201
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return {
+                    "configurations": [{"id": "new-config-id", "name": "Round Trip Configuration"}]
+                }
+
+            @property
+            def text(self) -> str:
+                return json.dumps(self.json())
+
+        return PostResponse()
+
+    monkeypatch.setattr("slcli.dff_click.make_api_request", mock_make_api_request)
+
+    cli = make_cli()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_file = Path(temp_dir) / "exported-config.json"
+
+        export_result = runner.invoke(
+            cli, ["customfield", "export", "--id", "config1", "--output", str(output_file)]
+        )
+        assert export_result.exit_code == 0
+
+        create_result = runner.invoke(cli, ["customfield", "create", "--file", str(output_file)])
+        assert create_result.exit_code == 0
+        assert captured_request["data"]["configurations"][0]["name"] == "Round Trip Configuration"
+        assert captured_request["data"]["fields"][0]["type"] == "LINKED_RESOURCE"
 
 
 def test_dff_config_delete_confirmation_abort(monkeypatch: Any, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary
- make `slcli customfield export` write an importable DFF payload envelope
- accept export-shaped payloads and normalize linked-resource field types during `customfield create` and `update`
- add regression tests covering linked-resource import and export/create round trips

Fixes #174

## Testing
- `poetry run black --check slcli/dff_click.py tests/unit/test_dff_click.py`
- `poetry run ni-python-styleguide lint slcli tests`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q`
- `poetry run pytest`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- `patch`: fix linked-resource DFF export/create round trips for custom fields