### PR TITLE
Secure bot Towncrier fragment checkout

### DIFF
--- a/.github/workflows/bot-towncrier-fragment.yml
+++ b/.github/workflows/bot-towncrier-fragment.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
   add-towncrier-fragment:
@@ -19,25 +18,27 @@ jobs:
         github.event.pull_request.user.login == 'renovate[bot]' ||
         github.event.pull_request.user.login == 'dependabot[bot]'
       )
+    environment:
+      name: towncrier-fragment
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout base branch
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
       - name: Create Towncrier fragment
         shell: bash
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          git fetch origin "${BASE_REF}" --depth=1
-          if git diff --name-only FETCH_HEAD...HEAD -- newsfragments | grep -q '^newsfragments/'; then
+          git fetch --no-tags origin "${HEAD_SHA}"
+          if git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- newsfragments | grep -q '^newsfragments/'; then
             echo "Newsfragment already present on PR branch."
             exit 0
           fi
@@ -59,10 +60,12 @@ jobs:
           esac
 
           printf '%s\n' "$content" > "$fragment"
+          echo "FRAGMENT_PATH=$fragment" >> "$GITHUB_ENV"
 
       - name: Commit Towncrier fragment
         shell: bash
         env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
@@ -74,6 +77,9 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add newsfragments
-          git commit -m "chore(ci): add towncrier fragment for PR #${PR_NUMBER}"
-          git push origin "HEAD:${HEAD_REF}"
+          fragment_blob=$(git hash-object -w "$FRAGMENT_PATH")
+          git read-tree "$HEAD_SHA"
+          git update-index --add --cacheinfo "100644,${fragment_blob},${FRAGMENT_PATH}"
+          tree_sha=$(git write-tree)
+          commit_sha=$(git commit-tree "$tree_sha" -p "$HEAD_SHA" -m "chore(ci): add towncrier fragment for PR #${PR_NUMBER}")
+          git push origin "${commit_sha}:refs/heads/${HEAD_REF}"

--- a/.github/workflows/bot-towncrier-fragment.yml
+++ b/.github/workflows/bot-towncrier-fragment.yml
@@ -50,6 +50,10 @@ jobs:
           fi
 
           fragment="newsfragments/deps-${fragment_stem}.patch.md"
+          if git cat-file -e "${HEAD_SHA}:${fragment}" 2>/dev/null; then
+            fragment="newsfragments/deps-${fragment_stem}-${PR_NUMBER}.patch.md"
+          fi
+
           content="$PR_TITLE"
           content="${content#chore(deps): }"
           content="${content#chore: }"
@@ -82,4 +86,4 @@ jobs:
           git update-index --add --cacheinfo "100644,${fragment_blob},${FRAGMENT_PATH}"
           tree_sha=$(git write-tree)
           commit_sha=$(git commit-tree "$tree_sha" -p "$HEAD_SHA" -m "chore(ci): add towncrier fragment for PR #${PR_NUMBER}")
-          git push origin "${commit_sha}:refs/heads/${HEAD_REF}"
+          git push --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" origin "${commit_sha}:refs/heads/${HEAD_REF}"

--- a/newsfragments/secure-bot-towncrier-checkout.patch.md
+++ b/newsfragments/secure-bot-towncrier-checkout.patch.md
@@ -1,0 +1,1 @@
+Prevent privileged workflows from checking out pull request-controlled code when generating dependency update fragments.


### PR DESCRIPTION
## Summary

- check out only the trusted base branch in the privileged `pull_request_target` workflow
- preserve Renovate PR contents by creating the fragment commit from fetched Git objects without materializing or executing PR-controlled files
- reduce token permissions to `contents: write` and bind the job to the `towncrier-fragment` environment

## Testing

- `poetry run ni-python-styleguide lint`
- `poetry run black --check .`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q` (1302 passed)
- `poetry run pytest` (1302 passed)
- `poetry run towncrier check --compare-with origin/main`
- workflow YAML, embedded Bash syntax, and base-only checkout invariants validated locally

## Release Notes

- Patch: prevent privileged workflows from checking out pull request-controlled code when generating dependency fragments.

## Notes

The `towncrier-fragment` GitHub environment must be created and configured in repository settings before merge; naming it in workflow YAML alone does not add protection rules. Restrict deployments to `main` and configure the desired reviewer/bypass policy. Required reviewers will make fragment generation wait for approval.