### PR TITLE
Add OK support and named webapp templates

### DIFF
--- a/newsfragments/webapp-template-support.minor.md
+++ b/newsfragments/webapp-template-support.minor.md
@@ -1,0 +1,1 @@
+Add OK feature-pack support and enable dashboard, list-detail, and admin hosted webapp templates.

--- a/slcli/skills/slcli/references/webapp/angular-ui-packages.md
+++ b/slcli/skills/slcli/references/webapp/angular-ui-packages.md
@@ -2,6 +2,24 @@
 
 Use this file when you need a quick package-level inventory before choosing components. Load `nimble-angular.md` only after you know which Nimble components you actually need.
 
+## Use published components first
+
+Before styling a `div` into a faux card, tile, accordion, search bar, button row, or summary panel,
+check this file and the Nimble Storybook first.
+
+- Prefer NI components for visible surfaces and interactions.
+- Use raw HTML mainly for layout containers, semantic sections, and text.
+- Treat custom card shells as the exception path, not the default response to a dashboard or layout request.
+
+## Reference links
+
+| Surface                 | Link                                                                         | Use                                                               |
+| ----------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Nimble Storybook        | https://nimble.ni.dev/storybook/index.html                                   | Search the published Nimble components before inventing a surface |
+| Nimble Getting Started  | https://nimble.ni.dev/storybook/index.html?path=/docs/getting-started--docs  | Bootstrap and package expectations                                |
+| Nimble Component APIs   | https://nimble.ni.dev/storybook/index.html?path=/docs/component-apis--docs   | Component inventory and API lookup                                |
+| Nimble Component Status | https://nimble.ni.dev/storybook/index.html?path=/docs/component-status--docs | Check maturity and availability                                   |
+
 ## Install recommendation
 
 For new SystemLink webapps, prefer installing the NI Angular UI packages together:
@@ -10,15 +28,15 @@ For new SystemLink webapps, prefer installing the NI Angular UI packages togethe
 npm install @ni/nimble-angular @ni/spright-angular @ni/ok-angular
 ```
 
-Use Nimble as the default foundation, then pull in Spright and OK Angular when the app needs their specialized components.
+Use Nimble as the default foundation, then pull in Spright and OK Angular when the app needs their specialized surfaces.
 
 ## Package roles
 
-| Package               | Primary role                                           | When to reach for it                                                                                                       |
-| --------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `@ni/nimble-angular`  | Core SystemLink-aligned component foundation           | Use for the default app shell, tables, buttons, inputs, drawers, banners, dialogs, navigation, and most day-to-day UI work |
-| `@ni/spright-angular` | Spright chat, rectangle, and NI-specific icon wrappers | Use for chat experiences, AI/copilot surfaces, and Spright-specific iconography                                            |
-| `@ni/ok-angular`      | OK-specific interaction components                     | Use when the design needs OK accordion items, OK search input, or OK button primitives                                     |
+| Package               | Primary role                                           | When to reach for it                                                                                                              |
+| --------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `@ni/nimble-angular`  | Core SystemLink-aligned component foundation           | Use for the default app shell, tables, buttons, inputs, drawers, banners, dialogs, navigation, and most day-to-day UI work        |
+| `@ni/spright-angular` | Spright chat, rectangle, and NI-specific icon wrappers | Use for chat experiences, AI/copilot surfaces, and Spright-specific iconography                                                   |
+| `@ni/ok-angular`      | OK-specific Angular wrappers                           | Use when the design needs OK accordion items, OK search input, OK chip selectors, summary panels, or OK button primitives         |
 
 ## Recommended AppModule example
 
@@ -99,6 +117,16 @@ Representative components already documented there include:
 - `nimble-banner`
 - `nimble-dialog`
 
+Representative layout and navigation surfaces to prefer before bespoke HTML include:
+
+- `nimble-anchor`
+- `nimble-anchor-tabs`
+- `nimble-anchor-tab`
+- `nimble-drawer`
+- `nimble-banner`
+- `nimble-spinner`
+- `nimble-table`
+
 ### `@ni/spright-angular`
 
 Published Angular wrappers currently include:
@@ -126,7 +154,7 @@ Published Spright icon directives currently include:
 
 ### `@ni/ok-angular`
 
-Published Angular wrappers in `@ni/ok-angular@2.4.0` currently include:
+Published Angular wrappers in `@ni/ok-angular@2.5.0` currently include:
 
 | Tag                         | Angular symbol                | Import path                             | Use                                          |
 | --------------------------- | ----------------------------- | --------------------------------------- | -------------------------------------------- |
@@ -135,17 +163,22 @@ Published Angular wrappers in `@ni/ok-angular@2.4.0` currently include:
 | `ok-fv-card`                | `OkFvCardModule`              | `@ni/ok-angular/fv/card`                | OK card surface with title and description   |
 | `ok-fv-chip-selector`       | `OkFvChipSelectorModule`      | `@ni/ok-angular/fv/chip-selector`       | Multi-value chip selector control            |
 | `ok-fv-context-help`        | `OkFvContextHelpModule`       | `@ni/ok-angular/fv/context-help`        | Inline context-help or severity help content |
+| `ok-fv-master-detail-list`  | `OkFvMasterDetailListModule`  | `@ni/ok-angular/fv/master-detail-list`  | Master/detail list container                 |
+| `ok-fv-master-detail-list-item` | `OkFvMasterDetailListItemModule` | `@ni/ok-angular/fv/master-detail-list-item` | Item rows inside the master/detail list |
 | `ok-fv-search-input`        | `OkFvSearchInputModule`       | `@ni/ok-angular/fv/search-input`        | OK search input control                      |
 | `ok-fv-split-button`        | `OkFvSplitButtonModule`       | `@ni/ok-angular/fv/split-button`        | Split button with primary and menu actions   |
 | `ok-fv-split-button-anchor` | `OkFvSplitButtonAnchorModule` | `@ni/ok-angular/fv/split-button-anchor` | Anchor-style split button                    |
 | `ok-fv-summary-panel`       | `OkFvSummaryPanelModule`      | `@ni/ok-angular/fv/summary-panel`       | Summary panel container                      |
 | `ok-fv-summary-panel-tile`  | `OkFvSummaryPanelTileModule`  | `@ni/ok-angular/fv/summary-panel-tile`  | Summary panel metric or status tile          |
 
+Use `@ni/ok-angular` as the default and preferred entry point for OK components in Angular apps. The wrapper package now includes the master-detail list surface as well, so generated apps and skill guidance should stay on `@ni/ok-angular` rather than importing `@ni/ok-components` directly.
+
 ## Selection guidance
 
 - Start with Nimble for the app shell and the majority of controls.
 - Add Spright when the app needs chat UI or Spright-specific iconography.
 - Add OK Angular when the design specifically benefits from its accordion item, search input, chip selector, split button, summary panel, card, or OK button components.
+- Prefer a published component over styling a `div` to imitate the same surface.
 - Keep imports explicit at the module level; do not use `CUSTOM_ELEMENTS_SCHEMA` as a shortcut for missing wrappers.
 
 ## Next step references

--- a/slcli/skills/slcli/references/webapp/layout-patterns.md
+++ b/slcli/skills/slcli/references/webapp/layout-patterns.md
@@ -51,9 +51,21 @@ Do not combine multiple starter patterns in the first implementation slice unles
 ## Core rules
 
 - Use Nimble components and Nimble design tokens for primary UI. Avoid generic cards as the default page structure for browse, detail, and settings workflows.
+- Check published Nimble, Spright, and OK components before creating a custom surface from plain `div`s.
+- Use `div`s for flex, grid, spacing, grouping, and semantics, not as a substitute for a published control or design surface.
 - Put toolbars and tab bars in a 40px-tall container with content vertically centered and a `1px solid var(--ni-nimble-divider-background-color)` bottom border.
 - Use `nimble-button` for button affordances. If you need clickable list rows or a section rail, style them as navigation rows rather than faux Nimble buttons.
 - Keep theme-aware aliases on `nimble-theme-provider`, not on `:root`, so custom colors and surfaces follow the active Nimble theme.
+
+## Prefer components over faux cards
+
+When the request sounds like "dashboard", "summary", "overview", or "settings", do not default to wrapping everything in repeated card containers.
+
+- For browse data, start with `nimble-table` plus a toolbar.
+- For selection-driven workflows, start with drawer-detail or master/detail.
+- For grouped configuration, start with accordion items or sectioned form groups.
+- For metrics or status rollups, prefer OK summary panels or a small number of focused summary surfaces.
+- Use cards only when a published card or summary component is the real primitive you need, not as a catch-all page layout pattern.
 
 ## Spacing tokens
 

--- a/slcli/skills/slcli/references/webapp/nimble-angular.md
+++ b/slcli/skills/slcli/references/webapp/nimble-angular.md
@@ -27,6 +27,8 @@ When building Angular apps with Nimble, use `@ni/nimble-angular` wrapper modules
 - Import the needed Angular module for each Nimble control instead of registering raw custom elements from `@ni/nimble-components`.
 - Do not add `CUSTOM_ELEMENTS_SCHEMA` just to silence unknown Nimble elements in templates. That usually hides a missing module import and weakens Angular's template validation.
 - If a Nimble icon or control is unknown, first look for the matching module in `@ni/nimble-angular` and import it.
+- If a Nimble wrapper does not exist, check `angular-ui-packages.md` and the Nimble Storybook before creating a custom HTML substitute.
+- Prefer a published NI component over styling a `div` to mimic the same interaction or surface.
 
 ## Fonts
 

--- a/slcli/skills/slcli/references/webapp/overview.md
+++ b/slcli/skills/slcli/references/webapp/overview.md
@@ -17,6 +17,23 @@ reference files when the implementation needs them.
 
 If the user only wants planning or a first implementation slice, stay in this file.
 
+## Component-first rule
+
+Before inventing a surface with `div`s, custom borders, or repeated card shells, check whether the
+needed primitive already exists in Nimble, Spright, or OK.
+
+- Use package components for interactive or visual surfaces first.
+- Use raw HTML mostly for semantic grouping, flex/grid layout, and text structure.
+- Do not build custom-styled buttons, inputs, tabs, drawers, search bars, banners, summary tiles,
+  or faux cards when a published NI component already covers the job.
+- Treat `div` wrappers as layout scaffolding, not as the primary design language.
+
+Start with these references before authoring bespoke UI:
+
+- Nimble Storybook: https://nimble.ni.dev/storybook/index.html
+- Nimble Component APIs: https://nimble.ni.dev/storybook/index.html?path=/docs/component-apis--docs
+- Nimble Getting Started: https://nimble.ni.dev/storybook/index.html?path=/docs/getting-started--docs
+
 ## First response checklist
 
 Before generating code, clarify only the details that change the implementation:
@@ -29,7 +46,7 @@ Before generating code, clarify only the details that change the implementation:
 
 Do not ask about Angular or Nimble versions unless the user is constrained by an existing project. Default to Angular 20 and the latest compatible `@ni/nimble-angular`, but verify the installed versions immediately after scaffold instead of assuming the generator produced the expected combination.
 
-For new SystemLink apps, recommend installing the NI Angular UI packages together unless the user is intentionally minimizing dependencies. `@ni/nimble-angular` remains the default foundation, `@ni/spright-angular` adds Spright chat and icon components, and `@ni/ok-angular` adds OK-specific controls such as accordion items and search input.
+For new SystemLink apps, recommend installing the NI UI packages together unless the user is intentionally minimizing dependencies. `@ni/nimble-angular` remains the default foundation, `@ni/spright-angular` adds Spright chat and icon components, and `@ni/ok-angular` is the default entry point for OK surfaces such as accordion items, search input, summary panels, and other OK wrappers. Do not reach for `@ni/ok-components` directly in normal app code.
 
 ## Recommended workflow
 
@@ -60,9 +77,12 @@ For the currently supported path, standardize on:
 
 - Angular 20.x
 - Node 24+
-- `@ni/nimble-angular` 33.2.x
-- `@ni/nimble-components` 35.8.x
-- `@ni/unit-format` 1.0.4+
+- `@ni/nimble-angular` 33.4.x
+- `@ni/nimble-components` 35.12.x
+- `@ni/unit-format` 1.0.5+
+- `@ni/spright-angular` 9.5.x
+- `@ni/ok-angular` 2.5.0+
+- `@ni/systemlink-clients-ts` 3.0.2
 - `@angular/build` for the hosted application builder
 - `@angular/localize` installed and added to build polyfills
 
@@ -76,7 +96,7 @@ Also add `@angular-devkit/build-angular` back to `devDependencies` before switch
 
 This fallback is not optional when the Nimble packages fail under the application builder. Fix the builder mismatch before implementing more UI.
 
-Recommend installing `@ni/spright-angular` and `@ni/ok-angular` early when using the manual `init` path, even if the first slice only uses Nimble. That avoids dependency churn later when the UI needs chat surfaces, product-specific icons, accordion items, or the OK search input.
+Recommend installing `@ni/spright-angular` and `@ni/ok-angular` early when using the manual `init` path, even if the first slice only uses Nimble. That avoids dependency churn later when the UI needs chat surfaces, product-specific icons, or OK wrappers.
 
 If the user has not scaffolded anything yet and explicitly wants a SystemLink-hosted webapp, recommend `slcli webapp new` first. Only fall back to `slcli webapp init` when they ask for manual bootstrapping or need to control the Angular workspace creation themselves.
 
@@ -103,13 +123,16 @@ Use SystemLink-appropriate layout defaults instead of inventing page structure f
 - Use drawers or collapsible side panels for settings and filters.
 - Use accordions for grouped fields and advanced configuration.
 - Use cards sparingly for summaries, not as the default editing or data layout.
+- Prefer NI summary-panel, accordion, table, drawer, tab, banner, and search components before composing a new surface from plain `div`s.
 
 Treat Nimble alignment as a requirement, not a style preference:
 
 - Use Nimble controls for primary actions, selection, inputs, status, and data display.
+- Prefer OK and Spright components when they provide a better fit than generic layout wrappers.
 - Use raw HTML elements mostly for semantic grouping, layout wrappers, and text structure.
 - Do not build custom-styled buttons, inputs, dropdowns, tabs, or pseudo-cards when Nimble already provides the interaction primitive.
 - Prefer Nimble spacing, borders, focus states, and theme tokens over bespoke visual treatments.
+- If an NI component exists for the surface, use it instead of styling a `div` to imitate it.
 - If a page starts to look like a generic marketing dashboard instead of a SystemLink tool, pull it back toward table/list-detail, drawers, banners, tabs, and structured metadata panels.
 
 ### 4. Integrate SystemLink APIs the low-risk way
@@ -176,6 +199,7 @@ Before you consider a SystemLink webapp slice correct, confirm all of the follow
 - Root `src/styles.scss` imports `@use '@ni/nimble-angular/styles/fonts' as *;`.
 - Nimble Angular modules are imported explicitly.
 - Primary interaction controls use Nimble wrappers rather than custom HTML surrogates.
+- When Nimble lacks a needed surface, check `angular-ui-packages.md` and the Nimble Storybook before creating a bespoke `div`-based substitute.
 - No hardcoded colors in component SCSS.
 - Theme-aware aliases live on `nimble-theme-provider`.
 - API client uses the correct SystemLink service base URL.

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -19,12 +19,11 @@ from .utils import (
 
 _WEBAPP_FRAMEWORK_CHOICES = ("angular",)
 _WEBAPP_TEMPLATE_CHOICES = ("blank", "dashboard", "list-detail", "admin")
-_WEBAPP_PHASE1_SUPPORTED_TEMPLATES = frozenset({"blank"})
-_WEBAPP_FEATURE_PACK_CHOICES = ("nimble", "spright", "clients")
+_WEBAPP_FEATURE_PACK_CHOICES = ("nimble", "spright", "clients", "ok")
 _WEBAPP_ROUTING_CHOICES = ("hash", "path")
 _WEBAPP_AUTH_CHOICES = ("same-origin", "api-key")
 _WEBAPP_THEME_SYNC_CHOICES = ("auto", "off")
-_WEBAPP_DEFAULT_FEATURE_PACKS = "nimble,clients"
+_WEBAPP_DEFAULT_FEATURE_PACKS = "nimble,clients,ok"
 _WEBAPP_SUPPORTED_ANGULAR_MAJOR = "20"
 _WEBAPP_VERSION_MANIFEST: Dict[str, Dict[str, str]] = {
     "20": {
@@ -43,6 +42,102 @@ _WEBAPP_VERSION_MANIFEST: Dict[str, Dict[str, str]] = {
         "nodeEngine": ">=24",
     }
 }
+_WEBAPP_TEMPLATE_PROFILES: Dict[str, Dict[str, Any]] = {
+    "blank": {
+        "source_template": "blank",
+        "tabs": [
+            {"id": "overview", "label": "Overview", "route": "/"},
+            {"id": "datasets", "label": "Data Table", "route": "/datasets"},
+            {"id": "assets", "label": "Drawer Detail", "route": "/assets"},
+            {"id": "master-detail", "label": "Master Detail", "route": "/master-detail"},
+            {"id": "operations", "label": "Operations", "route": "/operations"},
+            {"id": "settings", "label": "Settings", "route": "/settings"},
+        ],
+        "pattern_summary": "six Nimble-based layout patterns ready to replace with real SystemLink resource calls",
+        "patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Search-first Nimble table toolbar with concise Search <items> copy",
+            "Drawer-based detail inspection from a primary dataset",
+            "Master/detail split pane with read-only detail fields until edit mode",
+            "Split operations workspace with manual refresh and a confirm dialog",
+            "Grouped settings form with theme-aware sections and readonly hosted facts",
+        ],
+        "readme_patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Search-first Nimble table toolbar with concise Search <items> copy",
+            "Drawer-based detail inspection from a primary dataset",
+            "Master/detail split pane with read-only detail fields until edit mode",
+            "Split operations workspace with manual refresh and a confirm dialog",
+            "Grouped settings form with theme-aware sections and readonly hosted facts",
+        ],
+        "readiness_message": "This starter keeps hosted routing, Nimble tokens, and sample control text aligned to current Stratus guidance.",
+    },
+    "dashboard": {
+        "source_template": "blank",
+        "tabs": [
+            {"id": "overview", "label": "Overview", "route": "/"},
+            {"id": "datasets", "label": "Data Table", "route": "/datasets"},
+            {"id": "assets", "label": "Drawer Detail", "route": "/assets"},
+        ],
+        "pattern_summary": "three dashboard-oriented starter routes ready for metrics, tables, and record drill-down",
+        "patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Search-first Nimble table toolbar with concise Search <items> copy",
+            "Drawer-based detail inspection from a primary dataset",
+        ],
+        "readme_patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Search-first Nimble table toolbar with concise Search <items> copy",
+            "Drawer-based detail inspection from a primary dataset",
+        ],
+        "readiness_message": "This dashboard starter keeps hosted routing, Nimble tokens, and table-first control text aligned to current Stratus guidance.",
+    },
+    "list-detail": {
+        "source_template": "blank",
+        "tabs": [
+            {"id": "overview", "label": "Overview", "route": "/"},
+            {"id": "assets", "label": "Drawer Detail", "route": "/assets"},
+            {"id": "master-detail", "label": "Master Detail", "route": "/master-detail"},
+        ],
+        "pattern_summary": "three list-and-detail starter routes ready for inspection, selection, and edit workflows",
+        "patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Drawer-based detail inspection from a primary dataset",
+            "Master/detail split pane with read-only detail fields until edit mode",
+        ],
+        "readme_patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Drawer-based detail inspection from a primary dataset",
+            "Master/detail split pane with read-only detail fields until edit mode",
+        ],
+        "readiness_message": "This list-detail starter keeps hosted routing, Nimble tokens, and record-inspection flows aligned to current Stratus guidance.",
+    },
+    "admin": {
+        "source_template": "blank",
+        "tabs": [
+            {"id": "overview", "label": "Overview", "route": "/"},
+            {"id": "operations", "label": "Operations", "route": "/operations"},
+            {"id": "settings", "label": "Settings", "route": "/settings"},
+        ],
+        "pattern_summary": "three admin-focused starter routes ready for queue management and configuration workflows",
+        "patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Split operations workspace with manual refresh and a confirm dialog",
+            "Grouped settings form with theme-aware sections and readonly hosted facts",
+        ],
+        "readme_patterns": [
+            "Route-level navigation with Nimble anchor tabs",
+            "Split operations workspace with manual refresh and a confirm dialog",
+            "Grouped settings form with theme-aware sections and readonly hosted facts",
+        ],
+        "readiness_message": "This admin starter keeps hosted routing, Nimble tokens, and configuration-first workflows aligned to current Stratus guidance.",
+    },
+}
+
+
+def _webapp_template_profile(template: str) -> Dict[str, Any]:
+    """Return the generation profile for a named template."""
+    return _WEBAPP_TEMPLATE_PROFILES[template]
 
 
 def _webapp_templates_dir_candidates() -> List[Path]:
@@ -62,13 +157,15 @@ def _webapp_templates_dir_candidates() -> List[Path]:
 
 def _resolve_webapp_template_directory(framework: str, template: str) -> Path:
     """Resolve a bundled webapp template directory from the current install layout."""
+    source_template = _webapp_template_profile(template)["source_template"]
     for candidate_root in _webapp_templates_dir_candidates():
-        candidate = candidate_root / framework / template
+        candidate = candidate_root / framework / source_template
         if candidate.exists() and (candidate / "package.json").exists():
             return candidate
 
     raise FileNotFoundError(
-        f"Bundled webapp template not found for framework '{framework}' and template '{template}'."
+        "Bundled webapp template not found for framework "
+        f"'{framework}' and template '{source_template}'."
     )
 
 
@@ -110,17 +207,6 @@ def _parse_feature_pack_selection(selection: str) -> List[str]:
         sys.exit(ExitCodes.INVALID_INPUT)
 
     return unique_requested
-
-
-def _ensure_supported_webapp_template(template: str) -> None:
-    """Reject templates that are planned but not yet shipped."""
-    if template not in _WEBAPP_PHASE1_SUPPORTED_TEMPLATES:
-        click.echo(
-            "✗ Phase 1 currently supports only --template blank. "
-            "Dashboard, list-detail, and admin templates are planned follow-on work.",
-            err=True,
-        )
-        sys.exit(ExitCodes.INVALID_INPUT)
 
 
 def _template_relative_file_list(template_dir: Path) -> List[str]:
@@ -207,6 +293,337 @@ def _write_rendered_template_tree(
             source_path.read_text(encoding="utf-8"), replacements
         )
         target_path.write_text(rendered_text, encoding="utf-8")
+
+
+def _build_webapp_routing_module(template: str, routing_mode: str) -> str:
+    """Render app-routing.module.ts for the selected template."""
+    tabs = _webapp_template_profile(template)["tabs"]
+    import_map = {
+        "/": "HomePageComponent",
+        "/datasets": "DatasetsPageComponent",
+        "/assets": "AssetsPageComponent",
+        "/master-detail": "MasterDetailPageComponent",
+        "/operations": "OperationsPageComponent",
+        "/settings": "SettingsPageComponent",
+    }
+    file_map = {
+        "/": "./features/home/home-page.component",
+        "/datasets": "./features/datasets/datasets-page.component",
+        "/assets": "./features/assets/assets-page.component",
+        "/master-detail": "./features/master-detail/master-detail-page.component",
+        "/operations": "./features/operations/operations-page.component",
+        "/settings": "./features/settings/settings-page.component",
+    }
+
+    imports = [
+        "import { NgModule } from '@angular/core';",
+        "import { RouterModule, Routes } from '@angular/router';",
+        "",
+    ]
+    for tab in tabs:
+        route = tab["route"]
+        component_name = import_map[route]
+        imports.append(f"import {{ {component_name} }} from '{file_map[route]}';")
+
+    route_entries: List[str] = []
+    for tab in tabs:
+        path_value = "" if tab["route"] == "/" else tab["route"].lstrip("/")
+        component_name = import_map[tab["route"]]
+        route_entries.extend(
+            [
+                "  {",
+                f"    path: '{path_value}',",
+                f"    component: {component_name},",
+                "  },",
+            ]
+        )
+
+    lines = imports + [
+        "",
+        "const routes: Routes = [",
+        *route_entries,
+        "];",
+        "",
+        "@NgModule({",
+        f"  imports: [RouterModule.forRoot(routes, {{ useHash: {'true' if routing_mode == 'hash' else 'false'} }})],",
+        "  exports: [RouterModule],",
+        "})",
+        "export class AppRoutingModule {}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _build_webapp_shell_component(template: str) -> str:
+    """Render the app shell tabs for the selected template."""
+    tab_lines = [
+        f"    {{ id: '{tab['id']}', label: '{tab['label']}', route: '{tab['route']}' }},"
+        for tab in _webapp_template_profile(template)["tabs"]
+    ]
+
+    return "\n".join(
+        [
+            "import { CommonModule } from '@angular/common';",
+            "import { Component } from '@angular/core';",
+            "import { NavigationEnd, Router, RouterModule } from '@angular/router';",
+            "",
+            "import { NimbleAnchorTabModule, NimbleAnchorTabsModule } from '@ni/nimble-angular';",
+            "import { filter } from 'rxjs';",
+            "",
+            "import { SystemLinkContextService } from '../systemlink/systemlink-context.service';",
+            "",
+            "interface ShellTab {",
+            "  id: string;",
+            "  label: string;",
+            "  route: string;",
+            "}",
+            "",
+            "@Component({",
+            "  selector: 'sl-app-shell',",
+            "  standalone: true,",
+            "  imports: [",
+            "    CommonModule,",
+            "    RouterModule,",
+            "    NimbleAnchorTabsModule,",
+            "    NimbleAnchorTabModule,",
+            "  ],",
+            "  templateUrl: './app-shell.component.html',",
+            "  styleUrl: './app-shell.component.scss',",
+            "})",
+            "export class AppShellComponent {",
+            "  readonly tabs: readonly ShellTab[] = [",
+            *tab_lines,
+            "  ];",
+            "",
+            "  activeTabId = 'overview';",
+            "",
+            "  constructor(",
+            "    public readonly context: SystemLinkContextService,",
+            "    router: Router,",
+            "  ) {",
+            "    this.updateActiveTab(router.url);",
+            "    router.events",
+            "      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))",
+            "      .subscribe((event: NavigationEnd) => {",
+            "        this.updateActiveTab(event.urlAfterRedirects);",
+            "      });",
+            "  }",
+            "",
+            "  private updateActiveTab(url: string): void {",
+            "    const path = url.split('?')[0] || '/';",
+            "    const active = this.tabs.find((tab: ShellTab) => {",
+            "      if (tab.route === '/') {",
+            "        return path === '/';",
+            "      }",
+            "",
+            "      return path === tab.route || path.startsWith(`${tab.route}/`);",
+            "    });",
+            "",
+            "    this.activeTabId = active?.id ?? 'overview';",
+            "  }",
+            "}",
+            "",
+        ]
+    )
+
+
+def _quoted_typescript_list(values: List[str]) -> str:
+    """Return a comma-separated TypeScript string literal list."""
+    return ",\n        ".join(f"'{value}'" for value in values)
+
+
+def _build_webapp_home_data_service(template: str) -> str:
+    """Render the home data service for the selected template."""
+    profile = _webapp_template_profile(template)
+    patterns = _quoted_typescript_list(profile["patterns"])
+    return "\n".join(
+        [
+            "import { Injectable } from '@angular/core';",
+            "",
+            "import { SystemLinkContextService } from './systemlink-context.service';",
+            "",
+            "export interface HomeMetric {",
+            "  label: string;",
+            "  value: string;",
+            "  detail: string;",
+            "  tone: 'info' | 'success' | 'warning';",
+            "}",
+            "",
+            "export interface HomePageModel {",
+            "  metrics: HomeMetric[];",
+            "  patterns: string[];",
+            "  nextSteps: string[];",
+            "  readinessMessage: string;",
+            "}",
+            "",
+            "@Injectable({ providedIn: 'root' })",
+            "export class WebappHomeDataService {",
+            "  constructor(private readonly context: SystemLinkContextService) {}",
+            "",
+            "  async load(): Promise<HomePageModel> {",
+            "    return {",
+            "      metrics: [",
+            "        {",
+            "          label: 'Hosted origin',",
+            "          value: this.context.origin,",
+            "          detail: 'Root future SDK clients and direct fetch calls here.',",
+            "          tone: 'info',",
+            "        },",
+            "        {",
+            "          label: 'Auth mode',",
+            "          value: this.context.authMode,",
+            "          detail: 'Swap with --auth when you need API-key-driven development flows.',",
+            "          tone: 'warning',",
+            "        },",
+            "        {",
+            "          label: 'Workspace',",
+            "          value: this.context.workspaceName,",
+            "          detail: 'Publishing help text and starter docs are already aligned to this workspace.',",
+            "          tone: 'success',",
+            "        },",
+            "      ],",
+            "      patterns: [",
+            f"        {patterns},",
+            "      ],",
+            "      nextSteps: [",
+            "        'Replace one sample page with a real SystemLink query before adding more routes.',",
+            "        'Use Nimble buttons for actions and Nimble anchors or route tabs for navigation.',",
+            "        'Preserve hosted query parameters if you later add cross-app breadcrumbs.',",
+            "      ],",
+            f"      readinessMessage: '{profile['readiness_message']}',",
+            "    };",
+            "  }",
+            "}",
+            "",
+        ]
+    )
+
+
+def _build_webapp_readme(
+    template: str,
+    publish_name: str,
+    app_name: str,
+    routing_mode: str,
+    publish_command: str,
+    workspace_name: str,
+    auth_mode: str,
+) -> str:
+    """Render README.md for the selected template."""
+    profile = _webapp_template_profile(template)
+    routed_features = [tab["route"].lstrip("/") or "home" for tab in profile["tabs"]]
+    readme_patterns = "\n".join(f"- {item}" for item in profile["readme_patterns"])
+    return f"""# {publish_name}
+
+This app was generated by `slcli webapp new {app_name}` as a hosted Angular 20 starter for SystemLink.
+
+## What You Start With
+
+- Node.js 24+ declared in `package.json#engines`
+- Angular 20 with standalone root bootstrap and NgModule-managed feature declarations
+- `@ni/nimble-angular` wired into the standalone root plus `AppModule`
+- `nimble-theme-provider` at the application root
+- `APP_BASE_HREF` provided without a `<base>` tag in `src/index.html`
+- `useHash: {'true' if routing_mode == 'hash' else 'false'}` routing for hosted navigation
+- `@angular/localize/init` configured for the build polyfill path
+- Nimble fonts imported in `src/styles.scss`
+- modern Angular application builders configured for the hosted scaffold
+- initial bundle warning budget tuned for the included starter shell
+- shared loading, error, and empty states
+- SystemLink context and theme sync services under `src/app/core/systemlink/`
+- {profile['pattern_summary']}
+
+## Enabled Starter Routes
+
+{', '.join(routed_features)}
+
+## Local Development
+
+```bash
+npm install
+npm run build
+```
+
+The generated scaffold intentionally omits a default test runner setup so `npm install`
+does not pull in the deprecated Karma/Jasmine stack. Add your preferred test tooling when
+you start writing app-specific tests.
+
+## Publish To SystemLink
+
+```bash
+{publish_command}
+```
+
+Current workspace default: `{workspace_name or 'Default'}`
+
+## Hosted Validation Notes
+
+- Keep `APP_BASE_HREF` in `src/app/app.module.ts`
+- Keep `useHash: {'true' if routing_mode == 'hash' else 'false'}` in `src/app/app-routing.module.ts`
+- Do not add a `<base>` tag to `src/index.html`
+- Keep `inlineCritical: false` in `angular.json`
+- Use `window.location.origin` when adding more SystemLink service clients
+
+## Sample Service Wiring
+
+The generated `SystemLinkContextService` centralizes:
+
+- the hosted origin (`window.location.origin`)
+- auth mode (`{auth_mode}`)
+- request defaults for same-origin cookies or API-key headers
+
+## Included Patterns
+
+{readme_patterns}
+
+## Pattern Guardrails
+
+- Use Nimble tokens for custom fonts and colors. Import Nimble fonts once in `src/styles.scss`, then derive any custom styling from token-backed CSS variables.
+- Use `nimble-button` for actions and Nimble anchors or route tabs for navigation. Do not style regular buttons to imitate Nimble buttons.
+- Use concise `Search <items>` placeholders for toolbar text filters, and prefer `readonly` over `disabled` for non-editable text content.
+- Add refresh controls only to views with data that changes outside the current session. Static overview and settings routes should stay manual.
+- If you add breadcrumbs for cross-app navigation, preserve their hierarchy through query parameters instead of rewriting breadcrumb state during same-app tab switches.
+
+Use these routes as starting points and replace one of them with a real SystemLink resource flow before broadening the app shell.
+"""
+
+
+def _apply_selected_webapp_template(
+    target_dir: Path,
+    template: str,
+    app_name: str,
+    publish_name: str,
+    workspace_name: str,
+    routing_mode: str,
+    auth_mode: str,
+) -> None:
+    """Rewrite the generated starter entrypoints for the selected template."""
+    app_dir = target_dir / "src" / "app"
+    (app_dir / "app-routing.module.ts").write_text(
+        _build_webapp_routing_module(template, routing_mode),
+        encoding="utf-8",
+    )
+    (app_dir / "core" / "layout" / "app-shell.component.ts").write_text(
+        _build_webapp_shell_component(template),
+        encoding="utf-8",
+    )
+    (app_dir / "core" / "systemlink" / "webapp-home-data.service.ts").write_text(
+        _build_webapp_home_data_service(template),
+        encoding="utf-8",
+    )
+    (target_dir / "README.md").write_text(
+        _build_webapp_readme(
+            template=template,
+            publish_name=publish_name,
+            app_name=app_name,
+            routing_mode=routing_mode,
+            publish_command=_publish_command_for_directory(
+                _slugify_webapp_name(app_name), publish_name, workspace_name
+            ),
+            workspace_name=workspace_name,
+            auth_mode=auth_mode,
+        ),
+        encoding="utf-8",
+    )
 
 
 def _base_angular_dependencies(angular_major: str) -> Dict[str, str]:
@@ -366,6 +783,7 @@ def _emit_webapp_new_dry_run(
     plugin_manager: bool,
 ) -> None:
     """Print the generation plan without writing files."""
+    profile = _webapp_template_profile(template)
     click.echo("Webapp generation dry run")
     click.echo(f"  Framework: {framework}")
     click.echo(f"  Template: {template}")
@@ -382,6 +800,10 @@ def _emit_webapp_new_dry_run(
         click.echo(f"    - {package_name}@{version}")
     click.echo("  Config mutations:")
     click.echo(f"    - feature packs: {', '.join(feature_packs)}")
+    click.echo(
+        "    - enabled routes: "
+        + ", ".join(tab["route"].lstrip("/") or "home" for tab in profile["tabs"])
+    )
     click.echo("    - APP_BASE_HREF provider with no <base> tag")
     click.echo("    - Angular localize polyfills for build")
     click.echo("    - Nimble fonts in src/styles.scss")
@@ -418,7 +840,6 @@ def _generate_new_webapp(
         )
         sys.exit(ExitCodes.INVALID_INPUT)
 
-    _ensure_supported_webapp_template(template)
     feature_packs = _parse_feature_pack_selection(feature_pack_selection)
 
     project_name = _slugify_webapp_name(app_name)
@@ -454,6 +875,15 @@ def _generate_new_webapp(
 
     _ensure_generation_directory(target_dir, force)
     _write_rendered_template_tree(template_dir, target_dir, replacements)
+    _apply_selected_webapp_template(
+        target_dir=target_dir,
+        template=template,
+        app_name=app_name,
+        publish_name=publish_display_name,
+        workspace_name=workspace_name,
+        routing_mode=routing_mode,
+        auth_mode=auth_mode,
+    )
     _customize_generated_package_json(
         package_json_path=target_dir / "package.json",
         feature_packs=feature_packs,

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -165,7 +165,8 @@ def _resolve_webapp_template_directory(framework: str, template: str) -> Path:
 
     raise FileNotFoundError(
         "Bundled webapp template not found for framework "
-        f"'{framework}' and template '{source_template}'."
+        f"'{framework}', selected template '{template}', and source template "
+        f"'{source_template}'."
     )
 
 

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -428,6 +428,252 @@ def _build_webapp_shell_component(template: str) -> str:
     )
 
 
+def _build_webapp_app_module(enable_ok_feature: bool) -> str:
+    """Render app.module.ts for the selected feature-pack set."""
+    ok_imports = []
+    ok_modules = []
+    if enable_ok_feature:
+        ok_imports = [
+            "import { OkFvMasterDetailListItemModule } from '@ni/ok-angular/fv/master-detail-list-item';",
+            "import { OkFvMasterDetailListModule } from '@ni/ok-angular/fv/master-detail-list';",
+        ]
+        ok_modules = [
+            "    OkFvMasterDetailListModule,",
+            "    OkFvMasterDetailListItemModule,",
+        ]
+
+    lines = [
+        "import { APP_BASE_HREF, CommonModule } from '@angular/common';",
+        "import { NgModule } from '@angular/core';",
+        "import { FormsModule } from '@angular/forms';",
+        "",
+        "import {",
+        "  NimbleAnchorTabModule,",
+        "  NimbleAnchorTabsModule,",
+        "  NimbleBannerModule,",
+        "  NimbleButtonModule,",
+        "  NimbleCheckboxModule,",
+        "  NimbleDialogModule,",
+        "  NimbleDrawerModule,",
+        "  NimbleListOptionModule,",
+        "  NimbleSelectModule,",
+        "  NimbleSpinnerModule,",
+        "  NimbleSwitchModule,",
+        "  NimbleTextAreaModule,",
+        "  NimbleTextFieldModule,",
+        "  NimbleThemeProviderModule,",
+        "} from '@ni/nimble-angular';",
+        "import { NimbleChipModule } from '@ni/nimble-angular/chip';",
+        "import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';",
+        "import { NimbleTableModule } from '@ni/nimble-angular/table';",
+        "import { NimbleTableColumnTextModule } from '@ni/nimble-angular/table-column/text';",
+    ]
+    if ok_imports:
+        lines.extend([*ok_imports])
+
+    lines.extend(
+        [
+            "",
+            "import { AppRoutingModule } from './app-routing.module';",
+            "import { AssetsPageComponent } from './features/assets/assets-page.component';",
+            "import { DatasetsPageComponent } from './features/datasets/datasets-page.component';",
+            "import { HomePageComponent } from './features/home/home-page.component';",
+            "import { MasterDetailPageComponent } from './features/master-detail/master-detail-page.component';",
+            "import { OperationsPageComponent } from './features/operations/operations-page.component';",
+            "import { SettingsPageComponent } from './features/settings/settings-page.component';",
+            "import { EmptyStateComponent } from './shared/components/empty-state.component';",
+            "import { ErrorBannerComponent } from './shared/components/error-banner.component';",
+            "import { LoadingStateComponent } from './shared/components/loading-state.component';",
+            "",
+            "@NgModule({",
+            "  declarations: [",
+            "    HomePageComponent,",
+            "    DatasetsPageComponent,",
+            "    AssetsPageComponent,",
+            "    MasterDetailPageComponent,",
+            "    OperationsPageComponent,",
+            "    SettingsPageComponent,",
+            "    LoadingStateComponent,",
+            "    ErrorBannerComponent,",
+            "    EmptyStateComponent,",
+            "  ],",
+            "  imports: [",
+            "    CommonModule,",
+            "    FormsModule,",
+            "    AppRoutingModule,",
+            "    NimbleThemeProviderModule,",
+            "    NimbleLabelProviderCoreModule,",
+            "    NimbleAnchorTabsModule,",
+            "    NimbleAnchorTabModule,",
+            "    NimbleBannerModule,",
+            "    NimbleButtonModule,",
+            "    NimbleCheckboxModule,",
+            "    NimbleChipModule,",
+            "    NimbleDialogModule,",
+            "    NimbleDrawerModule,",
+            "    NimbleListOptionModule,",
+            "    NimbleSelectModule,",
+            "    NimbleSpinnerModule,",
+            "    NimbleSwitchModule,",
+            "    NimbleTextAreaModule,",
+            "    NimbleTextFieldModule,",
+            "    NimbleTableModule,",
+            "    NimbleTableColumnTextModule,",
+            *ok_modules,
+            "  ],",
+            "  providers: [{ provide: APP_BASE_HREF, useValue: '/' }],",
+            "})",
+            "export class AppModule {}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_master_detail_page_template(enable_ok_feature: bool) -> str:
+    """Render master-detail-page.component.html for the selected feature-pack set."""
+    list_markup = """
+            <ok-fv-master-detail-list
+                class=\"master-detail__list\"
+                placeholder=\"Filter devices...\"
+                (change)=\"onSelectionChange($event)\"
+            >
+                <ok-fv-master-detail-list-item
+                    *ngFor=\"let device of filteredDevices\"
+                    [attr.title-text]=\"device.name\"
+                    [attr.subtitle]=\"device.summary\"
+                    [attr.value]=\"device.id\"
+                    [attr.status-color]=\"device.statusColor || null\"
+                    [attr.status-label]=\"device.statusLabel || null\"
+                    [selected]=\"device.id === selectedDeviceId\"
+                ></ok-fv-master-detail-list-item>
+            </ok-fv-master-detail-list>
+""".rstrip()
+    if not enable_ok_feature:
+        list_markup = """
+            <nimble-select
+                class=\"master-detail__list\"
+                aria-label=\"Devices\"
+                filter-mode=\"standard\"
+                [(ngModel)]=\"selectedDeviceId\"
+                (ngModelChange)=\"onSelectedDeviceIdChange()\"
+            >
+                <nimble-list-option *ngFor=\"let device of filteredDevices\" [value]=\"device.id\">
+                    {{ device.name }} · {{ device.summary }}
+                </nimble-list-option>
+            </nimble-select>
+""".rstrip()
+
+    return (
+        """<section class=\"master-detail sl-page\">
+    <header class=\"sl-page__intro\">
+        <p class=\"sl-page__eyebrow\">Starter Pattern: Master Detail</p>
+        <h2>Use this sample layout when selection and lightweight editing need to stay side by side.</h2>
+        <p>
+            The list items, fields, and helper copy here are starter content. Replace them when the
+            route is connected to the real records your app manages.
+        </p>
+    </header>
+
+    <div class=\"master-detail__toolbar sl-toolbar\">
+        <div class=\"sl-toolbar__primary\">
+            <nimble-button
+                appearance=\"block\"
+                appearance-variant=\"accent\"
+                (click)=\"isEditing ? saveChanges() : toggleEditMode()\"
+                [disabled]=\"!selectedDevice\"
+            >
+                {{ isEditing ? 'Save details' : 'Edit details' }}
+            </nimble-button>
+        </div>
+    </div>
+
+    <div class=\"master-detail__workspace\">
+        <aside class=\"master-detail__master\">
+            <nimble-text-field
+                class=\"master-detail__filter\"
+                [(ngModel)]=\"filterTerm\"
+                placeholder=\"Search devices\"
+                (ngModelChange)=\"applyFilter()\"
+            >
+                Filter devices
+            </nimble-text-field>
+
+"""
+        + list_markup
+        + """
+        </aside>
+
+        <section class=\"master-detail__detail\" *ngIf=\"selectedDevice as device; else emptyState\">
+            <div class=\"master-detail__detail-header\">
+                <div>
+                    <h3>{{ device.name }}</h3>
+                    <p *ngIf=\"device.statusLabel\">{{ device.statusLabel }}</p>
+                </div>
+                <nimble-chip *ngIf=\"device.statusLabel\">{{ device.statusLabel }}</nimble-chip>
+            </div>
+
+            <div class=\"master-detail__detail-grid\">
+                <div>
+                    <span>Device name</span>
+                    <strong>{{ device.name }}</strong>
+                </div>
+                <div>
+                    <span>Model</span>
+                    <strong>{{ device.model }}</strong>
+                </div>
+                <div>
+                    <span>IP address</span>
+                    <strong>{{ device.ipAddress }}</strong>
+                </div>
+                <div>
+                    <span>Firmware version</span>
+                    <strong>{{ device.firmwareVersion }}</strong>
+                </div>
+            </div>
+
+            <div class=\"master-detail__edit-grid\">
+                <nimble-text-field [(ngModel)]=\"device.location\" [readonly]=\"!isEditing\">
+                    Location
+                </nimble-text-field>
+                <nimble-text-field [(ngModel)]=\"device.systemId\" [readonly]=\"!isEditing\">
+                    Device ID
+                </nimble-text-field>
+            </div>
+
+            <nimble-text-area [(ngModel)]=\"device.notes\" [readonly]=\"!isEditing\" resize=\"vertical\">
+                Notes
+            </nimble-text-area>
+
+            <nimble-switch [(ngModel)]=\"device.monitorEnabled\" [disabled]=\"!isEditing\">
+                Include in monitor roster
+            </nimble-switch>
+
+            <nimble-banner *ngIf=\"device.statusLabel === 'Pending changes'\" [open]=\"true\" severity=\"warning\">
+                Review the pending changes before this device returns to the connected roster.
+            </nimble-banner>
+
+            <dl class=\"master-detail__facts\">
+                <div>
+                    <dt>Last seen</dt>
+                    <dd>{{ device.lastSeen }}</dd>
+                </div>
+                <div>
+                    <dt>Calibration due</dt>
+                    <dd>{{ device.calibrationDue }}</dd>
+                </div>
+            </dl>
+        </section>
+    </div>
+
+    <ng-template #emptyState>
+        <sl-empty-state [message]=\"'Adjust the filter or add a real device query to populate this pattern.'\"></sl-empty-state>
+    </ng-template>
+</section>
+"""
+    )
+
+
 def _quoted_typescript_list(values: List[str]) -> str:
     """Return a comma-separated TypeScript string literal list."""
     return ",\n        ".join(f"'{value}'" for value in values)
@@ -596,9 +842,15 @@ def _apply_selected_webapp_template(
     workspace_name: str,
     routing_mode: str,
     auth_mode: str,
+    feature_packs: List[str],
 ) -> None:
     """Rewrite the generated starter entrypoints for the selected template."""
     app_dir = target_dir / "src" / "app"
+    enable_ok_feature = "ok" in feature_packs
+    (app_dir / "app.module.ts").write_text(
+        _build_webapp_app_module(enable_ok_feature),
+        encoding="utf-8",
+    )
     (app_dir / "app-routing.module.ts").write_text(
         _build_webapp_routing_module(template, routing_mode),
         encoding="utf-8",
@@ -609,6 +861,10 @@ def _apply_selected_webapp_template(
     )
     (app_dir / "core" / "systemlink" / "webapp-home-data.service.ts").write_text(
         _build_webapp_home_data_service(template),
+        encoding="utf-8",
+    )
+    (app_dir / "features" / "master-detail" / "master-detail-page.component.html").write_text(
+        _build_master_detail_page_template(enable_ok_feature),
         encoding="utf-8",
     )
     (target_dir / "README.md").write_text(
@@ -885,6 +1141,7 @@ def _generate_new_webapp(
         workspace_name=workspace_name,
         routing_mode=routing_mode,
         auth_mode=auth_mode,
+        feature_packs=feature_packs,
     )
     _customize_generated_package_json(
         package_json_path=target_dir / "package.json",

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -27,18 +27,18 @@ _WEBAPP_DEFAULT_FEATURE_PACKS = "nimble,clients,ok"
 _WEBAPP_SUPPORTED_ANGULAR_MAJOR = "20"
 _WEBAPP_VERSION_MANIFEST: Dict[str, Dict[str, str]] = {
     "20": {
-        "angular": "^20.3.0",
-        "typescript": "~5.9.2",
-        "zoneJs": "~0.15.0",
-        "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "angularBuild": "^20.3.30",
-        "nimbleAngular": "~33.2.0",
-        "nimbleComponents": "~35.8.0",
-        "okComponents": "1.6.0",
-        "unitFormat": "^1.0.4",
-        "systemlinkClients": "2.2.0",
-        "sprightAngular": "latest",
+        "angular": "^20.3.26",
+        "typescript": "~5.9.3",
+        "zoneJs": "~0.15.1",
+        "rxjs": "~7.8.2",
+        "tslib": "^2.8.1",
+        "angularBuild": "^20.3.32",
+        "nimbleAngular": "~33.4.4",
+        "nimbleComponents": "~35.12.3",
+        "okAngular": "2.5.0",
+        "unitFormat": "^1.0.5",
+        "systemlinkClients": "3.0.2",
+        "sprightAngular": "9.5.5",
         "nodeEngine": ">=24",
     }
 }
@@ -637,7 +637,6 @@ def _base_angular_dependencies(angular_major: str) -> Dict[str, str]:
         "@angular/forms": angular_version,
         "@angular/platform-browser": angular_version,
         "@angular/router": angular_version,
-        "@ni/ok-components": manifest["okComponents"],
         "rxjs": manifest["rxjs"],
         "tslib": manifest["tslib"],
         "zone.js": manifest["zoneJs"],
@@ -673,6 +672,8 @@ def _feature_pack_dependencies(feature_packs: List[str], angular_major: str) -> 
         dependencies["@ni/systemlink-clients-ts"] = manifest["systemlinkClients"]
     if "spright" in feature_packs:
         dependencies["@ni/spright-angular"] = manifest["sprightAngular"]
+    if "ok" in feature_packs:
+        dependencies["@ni/ok-angular"] = manifest["okAngular"]
     return dependencies
 
 

--- a/slcli/webapp_templates/angular/blank/src/app/app.module.ts
+++ b/slcli/webapp_templates/angular/blank/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
-import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import {
@@ -22,6 +22,8 @@ import { NimbleChipModule } from '@ni/nimble-angular/chip';
 import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
 import { NimbleTableModule } from '@ni/nimble-angular/table';
 import { NimbleTableColumnTextModule } from '@ni/nimble-angular/table-column/text';
+import { OkFvMasterDetailListItemModule } from '@ni/ok-angular/fv/master-detail-list-item';
+import { OkFvMasterDetailListModule } from '@ni/ok-angular/fv/master-detail-list';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AssetsPageComponent } from './features/assets/assets-page.component';
@@ -68,8 +70,9 @@ import { LoadingStateComponent } from './shared/components/loading-state.compone
     NimbleTextFieldModule,
     NimbleTableModule,
     NimbleTableColumnTextModule,
+    OkFvMasterDetailListModule,
+    OkFvMasterDetailListItemModule,
   ],
   providers: [{ provide: APP_BASE_HREF, useValue: '/' }],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AppModule {}

--- a/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.html
+++ b/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.html
@@ -23,19 +23,28 @@
 
   <div class="master-detail__workspace">
     <aside class="master-detail__master">
+      <nimble-text-field
+        class="master-detail__filter"
+        [(ngModel)]="filterTerm"
+        placeholder="Search devices"
+        (ngModelChange)="applyFilter()"
+      >
+        Filter devices
+      </nimble-text-field>
+
       <ok-fv-master-detail-list
         class="master-detail__list"
         placeholder="Filter devices..."
         (change)="onSelectionChange($event)"
       >
         <ok-fv-master-detail-list-item
-          *ngFor="let device of devices"
+          *ngFor="let device of filteredDevices"
           [attr.title-text]="device.name"
           [attr.subtitle]="device.summary"
           [attr.value]="device.id"
           [attr.status-color]="device.statusColor || null"
           [attr.status-label]="device.statusLabel || null"
-          [attr.selected]="device.id === selectedDeviceId ? '' : null"
+          [selected]="device.id === selectedDeviceId"
         ></ok-fv-master-detail-list-item>
       </ok-fv-master-detail-list>
     </aside>

--- a/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.scss
+++ b/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.scss
@@ -13,13 +13,17 @@
 .master-detail__master {
   display: flex;
   flex-direction: column;
+  gap: var(--ni-nimble-medium-padding);
   min-height: 0;
   padding-right: var(--ni-nimble-large-padding);
   border-right: 1px solid var(--app-divider);
 }
 
+.master-detail__filter {
+  flex: 0 0 auto;
+}
+
 .master-detail__list {
-  display: block;
   flex: 1;
   min-height: 0;
 }

--- a/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
+++ b/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
@@ -166,6 +166,10 @@ export class MasterDetailPageComponent {
     this.isEditing = false;
   }
 
+  onSelectedDeviceIdChange(): void {
+    this.isEditing = false;
+  }
+
   toggleEditMode(): void {
     if (!this.selectedDevice) {
       return;

--- a/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
+++ b/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 
-import '@ni/ok-components/dist/esm/fv/master-detail-list';
-
 interface DeviceRecord {
   id: string;
   name: string;
@@ -126,14 +124,36 @@ const DEVICE_ROWS: readonly DeviceRecord[] = [
   templateUrl: './master-detail-page.component.html',
   styleUrl: './master-detail-page.component.scss',
 })
-export class MasterDetailPageComponent {
+export class MasterDetailPageComponent implements AfterViewInit {
   readonly devices: DeviceRecord[] = DEVICE_ROWS.map((device: DeviceRecord) => ({ ...device }));
+
+  filteredDevices: readonly DeviceRecord[] = [...this.devices];
+  filterTerm = '';
 
   selectedDeviceId = this.devices[0]?.id ?? '';
   isEditing = false;
 
   get selectedDevice(): DeviceRecord | null {
     return this.devices.find((device: DeviceRecord) => device.id === this.selectedDeviceId) ?? null;
+  }
+
+  applyFilter(): void {
+    const search = this.filterTerm.trim().toLowerCase();
+    const filtered = this.devices.filter((device: DeviceRecord) => {
+      return (
+        search.length === 0 ||
+        device.name.toLowerCase().includes(search) ||
+        device.summary.toLowerCase().includes(search) ||
+        device.location.toLowerCase().includes(search) ||
+        device.model.toLowerCase().includes(search)
+      );
+    });
+
+    this.filteredDevices = filtered;
+    if (!filtered.some((device: DeviceRecord) => device.id === this.selectedDeviceId)) {
+      this.selectedDeviceId = filtered[0]?.id ?? '';
+      this.isEditing = false;
+    }
   }
 
   onSelectionChange(event: Event): void {

--- a/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
+++ b/slcli/webapp_templates/angular/blank/src/app/features/master-detail/master-detail-page.component.ts
@@ -124,7 +124,7 @@ const DEVICE_ROWS: readonly DeviceRecord[] = [
   templateUrl: './master-detail-page.component.html',
   styleUrl: './master-detail-page.component.scss',
 })
-export class MasterDetailPageComponent implements AfterViewInit {
+export class MasterDetailPageComponent {
   readonly devices: DeviceRecord[] = DEVICE_ROWS.map((device: DeviceRecord) => ({ ...device }));
 
   filteredDevices: readonly DeviceRecord[] = [...this.devices];

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -410,6 +410,17 @@ def test_webapp_new_with_nimble_only_keeps_template_base_dependencies(
     assert "@ni/ok-angular" not in dependencies
     assert "@ni/ok-components" not in dependencies
 
+    app_module = (target / "src" / "app" / "app.module.ts").read_text(encoding="utf-8")
+    master_detail_html = (
+        target / "src" / "app" / "features" / "master-detail" / "master-detail-page.component.html"
+    ).read_text(encoding="utf-8")
+
+    assert "@ni/ok-angular" not in app_module
+    assert "OkFvMasterDetailListModule" not in app_module
+    assert "ok-fv-master-detail-list" not in master_detail_html
+    assert "nimble-select" in master_detail_html
+    assert "nimble-list-option" in master_detail_html
+
 
 def test_webapp_new_accepts_ok_feature_pack(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     runner = CliRunner()

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -227,14 +227,14 @@ def test_webapp_new_blank_creates_host_ready_workspace(
     )
     readme = (target / "README.md").read_text(encoding="utf-8")
 
-    assert package_json["dependencies"]["@ni/nimble-angular"] == "~33.2.0"
-    assert package_json["dependencies"]["@ni/ok-components"] == "1.6.0"
-    assert package_json["dependencies"]["@ni/systemlink-clients-ts"] == "2.2.0"
+    assert package_json["dependencies"]["@ni/nimble-angular"] == "~33.4.4"
+    assert package_json["dependencies"]["@ni/ok-angular"] == "2.5.0"
+    assert package_json["dependencies"]["@ni/systemlink-clients-ts"] == "3.0.2"
     assert "@angular/platform-browser-dynamic" not in package_json["dependencies"]
     assert "@angular/animations" not in package_json["dependencies"]
     assert package_json["engines"]["node"] == ">=24"
-    assert package_json["devDependencies"]["@angular/localize"] == "^20.3.0"
-    assert package_json["devDependencies"]["@angular/build"] == "^20.3.30"
+    assert package_json["devDependencies"]["@angular/localize"] == "^20.3.26"
+    assert package_json["devDependencies"]["@angular/build"] == "^20.3.32"
     assert "@angular-devkit/build-angular" not in package_json["devDependencies"]
     assert "test" not in package_json["scripts"]
     assert "<base" not in index_html
@@ -245,7 +245,7 @@ def test_webapp_new_blank_creates_host_ready_workspace(
     assert "AppShellComponent" in app_component
     assert "APP_BASE_HREF" in app_module
     assert "bootstrap:" not in app_module
-    assert "CUSTOM_ELEMENTS_SCHEMA" in app_module
+    assert "CUSTOM_ELEMENTS_SCHEMA" not in app_module
     assert "CommonModule" in app_module
     assert "BrowserModule" not in app_module
     assert "MasterDetailPageComponent" in app_module
@@ -344,7 +344,8 @@ def test_webapp_new_blank_uses_supported_nimble_api_shapes(
     assert "startResize" in operations_ts
     assert "toggleDetailPane" in operations_ts
     assert "isDetailCollapsed" in operations_ts
-    assert "@ni/ok-components/dist/esm/fv/master-detail-list" in master_detail_ts
+    assert "MasterDetailChangeDetail" in master_detail_ts
+    assert "filteredDevices" in master_detail_ts
     assert ".close();" in assets_ts
     assert ".hide();" not in assets_ts
     assert "selectedRecordIds[0]" in assets_ts
@@ -368,6 +369,8 @@ def test_webapp_new_blank_uses_supported_nimble_api_shapes(
     assert "nimble-text-area" in master_detail_html
     assert "ok-fv-master-detail-list" in master_detail_html
     assert "ok-fv-master-detail-list-item" in master_detail_html
+    assert "nimble-text-field" in master_detail_html
+    assert "Filter devices" in master_detail_html
     assert "nimble-chip" in assets_html
     assert "nimble-chip" in operations_html
     assert "nimble-chip" in master_detail_html
@@ -402,10 +405,10 @@ def test_webapp_new_with_nimble_only_keeps_template_base_dependencies(
     package_json = loads((target / "package.json").read_text(encoding="utf-8"))
     dependencies = package_json["dependencies"]
 
-    assert dependencies["@ni/nimble-angular"] == "~33.2.0"
-    assert dependencies["@ni/ok-components"] == "1.6.0"
+    assert dependencies["@ni/nimble-angular"] == "~33.4.4"
     assert "@ni/systemlink-clients-ts" not in dependencies
     assert "@ni/ok-angular" not in dependencies
+    assert "@ni/ok-components" not in dependencies
 
 
 def test_webapp_new_accepts_ok_feature_pack(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -430,7 +433,7 @@ def test_webapp_new_accepts_ok_feature_pack(tmp_path: Path, monkeypatch: MonkeyP
     assert result.exit_code == 0
     package_json = loads((target / "package.json").read_text(encoding="utf-8"))
 
-    assert package_json["dependencies"]["@ni/ok-components"] == "1.6.0"
+    assert package_json["dependencies"]["@ni/ok-angular"] == "2.5.0"
     assert "@ni/systemlink-clients-ts" not in package_json["dependencies"]
 
 

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -529,19 +529,19 @@ def test_webapp_new_plugin_manager_writes_packaging_metadata(
     [
         (
             "dashboard",
-            ["path: 'datasets'", "path: 'assets'"],
+            ["path: ''", "path: 'datasets'", "path: 'assets'"],
             ["path: 'master-detail'", "path: 'operations'", "path: 'settings'"],
             "Search-first Nimble table toolbar",
         ),
         (
             "list-detail",
-            ["path: 'assets'", "path: 'master-detail'"],
+            ["path: ''", "path: 'assets'", "path: 'master-detail'"],
             ["path: 'datasets'", "path: 'operations'", "path: 'settings'"],
             "Master/detail split pane",
         ),
         (
             "admin",
-            ["path: 'operations'", "path: 'settings'"],
+            ["path: ''", "path: 'operations'", "path: 'settings'"],
             ["path: 'datasets'", "path: 'assets'", "path: 'master-detail'"],
             "Grouped settings form",
         ),
@@ -592,6 +592,18 @@ def test_webapp_new_named_templates_render_focused_navigation(
     assert "readonly tabs: readonly ShellTab[]" in shell
     assert expected_pattern in home_data
     assert expected_pattern in readme
+
+
+def test_resolve_webapp_template_directory_reports_selected_template_name(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(webapp_bootstrap, "_webapp_templates_dir_candidates", lambda: [])
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        webapp_bootstrap._resolve_webapp_template_directory("angular", "dashboard")
+
+    assert "selected template 'dashboard'" in str(exc_info.value)
+    assert "source template 'blank'" in str(exc_info.value)
 
 
 def test_webapp_new_runs_install_and_build(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -408,6 +408,32 @@ def test_webapp_new_with_nimble_only_keeps_template_base_dependencies(
     assert "@ni/ok-angular" not in dependencies
 
 
+def test_webapp_new_accepts_ok_feature_pack(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    runner = CliRunner()
+    patch_keyring(monkeypatch)
+
+    target = tmp_path / "ok-pack"
+    result = runner.invoke(
+        cli,
+        [
+            "webapp",
+            "new",
+            "ok-pack",
+            "--directory",
+            str(target),
+            "--skip-install",
+            "--with",
+            "nimble,ok",
+        ],
+    )
+
+    assert result.exit_code == 0
+    package_json = loads((target / "package.json").read_text(encoding="utf-8"))
+
+    assert package_json["dependencies"]["@ni/ok-components"] == "1.6.0"
+    assert "@ni/systemlink-clients-ts" not in package_json["dependencies"]
+
+
 def test_webapp_new_dry_run_does_not_write_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     runner = CliRunner()
     patch_keyring(monkeypatch)
@@ -495,25 +521,74 @@ def test_webapp_new_plugin_manager_writes_packaging_metadata(
     assert "npm run pack:webapp" in result.output
 
 
-def test_webapp_new_rejects_unshipped_templates(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("template", "present_routes", "absent_routes", "expected_pattern"),
+    [
+        (
+            "dashboard",
+            ["path: 'datasets'", "path: 'assets'"],
+            ["path: 'master-detail'", "path: 'operations'", "path: 'settings'"],
+            "Search-first Nimble table toolbar",
+        ),
+        (
+            "list-detail",
+            ["path: 'assets'", "path: 'master-detail'"],
+            ["path: 'datasets'", "path: 'operations'", "path: 'settings'"],
+            "Master/detail split pane",
+        ),
+        (
+            "admin",
+            ["path: 'operations'", "path: 'settings'"],
+            ["path: 'datasets'", "path: 'assets'", "path: 'master-detail'"],
+            "Grouped settings form",
+        ),
+    ],
+)
+def test_webapp_new_named_templates_render_focused_navigation(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    template: str,
+    present_routes: List[str],
+    absent_routes: List[str],
+    expected_pattern: str,
+) -> None:
     runner = CliRunner()
     patch_keyring(monkeypatch)
 
+    target = tmp_path / template
     result = runner.invoke(
         cli,
         [
             "webapp",
             "new",
-            "support-console",
+            template,
             "--directory",
-            str(tmp_path / "support"),
+            str(target),
             "--template",
-            "admin",
+            template,
+            "--skip-install",
         ],
     )
 
-    assert result.exit_code == ExitCodes.INVALID_INPUT
-    assert "Phase 1 currently supports only --template blank" in result.output
+    assert result.exit_code == 0
+
+    routing = (target / "src" / "app" / "app-routing.module.ts").read_text(encoding="utf-8")
+    shell = (target / "src" / "app" / "core" / "layout" / "app-shell.component.ts").read_text(
+        encoding="utf-8"
+    )
+    home_data = (
+        target / "src" / "app" / "core" / "systemlink" / "webapp-home-data.service.ts"
+    ).read_text(encoding="utf-8")
+    readme = (target / "README.md").read_text(encoding="utf-8")
+
+    for route in present_routes:
+        assert route in routing
+    for route in absent_routes:
+        assert route not in routing
+
+    assert "readonly tabs: readonly ShellTab[]" in shell
+    assert expected_pattern in home_data
+    assert expected_pattern in readme
 
 
 def test_webapp_new_runs_install_and_build(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add `ok` as a supported webapp feature pack and include it in the default scaffold selection
- enable `dashboard`, `list-detail`, and `admin` webapp templates by deriving focused routes, tabs, and starter docs from the hosted Angular scaffold
- extend webapp CLI tests to cover OK pack selection and the named template variants

## Testing
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q`
- `poetry run pytest`

## Release Notes
- `minor`: add OK feature-pack support and enable dashboard, list-detail, and admin hosted webapp templates
