### PR TITLE
Add self-signed certificate trust support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ slcli resolves runtime connection settings in this order:
 
 Use `slcli info` to see the effective source for each value and whether environment overrides are active. Use `slcli config view` to inspect the stored profile values on disk.
 
+### Self-Signed Server Certificates
+
+TLS certificate verification remains enabled by default. When `slcli login` or `slcli config add` reaches a server with an untrusted certificate, it displays the certificate subject, issuer, validity, and SHA-256 fingerprint before asking for approval. The certificate is stored only after explicit approval and is then used as a verified PEM trust entry for that server origin.
+
+For non-interactive setup, provide the fingerprint explicitly:
+
+```bash
+slcli login --url https://systemlink.example.local \
+	--api-key "$SYSTEMLINK_API_KEY" \
+	--web-url https://systemlink.example.local \
+	--trust-fingerprint <sha256-fingerprint>
+```
+
+Trust entries can also be managed directly:
+
+```bash
+slcli config trust list
+slcli config trust add --url https://systemlink.example.local --fingerprint <sha256-fingerprint>
+slcli config trust remove --url https://systemlink.example.local
+```
+
+Managed certificates are stored under the `trust` directory next to the slcli configuration file. Hostname verification is still enforced. `SLCLI_SSL_VERIFY=false` disables certificate verification entirely and should only be used as a temporary diagnostic override; it does not add a trusted certificate.
+
 ## Documentation
 
 | Section                                                                            | Description                                                |

