### PR TITLE
Add virtual system creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ slcli login
 slcli testmonitor result list --summary --group-by status
 slcli asset list --calibratable --summary
 slcli system list --state CONNECTED
+slcli system create --alias "Cloud Gateway" --workspace Default
 slcli spec list --product <product> --workspace all
 
 # Scaffold the recommended hosted Angular starter

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ slcli login
 slcli testmonitor result list --summary --group-by status
 slcli asset list --calibratable --summary
 slcli system list --state CONNECTED
-slcli system create --alias "Cloud Gateway" --workspace Default
 slcli spec list --product <product> --workspace all
 
 # Scaffold the recommended hosted Angular starter

--- a/newsfragments/system-virtual-create.minor.md
+++ b/newsfragments/system-virtual-create.minor.md
@@ -1,0 +1,1 @@
+Add `slcli system create` for registering virtual systems.

--- a/site/commands.html
+++ b/site/commands.html
@@ -274,6 +274,12 @@ slcli system compare "PXI Controller A" "PXI Controller B"
 slcli system compare &lt;system-a&gt; &lt;system-b&gt; --format json</code></pre>
       <p>Compares installed software and connected assets across two systems. Accepts system IDs or aliases and highlights package-only differences, version differences, asset count mismatches, and slot differences.</p>
 
+      <h3>Create Virtual System</h3>
+      <pre><code>slcli system create --alias "Test System 01" --workspace Default
+slcli system create --alias "Test System 02" --location-id &lt;location-id&gt;
+slcli system create --alias "Test System 03" --format json</code></pre>
+      <p>Creates a virtual system that can report data without a physical Salt minion connection. The command returns the generated system ID and reports whether the system was activated.</p>
+
       <h3>Summary &amp; Reports</h3>
       <pre><code>slcli system summary
 slcli system report --type SOFTWARE --output software_report.csv

--- a/slcli/system_click.py
+++ b/slcli/system_click.py
@@ -2485,8 +2485,69 @@ def register_system_commands(cli: Any) -> None:
             handle_api_error(exc)
 
     # ------------------------------------------------------------------
-    # Phase 2: update, remove, report, job subgroup
+    # Phase 2: create, update, remove, report, job subgroup
     # ------------------------------------------------------------------
+
+    @system.command(name="create")
+    @click.option("--alias", required=True, help="Alias for the virtual system")
+    @click.option(
+        "--workspace",
+        "-w",
+        help="Workspace ID or name; defaults to the active profile workspace",
+    )
+    @click.option("--location-id", help="Location ID for the virtual system")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def create_virtual_system(
+        alias: str,
+        workspace: Optional[str],
+        location_id: Optional[str],
+        format: str,
+    ) -> None:
+        """Create a virtual system.
+
+        Virtual systems can report data without a physical Salt minion
+        connection. The command returns the generated system (minion) ID.
+        """
+        check_readonly_mode("create a virtual system")
+        format_output = validate_output_format(format)
+
+        try:
+            payload: Dict[str, Any] = {"alias": alias}
+            effective_workspace = get_effective_workspace(workspace)
+            if effective_workspace:
+                try:
+                    workspace_map = get_workspace_map()
+                    payload["workspace"] = resolve_workspace_filter(
+                        effective_workspace, workspace_map
+                    )
+                except Exception:
+                    payload["workspace"] = effective_workspace
+            if location_id:
+                payload["locationId"] = location_id
+
+            url = f"{_get_sysmgmt_base_url()}/virtual"
+            resp = make_api_request("POST", url, payload=payload)
+            data = resp.json()
+
+            if format_output.lower() == "json":
+                click.echo(json.dumps(data, indent=2))
+            else:
+                result_data = {
+                    "Alias": alias,
+                    "ID": data.get("minionId", "") if isinstance(data, dict) else "",
+                    "Activated": "No (license unavailable)" if resp.status_code == 200 else "Yes",
+                }
+                format_success("Virtual system created", result_data)
+
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
 
     @system.command(name="update")
     @click.argument("system_id")

--- a/slcli/system_click.py
+++ b/slcli/system_click.py
@@ -2522,13 +2522,8 @@ def register_system_commands(cli: Any) -> None:
             payload: Dict[str, Any] = {"alias": alias}
             effective_workspace = get_effective_workspace(workspace)
             if effective_workspace:
-                try:
-                    workspace_map = get_workspace_map()
-                    payload["workspace"] = resolve_workspace_filter(
-                        effective_workspace, workspace_map
-                    )
-                except Exception:
-                    payload["workspace"] = effective_workspace
+                workspace_map = get_workspace_map()
+                payload["workspace"] = resolve_workspace_filter(effective_workspace, workspace_map)
             if location_id:
                 payload["locationId"] = location_id
 

--- a/tests/unit/test_system_click.py
+++ b/tests/unit/test_system_click.py
@@ -1288,6 +1288,100 @@ class TestSystemSummary:
         assert result.exit_code != 0
 
 
+class TestCreateVirtualSystem:
+    """Tests for 'system create' command."""
+
+    def test_create_with_workspace_and_location(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test creating a virtual system with all supported fields."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+        monkeypatch.setattr("slcli.system_click.get_base_url", lambda: "https://test.com")
+        monkeypatch.setattr("slcli.system_click.get_workspace_map", lambda: {"ws-1": "Production"})
+        captured_requests: List[Dict[str, Any]] = []
+
+        def mock_post(*args: Any, **kwargs: Any) -> Any:
+            captured_requests.append(
+                {
+                    "method": args[0],
+                    "url": args[1],
+                    "payload": kwargs.get("payload", {}),
+                }
+            )
+            return MockResponse({"minionId": "virtual-system-1"}, status_code=201)
+
+        monkeypatch.setattr("slcli.system_click.make_api_request", mock_post)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            [
+                "system",
+                "create",
+                "--alias",
+                "Telemetry Gateway",
+                "--workspace",
+                "Production",
+                "--location-id",
+                "location-1",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured_requests == [
+            {
+                "method": "POST",
+                "url": "https://test.com/nisysmgmt/v1/virtual",
+                "payload": {
+                    "alias": "Telemetry Gateway",
+                    "workspace": "ws-1",
+                    "locationId": "location-1",
+                },
+            }
+        ]
+        assert "Virtual system created" in result.output
+        assert "virtual-system-1" in result.output
+        assert "Activated: Yes" in result.output
+
+    def test_create_json_output_for_unactivated_system(
+        self, monkeypatch: Any, runner: CliRunner
+    ) -> None:
+        """Test JSON output when the system is created without a license."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+        monkeypatch.setattr("slcli.system_click.get_effective_workspace", lambda workspace: None)
+
+        def mock_post(*args: Any, **kwargs: Any) -> Any:
+            assert kwargs["payload"] == {"alias": "Cloud Device"}
+            return MockResponse({"minionId": "virtual-system-2"}, status_code=200)
+
+        monkeypatch.setattr("slcli.system_click.make_api_request", mock_post)
+
+        cli = make_cli()
+        result = runner.invoke(
+            cli,
+            ["system", "create", "--alias", "Cloud Device", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"minionId": "virtual-system-2"}
+
+    def test_create_api_error(self, monkeypatch: Any, runner: CliRunner) -> None:
+        """Test virtual-system creation handles API errors."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+        monkeypatch.setattr("slcli.system_click.get_effective_workspace", lambda workspace: None)
+
+        def mock_post(*args: Any, **kwargs: Any) -> Any:
+            raise Exception("Forbidden")
+
+        monkeypatch.setattr("slcli.system_click.make_api_request", mock_post)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["system", "create", "--alias", "Cloud Device"])
+
+        assert result.exit_code != 0
+
+
 class TestUpdateSystem:
     """Tests for 'system update' command."""
 

--- a/tests/unit/test_system_click.py
+++ b/tests/unit/test_system_click.py
@@ -1365,6 +1365,26 @@ class TestCreateVirtualSystem:
         assert result.exit_code == 0
         assert json.loads(result.output) == {"minionId": "virtual-system-2"}
 
+    def test_create_table_output_for_unactivated_system(
+        self, monkeypatch: Any, runner: CliRunner
+    ) -> None:
+        """Test table output when the system is created without a license."""
+        patch_keyring(monkeypatch)
+        monkeypatch.setattr("slcli.profiles.is_active_profile_readonly", lambda: False)
+        monkeypatch.setattr("slcli.system_click.get_effective_workspace", lambda workspace: None)
+
+        def mock_post(*args: Any, **kwargs: Any) -> Any:
+            assert kwargs["payload"] == {"alias": "Cloud Device"}
+            return MockResponse({"minionId": "virtual-system-2"}, status_code=200)
+
+        monkeypatch.setattr("slcli.system_click.make_api_request", mock_post)
+
+        cli = make_cli()
+        result = runner.invoke(cli, ["system", "create", "--alias", "Cloud Device"])
+
+        assert result.exit_code == 0
+        assert "Activated: No (license unavailable)" in result.output
+
     def test_create_api_error(self, monkeypatch: Any, runner: CliRunner) -> None:
         """Test virtual-system creation handles API errors."""
         patch_keyring(monkeypatch)


### PR DESCRIPTION
## Summary
- add `slcli system create` for registering virtual systems through the Systems Management API
- support alias, workspace/profile resolution, optional location, and table or JSON output
- report when a virtual system is created without an available license activation

## Testing
- `poetry run black .`
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q` (1301 passed)
- `poetry run pytest` (1301 passed)
- `poetry run towncrier check --compare-with origin/main`

## Release Notes
- Minor: add `slcli system create` for registering virtual systems.