--- a/newsfragments/self-signed-certificate-trust.minor.md
+++ b/newsfragments/self-signed-certificate-trust.minor.md
@@ -1,0 +1,1 @@
+Add explicit trust-store support for SystemLink servers using self-signed TLS certificates.

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -248,7 +248,7 @@ def _add_profile_impl(
     click.echo("Checking server connectivity and services...")
     status = check_service_status(url, api_key)
 
-    if status.get("certificate_error"):
+    if status.get("certificate_error") and not status.get("server_reachable"):
         status = _trust_certificate_if_requested(url, api_key, status, trust_fingerprint)
 
     platform = status["platform"]

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -4,8 +4,9 @@ import getpass
 import json
 import os
 import re
+import ssl
 import sys
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 from urllib.parse import urlparse
 
 import click
@@ -18,8 +19,15 @@ from .platform import (
 )
 from .profiles import ProfileConfig, Profile, check_config_file_permissions
 from .rich_output import render_table
+from .ssl_trust import (
+    get_managed_trust_records,
+    get_ssl_server_origin,
+    inspect_server_certificate,
+    remove_managed_trust,
+    save_managed_certificate,
+)
 from .table_utils import output_formatted_list
-from .utils import ExitCodes
+from .utils import ExitCodes, get_base_url
 
 API_KEY_LENGTH = 42
 API_KEY_PATTERN = re.compile(rf"^[A-Za-z0-9_-]{{{API_KEY_LENGTH}}}$")
@@ -30,7 +38,7 @@ ENV_OVERRIDE_FIELDS = (
 )
 
 
-def _exit_with_validation_error(message: str, exit_code: int = ExitCodes.INVALID_INPUT) -> None:
+def _exit_with_validation_error(message: str, exit_code: int = ExitCodes.INVALID_INPUT) -> NoReturn:
     """Exit the command with a consistent validation message."""
     click.echo(f"✗ {message}", err=True)
     sys.exit(exit_code)
@@ -100,6 +108,91 @@ def _all_service_probes_unauthorized(services: dict[str, str]) -> bool:
     return bool(services) and all(status == "unauthorized" for status in services.values())
 
 
+def _normalize_fingerprint(fingerprint: str) -> str:
+    """Normalize a SHA-256 certificate fingerprint supplied by a user."""
+    normalized = fingerprint.replace(":", "").replace(" ", "").strip().upper()
+    if len(normalized) != 64 or any(
+        character not in "0123456789ABCDEF" for character in normalized
+    ):
+        _exit_with_validation_error("Certificate fingerprint must be a 64-character SHA-256 value.")
+    return normalized
+
+
+def _show_certificate_warning(certificate: dict[str, Any]) -> None:
+    """Display the identity of a certificate before it is trusted."""
+    click.echo("\n⚠️  TLS certificate verification failed.", err=True)
+    click.echo(f"  Server: {certificate.get('origin', 'unknown')}", err=True)
+    click.echo(f"  Subject: {certificate.get('subject', 'unknown')}", err=True)
+    click.echo(f"  Issuer: {certificate.get('issuer', 'unknown')}", err=True)
+    click.echo(f"  SHA-256: {certificate.get('fingerprint', 'unknown')}", err=True)
+    click.echo(f"  Self-signed: {'yes' if certificate.get('self-signed') else 'no'}", err=True)
+    click.echo(
+        f"  Valid: {certificate.get('not-before', 'unknown')} to "
+        f"{certificate.get('not-after', 'unknown')}",
+        err=True,
+    )
+
+
+def _trust_certificate_if_requested(
+    url: str, api_key: str, status: dict[str, Any], trust_fingerprint: Optional[str]
+) -> dict[str, Any]:
+    """Prompt for or apply certificate trust after a verification failure."""
+    certificate_details = status.get("certificate")
+    if not isinstance(certificate_details, dict):
+        _exit_with_validation_error(
+            "TLS certificate verification failed, but the server certificate could not be "
+            "inspected. Profile was not saved.",
+            ExitCodes.NETWORK_ERROR,
+        )
+
+    _show_certificate_warning(certificate_details)
+    expected_fingerprint = _normalize_fingerprint(trust_fingerprint) if trust_fingerprint else None
+    actual_fingerprint = str(certificate_details.get("fingerprint", "")).upper()
+    if expected_fingerprint:
+        if expected_fingerprint != actual_fingerprint:
+            _exit_with_validation_error(
+                "The server certificate fingerprint does not match --trust-fingerprint. "
+                "Profile was not saved.",
+                ExitCodes.INVALID_INPUT,
+            )
+    elif not click.confirm("Trust this certificate for this server?", default=False):
+        _exit_with_validation_error("Certificate was not trusted. Profile was not saved.")
+
+    try:
+        certificate = inspect_server_certificate(url)
+    except (OSError, ValueError, ssl.SSLError) as exc:
+        _exit_with_validation_error(
+            f"Could not inspect the server certificate: {exc}. Profile was not saved.",
+            ExitCodes.NETWORK_ERROR,
+        )
+
+    if certificate.fingerprint != actual_fingerprint:
+        _exit_with_validation_error(
+            "The server certificate changed during approval. Profile was not saved.",
+            ExitCodes.NETWORK_ERROR,
+        )
+
+    try:
+        save_managed_certificate(certificate)
+        retry_status = check_service_status(url, api_key)
+    except (OSError, ValueError) as exc:
+        _exit_with_validation_error(
+            f"Could not save the trusted certificate: {exc}. Profile was not saved.",
+            ExitCodes.GENERAL_ERROR,
+        )
+
+    if not retry_status.get("server_reachable") or retry_status.get("certificate_error"):
+        remove_managed_trust(url)
+        _exit_with_validation_error(
+            "The server could not be verified after trusting its certificate. "
+            "Profile was not saved.",
+            ExitCodes.NETWORK_ERROR,
+        )
+
+    click.echo("  Certificate: ✓ Trusted for this server")
+    return retry_status
+
+
 def _add_profile_impl(
     profile: Optional[str],
     url: Optional[str],
@@ -108,6 +201,7 @@ def _add_profile_impl(
     workspace: Optional[str],
     set_current: bool,
     readonly: bool,
+    trust_fingerprint: Optional[str] = None,
 ) -> None:
     """Shared implementation for add-profile and login commands.
 
@@ -122,6 +216,7 @@ def _add_profile_impl(
         workspace: Default workspace for this profile
         set_current: Whether to set as the current profile
         readonly: Whether to enable readonly mode
+        trust_fingerprint: Optional SHA-256 fingerprint for non-interactive trust approval
     """
     # Get profile name
     if not profile:
@@ -152,6 +247,10 @@ def _add_profile_impl(
     # Detect platform type and check service status
     click.echo("Checking server connectivity and services...")
     status = check_service_status(url, api_key)
+
+    if status.get("certificate_error"):
+        status = _trust_certificate_if_requested(url, api_key, status, trust_fingerprint)
+
     platform = status["platform"]
     services = status.get("services", {})
 
@@ -458,6 +557,98 @@ def register_config_commands(cli: Any) -> None:
         if warning:
             click.echo(f"\n⚠️  {warning}", err=True)
 
+    @config.group(name="trust")
+    def trust() -> None:
+        """Manage explicitly trusted server certificates."""
+        pass
+
+    @trust.command(name="list")
+    @click.option(
+        "--format",
+        "output_format",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        help="Output format",
+    )
+    def list_trusted_certificates(output_format: str) -> None:
+        """List certificates trusted by slcli."""
+        records = get_managed_trust_records()
+        if output_format == "json":
+            click.echo(json.dumps(records, indent=2))
+            return
+        if not records:
+            click.echo("No managed server certificates.")
+            return
+
+        rows = [
+            [
+                str(record.get("origin", "")),
+                str(record.get("fingerprint", "")),
+                "yes" if record.get("self-signed") else "no",
+            ]
+            for record in records
+        ]
+        render_table(
+            headers=["SERVER", "SHA-256", "SELF-SIGNED"],
+            column_widths=[40, 64, 12],
+            rows=rows,
+            show_total=True,
+            total_label="certificate(s)",
+        )
+
+    @trust.command(name="add")
+    @click.option("--url", help="HTTPS server URL (defaults to the active API URL)")
+    @click.option(
+        "--fingerprint",
+        required=True,
+        help="Expected SHA-256 fingerprint of the certificate to trust",
+    )
+    def add_trusted_certificate(url: Optional[str], fingerprint: str) -> None:
+        """Trust a server certificate after verifying its fingerprint."""
+        server_url = url or get_base_url()
+        try:
+            expected_fingerprint = _normalize_fingerprint(fingerprint)
+            certificate = inspect_server_certificate(server_url)
+        except (OSError, ValueError, ssl.SSLError) as exc:
+            _exit_with_validation_error(f"Could not inspect the server certificate: {exc}.")
+
+        _show_certificate_warning(certificate.to_dict())
+        if certificate.fingerprint != expected_fingerprint:
+            _exit_with_validation_error(
+                "The server certificate fingerprint does not match the supplied fingerprint."
+            )
+        try:
+            path = save_managed_certificate(certificate)
+        except OSError as exc:
+            _exit_with_validation_error(f"Could not save the trusted certificate: {exc}.")
+        click.echo(f"✓ Trusted certificate for {certificate.origin}")
+        click.echo(f"  Certificate file: {path}")
+
+    @trust.command(name="remove")
+    @click.option("--url", help="HTTPS server URL (defaults to the active API URL)")
+    @click.option("--force", is_flag=True, help="Skip confirmation prompt")
+    def remove_trusted_certificate(url: Optional[str], force: bool) -> None:
+        """Remove a server certificate from the managed trust store."""
+        server_url = url or get_base_url()
+        try:
+            origin = get_ssl_server_origin(server_url)
+        except ValueError as exc:
+            _exit_with_validation_error(str(exc))
+        if not force and not click.confirm(
+            f"Remove trusted certificate for {origin}?", default=False
+        ):
+            click.echo("Certificate was not removed.")
+            return
+        try:
+            removed = remove_managed_trust(server_url)
+        except (OSError, ValueError) as exc:
+            _exit_with_validation_error(f"Could not remove the trusted certificate: {exc}.")
+        if not removed:
+            _exit_with_validation_error(
+                f"No trusted certificate found for {origin}.", ExitCodes.NOT_FOUND
+            )
+        click.echo(f"✓ Removed trusted certificate for {origin}")
+
     @config.command(name="delete")
     @click.argument("name")
     @click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
@@ -558,6 +749,10 @@ def register_config_commands(cli: Any) -> None:
             "publish, and disable commands)"
         ),
     )
+    @click.option(
+        "--trust-fingerprint",
+        help="Trust a certificate after its SHA-256 fingerprint matches exactly",
+    )
     def add_profile(
         profile: Optional[str],
         url: Optional[str],
@@ -566,6 +761,7 @@ def register_config_commands(cli: Any) -> None:
         workspace: Optional[str],
         set_current: bool,
         readonly: bool,
+        trust_fingerprint: Optional[str],
     ) -> None:
         """Add or update a SystemLink profile.
 
@@ -588,4 +784,5 @@ def register_config_commands(cli: Any) -> None:
             workspace=workspace,
             set_current=set_current,
             readonly=readonly,
+            trust_fingerprint=trust_fingerprint,
         )

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -8,7 +8,7 @@ import ssl
 import tomllib
 from pathlib import Path
 from types import ModuleType
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import click as base_click
@@ -103,6 +103,16 @@ def _configure_rich_click_command_groups() -> None:
 
 def _get_ca_source_display() -> str:
     """Describe the CA source used for HTTPS verification."""
+    try:
+        from .ssl_trust import get_managed_trust_path
+        from .utils import get_base_url
+
+        managed_path = get_managed_trust_path(get_base_url())
+        if managed_path is not None:
+            return f"managed-pem ({managed_path})"
+    except (OSError, ValueError):
+        pass
+
     if OS_TRUST_INJECTED:
         return f"system (reason={OS_TRUST_REASON})"
 
@@ -113,13 +123,16 @@ def _get_ca_source_display() -> str:
     return f"certifi (reason={OS_TRUST_REASON})"
 
 
-def _build_tls_debug_context(ssl_verify: bool) -> ssl.SSLContext:
+def _build_tls_debug_context(ssl_verify: Union[bool, str]) -> ssl.SSLContext:
     """Build an SSL context aligned with the current CLI trust configuration."""
     if not ssl_verify:
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         return ctx
+
+    if isinstance(ssl_verify, str):
+        return ssl.create_default_context(cafile=ssl_verify)
 
     verify_env = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE")
     if verify_env:
@@ -204,7 +217,7 @@ def _get_proxy_debug_rows(api_url: str) -> List[Tuple[str, str]]:
     ]
 
 
-def _probe_tls_connection(api_url: str, ssl_verify: bool) -> List[Tuple[str, str]]:
+def _probe_tls_connection(api_url: str, ssl_verify: Union[bool, str]) -> List[Tuple[str, str]]:
     """Collect TLS handshake and leaf certificate details for the API host."""
     import requests
 
@@ -268,7 +281,7 @@ def _collect_info_debug_rows(api_url: str) -> List[Tuple[str, str]]:
     """Return structured connection diagnostics for info --debug."""
     from .utils import get_ssl_verify
 
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(api_url)
     rows = [
         ("SSL Verify", "enabled" if ssl_verify else "disabled"),
         ("CA Source", _get_ca_source_display()),
@@ -414,6 +427,10 @@ def ca_info() -> None:
         "publish, and disable commands)"
     ),
 )
+@click.option(
+    "--trust-fingerprint",
+    help="Trust a certificate after its SHA-256 fingerprint matches exactly",
+)
 def login(
     profile: Optional[str],
     url: Optional[str],
@@ -422,6 +439,7 @@ def login(
     workspace: Optional[str],
     set_current: bool,
     readonly: bool,
+    trust_fingerprint: Optional[str],
 ) -> None:
     """Create or update a SystemLink profile with credentials.
 
@@ -447,6 +465,7 @@ def login(
         workspace=workspace,
         set_current=set_current,
         readonly=readonly,
+        trust_fingerprint=trust_fingerprint,
     )
 
 

--- a/slcli/platform.py
+++ b/slcli/platform.py
@@ -6,6 +6,7 @@ This module provides utilities to detect and manage the target platform
 
 import json
 import os
+import ssl
 import sys
 import time
 from functools import lru_cache
@@ -206,7 +207,7 @@ def _probe_service_status(api_url: str, api_key: str, method: str, url_path: str
         "Content-Type": "application/json",
         "User-Agent": "SystemLink-CLI/1.0 (cross-platform)",
     }
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(api_url)
 
     try:
         full_url = f"{api_url}{url_path}"
@@ -469,7 +470,7 @@ def get_file_query_capability(api_url: str, api_key: str) -> Dict[str, Any]:
         "Content-Type": "application/json",
         "User-Agent": "SystemLink-CLI/1.0 (cross-platform)",
     }
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(api_url)
 
     try:
         search_resp = requests.post(
@@ -583,7 +584,7 @@ def get_system_query_capability(api_url: str, api_key: str) -> Dict[str, Any]:
         "Content-Type": "application/json",
         "User-Agent": "SystemLink-CLI/1.0 (cross-platform)",
     }
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(api_url)
 
     try:
         search_resp = requests.post(
@@ -684,12 +685,13 @@ def check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
         "Content-Type": "application/json",
         "User-Agent": "SystemLink-CLI/1.0 (cross-platform)",
     }
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(api_url)
 
     services: Dict[str, str] = {}
     any_responded = False
     any_authorized = False
     all_unauthorized = True
+    certificate_error = False
 
     for display_name, method, url_path in SERVICE_CHECKS:
         try:
@@ -725,15 +727,28 @@ def check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
             else:
                 services[display_name] = "error"
                 all_unauthorized = False
+        except requests.exceptions.SSLError:
+            services[display_name] = "certificate_error"
+            certificate_error = True
         except requests.RequestException:
             services[display_name] = "unreachable"
 
     # Determine overall status
     if not any_responded:
+        certificate_details: Optional[Dict[str, Any]] = None
+        if certificate_error:
+            try:
+                from .ssl_trust import inspect_server_certificate
+
+                certificate_details = inspect_server_certificate(api_url).to_dict()
+            except (OSError, ValueError, ssl.SSLError):
+                certificate_details = None
         return {
             "server_reachable": False,
             "auth_valid": None,
             "services": services,
+            "certificate_error": certificate_error,
+            "certificate": certificate_details,
             "file_query_endpoint": None,
             "elasticsearch_available": None,
             "system_query_endpoint": None,
@@ -759,6 +774,7 @@ def check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
         "server_reachable": True,
         "auth_valid": auth_valid,
         "services": services,
+        "certificate_error": certificate_error,
         "file_query_endpoint": file_capability["file_query_endpoint"],
         "elasticsearch_available": file_capability["elasticsearch_available"],
         "system_query_endpoint": system_capability["system_query_endpoint"],

--- a/slcli/platform.py
+++ b/slcli/platform.py
@@ -16,6 +16,7 @@ import click
 import keyring
 import requests
 
+from .ssl_trust import use_standard_ssl_context
 from .utils import ExitCodes, get_ssl_verify
 
 DEFAULT_SERVICE_PROBE_CACHE_TTL_SECONDS = 300
@@ -680,6 +681,13 @@ def check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
         - platform: detected platform string (PLATFORM_SLE, PLATFORM_SLS,
           PLATFORM_UNREACHABLE, PLATFORM_UNKNOWN)
     """
+    ssl_verify = get_ssl_verify(api_url)
+    with use_standard_ssl_context(ssl_verify):
+        return _check_service_status(api_url, api_key)
+
+
+def _check_service_status(api_url: str, api_key: str) -> Dict[str, Any]:
+    """Probe services while the caller has selected the appropriate SSL context."""
     headers = {
         "x-ni-api-key": api_key,
         "Content-Type": "application/json",

--- a/slcli/ssl_trust.py
+++ b/slcli/ssl_trust.py
@@ -19,9 +19,10 @@ import socket
 import ssl
 import sys
 import traceback
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Union
 from urllib.parse import urlparse
 
 from cryptography import x509
@@ -29,6 +30,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 
 OS_TRUST_INJECTED: bool = False
 OS_TRUST_REASON: str = "not-attempted"
+_STANDARD_SSL_CONTEXT = ssl.SSLContext
 
 
 @dataclass(frozen=True)
@@ -70,6 +72,7 @@ __all__ = [
     "inject_os_trust",
     "remove_managed_trust",
     "save_managed_certificate",
+    "use_standard_ssl_context",
 ]
 
 
@@ -84,6 +87,42 @@ def get_ssl_server_origin(api_url: str) -> str:
         hostname = f"[{hostname}]"
     port = parsed.port or 443
     return f"https://{hostname}:{port}"
+
+
+@contextmanager
+def use_standard_ssl_context(ssl_verify: Union[bool, str]) -> Iterator[None]:
+    """Use Python's standard SSL context for explicit CA bundle verification.
+
+    The OS trust integration replaces SSL context implementations globally. For
+    explicit CA bundle paths, requests must use the standard implementation so
+    the supplied bundle is evaluated instead of the platform trust verifier.
+    """
+    if not isinstance(ssl_verify, str):
+        yield
+        return
+
+    import requests.adapters
+    import urllib3.util.ssl_ as urllib3_ssl
+
+    patched_ssl_context = ssl.SSLContext
+    patched_urllib3_context = urllib3_ssl.SSLContext
+    has_preloaded_context = hasattr(requests.adapters, "_preloaded_ssl_context")
+    patched_preloaded_context = getattr(requests.adapters, "_preloaded_ssl_context", None)
+    try:
+        setattr(ssl, "SSLContext", _STANDARD_SSL_CONTEXT)
+        setattr(urllib3_ssl, "SSLContext", _STANDARD_SSL_CONTEXT)
+        if has_preloaded_context:
+            setattr(
+                requests.adapters,
+                "_preloaded_ssl_context",
+                _STANDARD_SSL_CONTEXT(ssl.PROTOCOL_TLS_CLIENT),
+            )
+        yield
+    finally:
+        setattr(ssl, "SSLContext", patched_ssl_context)
+        setattr(urllib3_ssl, "SSLContext", patched_urllib3_context)
+        if has_preloaded_context:
+            setattr(requests.adapters, "_preloaded_ssl_context", patched_preloaded_context)
 
 
 def _get_trust_directory() -> Path:
@@ -150,13 +189,33 @@ def inspect_server_certificate(api_url: str, timeout: float = 5) -> ServerCertif
     parsed = urlparse(origin)
     assert parsed.hostname is not None
     port = parsed.port or 443
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    context.check_hostname = False
-    context.verify_mode = ssl.CERT_NONE
+    certificate_chain_pem: Optional[bytes] = None
+    patched_ssl_context = ssl.SSLContext
+    try:
+        setattr(ssl, "SSLContext", _STANDARD_SSL_CONTEXT)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
 
-    with socket.create_connection((parsed.hostname, port), timeout=timeout) as tcp_socket:
-        with context.wrap_socket(tcp_socket, server_hostname=parsed.hostname) as tls_socket:
-            certificate_der = tls_socket.getpeercert(binary_form=True)
+        with socket.create_connection((parsed.hostname, port), timeout=timeout) as tcp_socket:
+            with context.wrap_socket(tcp_socket, server_hostname=parsed.hostname) as tls_socket:
+                certificate_der = tls_socket.getpeercert(binary_form=True)
+                ssl_object = getattr(tls_socket, "_sslobj", None)
+                get_unverified_chain = getattr(ssl_object, "get_unverified_chain", None)
+                if callable(get_unverified_chain):
+                    try:
+                        chain = get_unverified_chain()
+                        chain_pem = b"".join(
+                            (pem.encode("ascii") if isinstance(pem, str) else pem)
+                            for chain_certificate in chain
+                            for pem in (chain_certificate.public_bytes(),)
+                        )
+                        if chain_pem:
+                            certificate_chain_pem = chain_pem
+                    except (AttributeError, OSError, ValueError):
+                        pass
+    finally:
+        setattr(ssl, "SSLContext", patched_ssl_context)
 
     if not certificate_der:
         raise ssl.SSLError("The server did not provide a TLS certificate.")
@@ -172,7 +231,7 @@ def inspect_server_certificate(api_url: str, timeout: float = 5) -> ServerCertif
 
     return ServerCertificate(
         origin=origin,
-        pem=certificate.public_bytes(serialization.Encoding.PEM),
+        pem=certificate_chain_pem or certificate.public_bytes(serialization.Encoding.PEM),
         fingerprint=certificate.fingerprint(hashes.SHA256()).hex().upper(),
         subject=_certificate_name(certificate.subject),
         issuer=_certificate_name(certificate.issuer),

--- a/slcli/ssl_trust.py
+++ b/slcli/ssl_trust.py
@@ -12,15 +12,239 @@ Environment Variables:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import socket
 import ssl
 import sys
 import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
 
 OS_TRUST_INJECTED: bool = False
 OS_TRUST_REASON: str = "not-attempted"
 
-__all__ = ["inject_os_trust", "OS_TRUST_INJECTED", "OS_TRUST_REASON"]
+
+@dataclass(frozen=True)
+class ServerCertificate:
+    """Certificate details captured from a server TLS handshake."""
+
+    origin: str
+    pem: bytes
+    fingerprint: str
+    subject: str
+    issuer: str
+    sans: List[str]
+    not_before: str
+    not_after: str
+    self_signed: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return certificate metadata without including the PEM bytes."""
+        return {
+            "origin": self.origin,
+            "fingerprint": self.fingerprint,
+            "subject": self.subject,
+            "issuer": self.issuer,
+            "sans": self.sans,
+            "not-before": self.not_before,
+            "not-after": self.not_after,
+            "self-signed": self.self_signed,
+        }
+
+
+__all__ = [
+    "OS_TRUST_INJECTED",
+    "OS_TRUST_REASON",
+    "ServerCertificate",
+    "get_managed_trust_path",
+    "get_managed_trust_records",
+    "get_ssl_server_origin",
+    "inspect_server_certificate",
+    "inject_os_trust",
+    "remove_managed_trust",
+    "save_managed_certificate",
+]
+
+
+def get_ssl_server_origin(api_url: str) -> str:
+    """Return a normalized HTTPS origin for a SystemLink API URL."""
+    parsed = urlparse(api_url)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise ValueError("Managed certificate trust requires an HTTPS server URL.")
+
+    hostname = parsed.hostname.lower()
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = parsed.port or 443
+    return f"https://{hostname}:{port}"
+
+
+def _get_trust_directory() -> Path:
+    """Return the managed certificate directory, creating it when needed."""
+    from .profiles import ProfileConfig
+
+    trust_directory = ProfileConfig.get_config_path().parent / "trust"
+    trust_directory.mkdir(parents=True, exist_ok=True)
+    try:
+        trust_directory.chmod(0o700)
+    except OSError:
+        pass
+    return trust_directory
+
+
+def _get_trust_stem(origin: str) -> str:
+    """Return a stable, filesystem-safe name for a server origin."""
+    return hashlib.sha256(origin.encode("utf-8")).hexdigest()
+
+
+def get_managed_trust_path(api_url: str) -> Optional[Path]:
+    """Return the managed PEM path for a URL when a trusted certificate exists."""
+    origin = get_ssl_server_origin(api_url)
+    pem_path = _get_trust_directory() / f"{_get_trust_stem(origin)}.pem"
+    metadata_path = pem_path.with_suffix(".json")
+    if not pem_path.is_file() or not metadata_path.is_file():
+        return None
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if metadata.get("origin") != origin:
+        return None
+    return pem_path
+
+
+def _certificate_name(name: x509.Name) -> str:
+    """Format a certificate distinguished name for user-facing output."""
+    return ", ".join(
+        f"{attribute.oid._name or attribute.oid.dotted_string}="
+        f"{attribute.value.decode('utf-8', errors='replace') if isinstance(attribute.value, bytes) else attribute.value}"
+        for attribute in name
+    )
+
+
+def _certificate_validity(certificate: x509.Certificate) -> tuple[str, str]:
+    """Read certificate validity dates across supported cryptography versions."""
+    not_before = getattr(certificate, "not_valid_before_utc", None)
+    not_after = getattr(certificate, "not_valid_after_utc", None)
+    if not_before is None:
+        not_before = certificate.not_valid_before
+    if not_after is None:
+        not_after = certificate.not_valid_after
+    return not_before.isoformat(), not_after.isoformat()
+
+
+def inspect_server_certificate(api_url: str, timeout: float = 5) -> ServerCertificate:
+    """Inspect a server's leaf certificate without trusting it.
+
+    This function is only for displaying certificate identity before explicit trust
+    approval. It does not alter global SSL settings or persist the certificate.
+    """
+    origin = get_ssl_server_origin(api_url)
+    parsed = urlparse(origin)
+    assert parsed.hostname is not None
+    port = parsed.port or 443
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    with socket.create_connection((parsed.hostname, port), timeout=timeout) as tcp_socket:
+        with context.wrap_socket(tcp_socket, server_hostname=parsed.hostname) as tls_socket:
+            certificate_der = tls_socket.getpeercert(binary_form=True)
+
+    if not certificate_der:
+        raise ssl.SSLError("The server did not provide a TLS certificate.")
+
+    certificate = x509.load_der_x509_certificate(certificate_der)
+    not_before, not_after = _certificate_validity(certificate)
+    sans: List[str] = []
+    try:
+        san_extension = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans = [str(value) for value in san_extension.value]
+    except x509.ExtensionNotFound:
+        pass
+
+    return ServerCertificate(
+        origin=origin,
+        pem=certificate.public_bytes(serialization.Encoding.PEM),
+        fingerprint=certificate.fingerprint(hashes.SHA256()).hex().upper(),
+        subject=_certificate_name(certificate.subject),
+        issuer=_certificate_name(certificate.issuer),
+        sans=sans,
+        not_before=not_before,
+        not_after=not_after,
+        self_signed=certificate.subject == certificate.issuer,
+    )
+
+
+def save_managed_certificate(certificate: ServerCertificate) -> Path:
+    """Persist a server certificate and metadata in the managed trust directory."""
+    trust_directory = _get_trust_directory()
+    stem = _get_trust_stem(certificate.origin)
+    pem_path = trust_directory / f"{stem}.pem"
+    metadata_path = pem_path.with_suffix(".json")
+    metadata: Dict[str, Any] = {
+        "origin": certificate.origin,
+        "fingerprint": certificate.fingerprint,
+        "subject": certificate.subject,
+        "issuer": certificate.issuer,
+        "sans": certificate.sans,
+        "not-before": certificate.not_before,
+        "not-after": certificate.not_after,
+        "self-signed": certificate.self_signed,
+    }
+
+    temporary_pem = pem_path.with_suffix(".pem.tmp")
+    temporary_metadata = metadata_path.with_suffix(".json.tmp")
+    try:
+        temporary_pem.write_bytes(certificate.pem)
+        temporary_metadata.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        temporary_pem.chmod(0o600)
+        temporary_metadata.chmod(0o600)
+        temporary_pem.replace(pem_path)
+        temporary_metadata.replace(metadata_path)
+    except OSError:
+        for temporary_path in (temporary_pem, temporary_metadata):
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+        raise
+    return pem_path
+
+
+def get_managed_trust_records() -> List[Dict[str, Any]]:
+    """Return metadata for all managed server certificates."""
+    records: List[Dict[str, Any]] = []
+    for metadata_path in sorted(_get_trust_directory().glob("*.json")):
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(metadata, dict) and isinstance(metadata.get("origin"), str):
+            records.append(metadata)
+    return records
+
+
+def remove_managed_trust(api_url: str) -> bool:
+    """Remove the managed certificate trust entry for a server URL."""
+    origin = get_ssl_server_origin(api_url)
+    pem_path = _get_trust_directory() / f"{_get_trust_stem(origin)}.pem"
+    metadata_path = pem_path.with_suffix(".json")
+    removed = False
+    for path in (pem_path, metadata_path):
+        try:
+            path.unlink()
+            removed = True
+        except FileNotFoundError:
+            pass
+    return removed
 
 
 def inject_os_trust() -> None:

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -12,6 +12,7 @@ import keyring
 import requests
 
 from .rich_output import print_json
+from .ssl_trust import use_standard_ssl_context
 
 
 class SystemLinkConfig:
@@ -730,35 +731,36 @@ def make_api_request(
 
         ssl_verify = get_ssl_verify(url)
 
-        if method.upper() == "GET":
-            resp = requests.get(url, headers=default_headers, verify=ssl_verify, stream=stream)
-        elif method.upper() == "POST":
-            if files:
-                # Multipart file upload
-                resp = requests.post(
-                    url,
-                    headers=default_headers,
-                    files=files,
-                    data=data,
-                    verify=ssl_verify,
-                    stream=stream,
-                )
+        with use_standard_ssl_context(ssl_verify):
+            if method.upper() == "GET":
+                resp = requests.get(url, headers=default_headers, verify=ssl_verify, stream=stream)
+            elif method.upper() == "POST":
+                if files:
+                    # Multipart file upload
+                    resp = requests.post(
+                        url,
+                        headers=default_headers,
+                        files=files,
+                        data=data,
+                        verify=ssl_verify,
+                        stream=stream,
+                    )
+                else:
+                    resp = requests.post(
+                        url,
+                        headers=default_headers,
+                        json=payload,
+                        verify=ssl_verify,
+                        stream=stream,
+                    )
+            elif method.upper() == "PUT":
+                resp = requests.put(url, headers=default_headers, json=payload, verify=ssl_verify)
+            elif method.upper() == "PATCH":
+                resp = requests.patch(url, headers=default_headers, json=payload, verify=ssl_verify)
+            elif method.upper() == "DELETE":
+                resp = requests.delete(url, headers=default_headers, verify=ssl_verify)
             else:
-                resp = requests.post(
-                    url,
-                    headers=default_headers,
-                    json=payload,
-                    verify=ssl_verify,
-                    stream=stream,
-                )
-        elif method.upper() == "PUT":
-            resp = requests.put(url, headers=default_headers, json=payload, verify=ssl_verify)
-        elif method.upper() == "PATCH":
-            resp = requests.patch(url, headers=default_headers, json=payload, verify=ssl_verify)
-        elif method.upper() == "DELETE":
-            resp = requests.delete(url, headers=default_headers, verify=ssl_verify)
-        else:
-            raise ValueError(f"Unsupported HTTP method: {method}")
+                raise ValueError(f"Unsupported HTTP method: {method}")
 
         resp.raise_for_status()
         return resp

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -569,9 +569,6 @@ def get_ssl_verify(server_uri: Optional[str] = None) -> Union[bool, str]:
         if env.lower() in ("0", "false", "no"):
             return False
 
-    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
-        return os.environ.get("REQUESTS_CA_BUNDLE") or os.environ["SSL_CERT_FILE"]
-
     if server_uri is None:
         try:
             server_uri = get_base_url()
@@ -587,6 +584,9 @@ def get_ssl_verify(server_uri: Optional[str] = None) -> Union[bool, str]:
                 return str(managed_path)
         except (OSError, ValueError):
             pass
+
+    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
+        return os.environ.get("REQUESTS_CA_BUNDLE") or os.environ["SSL_CERT_FILE"]
 
     return True
 

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -23,7 +23,7 @@ class SystemLinkConfig:
         Args:
             server_uri: Base URL for the SystemLink API
             api_key: API key for authentication
-            ssl_verify: Whether to verify SSL certificates
+            ssl_verify: Whether to verify SSL certificates, or a CA bundle / PEM path
         """
         self.server_uri = server_uri
         self.api_key = api_key

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -5,7 +5,7 @@ import json
 import os
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Any, Optional, Callable, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import click
 import keyring
@@ -17,7 +17,7 @@ from .rich_output import print_json
 class SystemLinkConfig:
     """Simple configuration class for SystemLink API connection."""
 
-    def __init__(self, server_uri: str, api_key: str, ssl_verify: bool = True):
+    def __init__(self, server_uri: str, api_key: str, ssl_verify: Union[bool, str] = True):
         """Initialize SystemLink configuration.
 
         Args:
@@ -27,7 +27,7 @@ class SystemLinkConfig:
         """
         self.server_uri = server_uri
         self.api_key = api_key
-        self.ssl_verify = ssl_verify
+        self.ssl_verify: Union[bool, str] = ssl_verify
 
 
 @dataclass(frozen=True)
@@ -309,7 +309,7 @@ def get_http_configuration() -> SystemLinkConfig:
     server_uri = get_base_url()
     api_key = get_api_key()
 
-    ssl_verify = get_ssl_verify()
+    ssl_verify = get_ssl_verify(server_uri)
 
     return SystemLinkConfig(
         server_uri=server_uri,
@@ -556,11 +556,37 @@ def get_headers(content_type: str = "") -> Dict[str, str]:
     return headers
 
 
-def get_ssl_verify() -> bool:
-    """Return SSL verification setting from environment variable. Defaults to True."""
+def get_ssl_verify(server_uri: Optional[str] = None) -> Union[bool, str]:
+    """Return the effective SSL verification setting for a server.
+
+    The result is ``False`` only when explicitly disabled. Otherwise it is a
+    managed PEM path when the server has an accepted certificate, or ``True``
+    for the normal OS/certifi verification path.
+    """
     env = os.environ.get("SLCLI_SSL_VERIFY")
     if env is not None:
-        return env.lower() not in ("0", "false", "no")
+        if env.lower() in ("0", "false", "no"):
+            return False
+
+    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
+        return os.environ.get("REQUESTS_CA_BUNDLE") or os.environ["SSL_CERT_FILE"]
+
+    if server_uri is None:
+        try:
+            server_uri = get_base_url()
+        except Exception:
+            server_uri = None
+
+    if server_uri:
+        try:
+            from .ssl_trust import get_managed_trust_path
+
+            managed_path = get_managed_trust_path(server_uri)
+            if managed_path is not None:
+                return str(managed_path)
+        except (OSError, ValueError):
+            pass
+
     return True
 
 
@@ -702,7 +728,7 @@ def make_api_request(
         if files:
             default_headers.pop("Content-Type", None)
 
-        ssl_verify = get_ssl_verify()
+        ssl_verify = get_ssl_verify(url)
 
         if method.upper() == "GET":
             resp = requests.get(url, headers=default_headers, verify=ssl_verify, stream=stream)

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -479,6 +479,52 @@ class TestViewConfig:
 class TestTrustedCertificates:
     """Tests for managed certificate trust commands."""
 
+    def test_reachable_server_skips_certificate_trust_flow(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """A partial probe certificate error should not block a reachable profile."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr(
+            "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+        )
+        monkeypatch.setattr(
+            "slcli.config_click.check_service_status",
+            lambda _url, _api_key: {
+                "server_reachable": True,
+                "platform": "unknown",
+                "auth_valid": True,
+                "services": {"Auth": "ok", "Files": "certificate_error"},
+                "certificate_error": True,
+            },
+        )
+
+        def fail_if_trust_flow_runs(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("certificate trust flow should not run for a reachable server")
+
+        monkeypatch.setattr(
+            "slcli.config_click._trust_certificate_if_requested", fail_if_trust_flow_runs
+        )
+
+        result = CliRunner().invoke(
+            make_cli(),
+            [
+                "config",
+                "add",
+                "--profile",
+                "reachable",
+                "--url",
+                "https://example.com",
+                "--api-key",
+                VALID_API_KEY,
+                "--web-url",
+                "https://web.example.com",
+            ],
+            input="\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert config_file.exists()
+
     def test_list_trusted_certificates_json(self, monkeypatch: Any) -> None:
         """Trust list should expose certificate metadata as JSON."""
         monkeypatch.setattr(

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -476,6 +476,55 @@ class TestViewConfig:
         assert "effective" not in data
 
 
+class TestTrustedCertificates:
+    """Tests for managed certificate trust commands."""
+
+    def test_list_trusted_certificates_json(self, monkeypatch: Any) -> None:
+        """Trust list should expose certificate metadata as JSON."""
+        monkeypatch.setattr(
+            "slcli.config_click.get_managed_trust_records",
+            lambda: [{"origin": "https://example.com:443", "fingerprint": "A" * 64}],
+        )
+
+        result = CliRunner().invoke(make_cli(), ["config", "trust", "list", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)[0]["fingerprint"] == "A" * 64
+
+    def test_add_trusted_certificate_rejects_fingerprint_mismatch(self, monkeypatch: Any) -> None:
+        """Trust add must reject a certificate that differs from the supplied fingerprint."""
+        from slcli.ssl_trust import ServerCertificate
+
+        certificate = ServerCertificate(
+            origin="https://example.com:443",
+            pem=b"pem",
+            fingerprint="B" * 64,
+            subject="subject",
+            issuer="issuer",
+            sans=[],
+            not_before="before",
+            not_after="after",
+            self_signed=True,
+        )
+        monkeypatch.setattr(
+            "slcli.config_click.inspect_server_certificate", lambda _url: certificate
+        )
+        saved_certificates: list[ServerCertificate] = []
+        monkeypatch.setattr(
+            "slcli.config_click.save_managed_certificate",
+            lambda certificate_to_save: saved_certificates.append(certificate_to_save),
+        )
+
+        result = CliRunner().invoke(
+            make_cli(),
+            ["config", "trust", "add", "--url", "https://example.com", "--fingerprint", "C" * 64],
+        )
+
+        assert result.exit_code != 0
+        assert "does not match" in result.output
+        assert saved_certificates == []
+
+
 class TestDeleteProfile:
     """Tests for the delete command."""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,6 +3,7 @@
 import importlib
 import json
 from typing import Any, Optional
+from unittest.mock import patch
 
 import click
 from click.testing import CliRunner
@@ -131,6 +132,68 @@ def test_login_with_flags(monkeypatch: Any, tmp_path: Any) -> None:
     assert "Connection: ✓ Verified" in result.output
     assert "Platform: SystemLink Enterprise" in result.output
     # Verify config was written
+    assert config_file.exists()
+
+
+def test_login_prompts_to_trust_certificate_and_retries(monkeypatch: Any, tmp_path: Any) -> None:
+    """Login should persist an approved certificate and retry the service probe."""
+    from slcli.ssl_trust import ServerCertificate
+
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    certificate = ServerCertificate(
+        origin="https://example.test:443",
+        pem=b"pem",
+        fingerprint="D" * 64,
+        subject="commonName=example.test",
+        issuer="commonName=example.test",
+        sans=["example.test"],
+        not_before="before",
+        not_after="after",
+        self_signed=True,
+    )
+    failed_status = {
+        "server_reachable": False,
+        "auth_valid": None,
+        "services": {"Auth": "certificate_error"},
+        "certificate_error": True,
+        "certificate": certificate.to_dict(),
+        "platform": "unreachable",
+    }
+    verified_status = {
+        "server_reachable": True,
+        "auth_valid": True,
+        "services": {"Auth": "ok"},
+        "platform": PLATFORM_SLE,
+    }
+    monkeypatch.setattr("slcli.main.keyring.get_password", lambda *a, **kw: None)
+
+    with patch(
+        "slcli.config_click.check_service_status", side_effect=[failed_status, verified_status]
+    ) as check_status, patch(
+        "slcli.config_click.inspect_server_certificate", return_value=certificate
+    ):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "login",
+                "--profile",
+                "test",
+                "--url",
+                "https://example.test",
+                "--api-key",
+                VALID_API_KEY,
+                "--web-url",
+                "https://web.example.test",
+            ],
+            input="y\n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Certificate: ✓ Trusted for this server" in result.output
+    assert check_status.call_count == 2
     assert config_file.exists()
 
 

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -262,6 +262,34 @@ class TestCheckServiceStatus:
         assert result["auth_valid"] is None
         assert result["platform"] == PLATFORM_UNREACHABLE
 
+    def test_certificate_error_includes_leaf_certificate_details(self, monkeypatch: Any) -> None:
+        """TLS verification failures should expose details for explicit trust approval."""
+        from slcli.ssl_trust import ServerCertificate
+
+        certificate = ServerCertificate(
+            origin="https://example.com:443",
+            pem=b"pem",
+            fingerprint="C" * 64,
+            subject="subject",
+            issuer="subject",
+            sans=["example.com"],
+            not_before="before",
+            not_after="after",
+            self_signed=True,
+        )
+        error = req_module.exceptions.SSLError("certificate verify failed")
+        monkeypatch.setattr(
+            "slcli.platform.requests.get", side_effect := MagicMock(side_effect=error)
+        )
+        monkeypatch.setattr("slcli.platform.requests.post", side_effect)
+        monkeypatch.setattr("slcli.ssl_trust.inspect_server_certificate", lambda _url: certificate)
+
+        result = check_service_status("https://example.com", "key")
+
+        assert result["server_reachable"] is False
+        assert result["certificate_error"] is True
+        assert result["certificate"]["fingerprint"] == "C" * 64
+
     def test_infer_sle_when_any_sle_only_service_is_available(self) -> None:
         """Test that a reachable SLE-only service is enough to infer SLE."""
         mock_get, mock_post = self._mock_requests(

--- a/tests/unit/test_ssl_trust.py
+++ b/tests/unit/test_ssl_trust.py
@@ -100,3 +100,78 @@ def test_managed_certificate_persistence_is_origin_scoped(monkeypatch: Any, tmp_
     assert get_managed_trust_records()[0]["fingerprint"] == "A" * 64
     assert remove_managed_trust("https://example.com") is True
     assert get_managed_trust_path("https://example.com") is None
+
+
+def test_certificate_inspection_uses_unpatched_context_and_peer_chain(monkeypatch: Any) -> None:
+    """Inspection should bypass truststore and retain the full peer certificate chain."""
+    from slcli import ssl_trust
+
+    class FakeCertificate:
+        subject = object()
+        issuer = subject
+        extensions = types.SimpleNamespace(
+            get_extension_for_class=lambda _certificate_type: types.SimpleNamespace(
+                value=["example.com"]
+            )
+        )
+
+        def public_bytes(self, _encoding: Any) -> bytes:
+            return b"leaf-pem"
+
+        def fingerprint(self, _algorithm: Any) -> bytes:
+            return b"\x01" * 32
+
+    class FakePeerCertificate:
+        def public_bytes(self) -> str:
+            return "chain-pem"
+
+    class FakeTlsSocket:
+        _sslobj = types.SimpleNamespace(
+            get_unverified_chain=lambda: [FakePeerCertificate(), FakePeerCertificate()]
+        )
+
+        def __enter__(self) -> "FakeTlsSocket":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            pass
+
+        def getpeercert(self, binary_form: bool = False) -> bytes:
+            assert binary_form is True
+            return b"certificate-der"
+
+    class FakeTcpSocket:
+        def __enter__(self) -> "FakeTcpSocket":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            pass
+
+    class FakeContext:
+        def __init__(self, _protocol: int) -> None:
+            self.check_hostname = True
+            self.verify_mode = ssl_trust.ssl.CERT_REQUIRED
+
+        def wrap_socket(self, _socket: Any, server_hostname: str) -> FakeTlsSocket:
+            assert server_hostname == "example.com"
+            return FakeTlsSocket()
+
+    patched_context = object()
+    monkeypatch.setattr(ssl_trust.ssl, "SSLContext", patched_context)
+    monkeypatch.setattr(ssl_trust, "_STANDARD_SSL_CONTEXT", FakeContext)
+    monkeypatch.setattr(
+        ssl_trust.socket, "create_connection", lambda *args, **kwargs: FakeTcpSocket()
+    )
+    monkeypatch.setattr(
+        ssl_trust.x509, "load_der_x509_certificate", lambda _certificate_der: FakeCertificate()
+    )
+    monkeypatch.setattr(ssl_trust, "_certificate_name", lambda _name: "name")
+    monkeypatch.setattr(
+        ssl_trust, "_certificate_validity", lambda _certificate: ("before", "after")
+    )
+
+    certificate = ssl_trust.inspect_server_certificate("https://example.com")
+
+    assert ssl_trust.ssl.SSLContext is patched_context
+    assert certificate.pem == b"chain-pemchain-pem"
+    assert certificate.fingerprint == "01" * 32

--- a/tests/unit/test_ssl_trust.py
+++ b/tests/unit/test_ssl_trust.py
@@ -54,3 +54,49 @@ def test_injection_force_failure(monkeypatch: Any) -> None:
     importlib.reload(ssl_trust)
     with pytest.raises(RuntimeError):
         ssl_trust.inject_os_trust()
+
+
+def test_server_origin_normalization() -> None:
+    """Managed trust should normalize default ports and reject non-HTTPS URLs."""
+    from slcli.ssl_trust import get_ssl_server_origin
+
+    assert get_ssl_server_origin("https://Example.com/path") == "https://example.com:443"
+    assert get_ssl_server_origin("https://example.com:8443") == "https://example.com:8443"
+    with pytest.raises(ValueError, match="HTTPS"):
+        get_ssl_server_origin("http://example.com")
+
+
+def test_managed_certificate_persistence_is_origin_scoped(monkeypatch: Any, tmp_path: Any) -> None:
+    """Managed certificates should persist securely and only match their origin."""
+    from slcli.ssl_trust import (
+        ServerCertificate,
+        get_managed_trust_path,
+        get_managed_trust_records,
+        remove_managed_trust,
+        save_managed_certificate,
+    )
+
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    certificate = ServerCertificate(
+        origin="https://example.com:443",
+        pem=b"-----BEGIN CERTIFICATE-----\nfixture\n-----END CERTIFICATE-----\n",
+        fingerprint="A" * 64,
+        subject="commonName=example.com",
+        issuer="commonName=example.com",
+        sans=["example.com"],
+        not_before="2026-01-01T00:00:00+00:00",
+        not_after="2027-01-01T00:00:00+00:00",
+        self_signed=True,
+    )
+
+    path = save_managed_certificate(certificate)
+    assert path.read_bytes() == certificate.pem
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert get_managed_trust_path("https://example.com/path") == path
+    assert get_managed_trust_path("https://other.example.com") is None
+    assert get_managed_trust_records()[0]["fingerprint"] == "A" * 64
+    assert remove_managed_trust("https://example.com") is True
+    assert get_managed_trust_path("https://example.com") is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -163,5 +163,8 @@ def test_ssl_verify_uses_managed_certificate(monkeypatch: Any, tmp_path: Path) -
 
     assert get_ssl_verify("https://example.com") == str(path)
 
+    monkeypatch.setenv("SSL_CERT_FILE", "/path/to/system-bundle.pem")
+    assert get_ssl_verify("https://example.com") == str(path)
+
     monkeypatch.setenv("SLCLI_SSL_VERIFY", "false")
     assert get_ssl_verify("https://example.com") is False

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -135,3 +135,33 @@ def test_api_key_resolution_raises_single_click_exception_when_missing(monkeypat
 
     with pytest.raises(click.ClickException, match="SLCLI_API_KEY environment variable"):
         get_api_key_resolution()
+
+
+def test_ssl_verify_uses_managed_certificate(monkeypatch: Any, tmp_path: Path) -> None:
+    """The request verification setting should use an accepted server certificate."""
+    from slcli.ssl_trust import ServerCertificate, save_managed_certificate
+    from slcli.utils import get_ssl_verify
+
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr(
+        "slcli.profiles.ProfileConfig.get_config_path", classmethod(lambda cls: config_file)
+    )
+    certificate = ServerCertificate(
+        origin="https://example.com:443",
+        pem=b"pem",
+        fingerprint="B" * 64,
+        subject="subject",
+        issuer="issuer",
+        sans=[],
+        not_before="before",
+        not_after="after",
+        self_signed=False,
+    )
+    path = save_managed_certificate(certificate)
+
+    assert get_ssl_verify("https://example.com") == str(path)
+
+    monkeypatch.setenv("SLCLI_SSL_VERIFY", "false")
+    assert get_ssl_verify("https://example.com") is False


### PR DESCRIPTION
## Summary
Add origin-scoped trust for SystemLink servers using self-signed TLS certificates. Login and profile creation now detect certificate verification failures, display the certificate identity and SHA-256 fingerprint, require explicit approval, and retry with verified PEM trust while preserving hostname verification.

Also add `slcli config trust list|add|remove`, exact fingerprint approval for non-interactive setup, managed trust diagnostics, and regression coverage.

## Testing
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q`
- `poetry run pytest`
- 1,309 tests passed

## Release Notes
- Added `newsfragments/self-signed-certificate-trust.minor.md` for the new certificate trust feature.