### PR TITLE
fix: show conflicting webapp details

### DIFF
--- a/newsfragments/webapp-conflict-details.patch.md
+++ b/newsfragments/webapp-conflict-details.patch.md
@@ -1,0 +1,1 @@
+Include the conflicting webapp ID and published URL when publishing a duplicate webapp name.

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -189,11 +189,27 @@ def _handle_webapp_create_conflict(
         return
 
     try:
-        conflict_id = _find_conflicting_webapp_id(response.json())
+        response_data = response.json()
     except (ValueError, AttributeError):
-        conflict_id = ""
+        response_data = {}
 
-    click.echo("✗ A webapp with this name already exists.", err=True)
+    conflict_id = _find_conflicting_webapp_id(response_data)
+    conflict_message = ""
+    if isinstance(response_data, dict):
+        error_data = response_data.get("error")
+        if isinstance(error_data, dict):
+            message = error_data.get("message")
+            if message:
+                conflict_message = str(message)
+        if not conflict_message:
+            message = response_data.get("message")
+            if message:
+                conflict_message = str(message)
+
+    if not conflict_message:
+        conflict_message = "A webapp with this name already exists."
+
+    click.echo(f"✗ {conflict_message}", err=True)
     if conflict_id:
         conflict_url = _build_published_webapp_url(
             conflict_id,

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -178,6 +178,29 @@ def _find_conflicting_webapp_id(value: Any) -> str:
     return ""
 
 
+def _find_existing_webapp(webapp_name: str, workspace_id: str) -> Optional[Dict[str, Any]]:
+    """Find an existing WebVI with the requested name and workspace."""
+    escaped_name = webapp_name.replace("\\", "\\\\").replace('"', '\\"')
+    filter_parts = [f'type == "WebVI"', f'name.Contains("{escaped_name}")']
+    if workspace_id:
+        escaped_workspace = workspace_id.replace("\\", "\\\\").replace('"', '\\"')
+        filter_parts.append(f'workspace == "{escaped_workspace}"')
+
+    try:
+        webapps = _query_webapps_http(" and ".join(filter_parts), max_items=100)
+    except Exception:
+        return None
+
+    for webapp in webapps:
+        if (
+            webapp.get("type") == "WebVI"
+            and webapp.get("name") == webapp_name
+            and (not workspace_id or webapp.get("workspace") == workspace_id)
+        ):
+            return webapp
+    return None
+
+
 def _handle_webapp_create_conflict(
     response: Any,
     workspace_id: str,
@@ -194,6 +217,11 @@ def _handle_webapp_create_conflict(
         response_data = {}
 
     conflict_id = _find_conflicting_webapp_id(response_data)
+    conflict_record: Optional[Dict[str, Any]] = None
+    if not conflict_id:
+        conflict_record = _find_existing_webapp(webapp_name, workspace_id)
+        if conflict_record:
+            conflict_id = str(conflict_record.get("id", ""))
     conflict_message = ""
     if isinstance(response_data, dict):
         error_data = response_data.get("error")
@@ -211,11 +239,17 @@ def _handle_webapp_create_conflict(
 
     click.echo(f"✗ {conflict_message}", err=True)
     if conflict_id:
+        conflict_name = str(conflict_record.get("name", "")) if conflict_record else webapp_name
+        conflict_workspace_id = (
+            str(conflict_record.get("workspace", "")) if conflict_record else workspace_id
+        )
+        conflict_properties = conflict_record.get("properties", {}) if conflict_record else None
         conflict_url = _build_published_webapp_url(
             conflict_id,
-            webapp_name=webapp_name,
-            workspace_id=workspace_id,
+            webapp_name=conflict_name,
+            workspace_id=conflict_workspace_id,
             workspace_name_hint=workspace_name_hint,
+            properties=conflict_properties,
         )
         click.echo(f"  Conflicting Webapp ID: {conflict_id}", err=True)
         click.echo(f"  Conflicting Webapp URL: {conflict_url}", err=True)

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -151,6 +151,61 @@ def _build_published_webapp_url(
     return ""
 
 
+def _find_conflicting_webapp_id(value: Any) -> str:
+    """Find a webapp ID in a duplicate-create response payload."""
+    if isinstance(value, dict):
+        for key in (
+            "id",
+            "webappId",
+            "webAppId",
+            "existingId",
+            "existingWebappId",
+            "existingWebAppId",
+            "resourceId",
+        ):
+            candidate = value.get(key)
+            if candidate:
+                return str(candidate)
+        for nested in value.values():
+            conflict_id = _find_conflicting_webapp_id(nested)
+            if conflict_id:
+                return conflict_id
+    elif isinstance(value, list):
+        for nested in value:
+            conflict_id = _find_conflicting_webapp_id(nested)
+            if conflict_id:
+                return conflict_id
+    return ""
+
+
+def _handle_webapp_create_conflict(
+    response: Any,
+    workspace_id: str,
+    workspace_name_hint: str,
+    webapp_name: str,
+) -> None:
+    """Display details for a webapp that conflicts with a create request."""
+    if response.status_code != 409:
+        return
+
+    try:
+        conflict_id = _find_conflicting_webapp_id(response.json())
+    except (ValueError, AttributeError):
+        conflict_id = ""
+
+    click.echo("✗ A webapp with this name already exists.", err=True)
+    if conflict_id:
+        conflict_url = _build_published_webapp_url(
+            conflict_id,
+            webapp_name=webapp_name,
+            workspace_id=workspace_id,
+            workspace_name_hint=workspace_name_hint,
+        )
+        click.echo(f"  Conflicting Webapp ID: {conflict_id}", err=True)
+        click.echo(f"  Conflicting Webapp URL: {conflict_url}", err=True)
+    sys.exit(ExitCodes.INVALID_INPUT)
+
+
 def _query_webapps_http(filter_str: str, max_items: int = 1000) -> List[Dict[str, Any]]:
     """Query webapps using continuation token pagination.
 
@@ -1518,6 +1573,12 @@ def register_webapp_commands(cli: Any) -> None:
                             json=payload,
                             verify=get_ssl_verify(),
                         )
+                        _handle_webapp_create_conflict(
+                            resp_create,
+                            workspace_id=created_workspace_id,
+                            workspace_name_hint=get_effective_workspace(workspace) or workspace,
+                            webapp_name=name,
+                        )
                         resp_create.raise_for_status()
                         created = resp_create.json()
                         webapp_id = created.get("id")
@@ -1589,6 +1650,12 @@ def register_webapp_commands(cli: Any) -> None:
                         headers=get_headers("application/json"),
                         json=payload,
                         verify=get_ssl_verify(),
+                    )
+                    _handle_webapp_create_conflict(
+                        resp_create,
+                        workspace_id=created_workspace_id,
+                        workspace_name_hint=get_effective_workspace(workspace) or workspace,
+                        webapp_name=name,
                     )
                     resp_create.raise_for_status()
                     created = resp_create.json()

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -1456,14 +1456,35 @@ def test_webapp_publish_duplicate_name_shows_conflicting_webapp_details(
             return {
                 "error": {
                     "message": "The webapp name is already in use.",
-                    "details": {"webapp": {"id": "conflicting-webapp-id"}},
                 }
             }
 
         def raise_for_status(self) -> None:
             return None
 
-    monkeypatch.setattr(requests, "post", lambda *a, **k: MockPostResp())
+    class MockQueryResp:
+        def json(self) -> Dict[str, Any]:
+            return {
+                "webapps": [
+                    {
+                        "id": "conflicting-webapp-id",
+                        "name": "Existing App",
+                        "workspace": "ws1",
+                        "type": "WebVI",
+                        "properties": {},
+                    }
+                ]
+            }
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def mock_post(url: str, **kwargs: Any) -> Any:
+        if url.endswith("/webapps"):
+            return MockPostResp()
+        return MockQueryResp()
+
+    monkeypatch.setattr(requests, "post", mock_post)
     monkeypatch.setattr(slcli.webapp_click, "get_workspace_id_with_fallback", lambda _: "ws1")
     monkeypatch.setattr(slcli.webapp_click, "get_workspace_map", lambda: {"ws1": "Default"})
     monkeypatch.setattr(slcli.webapp_click, "get_web_url", lambda: "https://web.example.test")

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -1432,16 +1432,22 @@ def test_webapp_publish_creates_and_uploads(tmp_path: Path, monkeypatch: MonkeyP
     assert "https://web.example.test/webapps/app/Default/NewApp" in result.output
 
 
+@pytest.mark.parametrize("source_kind", ["package", "folder"])
 def test_webapp_publish_duplicate_name_shows_conflicting_webapp_details(
-    tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch, source_kind: str
 ) -> None:
     runner = CliRunner()
     patch_keyring(monkeypatch)
     import requests
     import slcli.webapp_click
 
-    package = tmp_path / "app.nipkg"
-    package.write_bytes(b"test")
+    if source_kind == "package":
+        source = tmp_path / "app.nipkg"
+        source.write_bytes(b"test")
+    else:
+        source = tmp_path / "site"
+        source.mkdir()
+        (source / "index.html").write_text("hi")
 
     class MockPostResp:
         status_code = 409
@@ -1449,7 +1455,7 @@ def test_webapp_publish_duplicate_name_shows_conflicting_webapp_details(
         def json(self) -> Dict[str, Any]:
             return {
                 "error": {
-                    "message": "A webapp with this name already exists.",
+                    "message": "The webapp name is already in use.",
                     "details": {"webapp": {"id": "conflicting-webapp-id"}},
                 }
             }
@@ -1463,11 +1469,11 @@ def test_webapp_publish_duplicate_name_shows_conflicting_webapp_details(
     monkeypatch.setattr(slcli.webapp_click, "get_web_url", lambda: "https://web.example.test")
 
     result = runner.invoke(
-        cli, ["webapp", "publish", str(package), "--name", "Existing App", "--workspace", "Default"]
+        cli, ["webapp", "publish", str(source), "--name", "Existing App", "--workspace", "Default"]
     )
 
     assert result.exit_code == ExitCodes.INVALID_INPUT
-    assert "A webapp with this name already exists." in result.output
+    assert "The webapp name is already in use." in result.output
     assert "Conflicting Webapp ID: conflicting-webapp-id" in result.output
     assert (
         "Conflicting Webapp URL: https://web.example.test/webapps/app/Default/Existing%20App"

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -1432,6 +1432,49 @@ def test_webapp_publish_creates_and_uploads(tmp_path: Path, monkeypatch: MonkeyP
     assert "https://web.example.test/webapps/app/Default/NewApp" in result.output
 
 
+def test_webapp_publish_duplicate_name_shows_conflicting_webapp_details(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    runner = CliRunner()
+    patch_keyring(monkeypatch)
+    import requests
+    import slcli.webapp_click
+
+    package = tmp_path / "app.nipkg"
+    package.write_bytes(b"test")
+
+    class MockPostResp:
+        status_code = 409
+
+        def json(self) -> Dict[str, Any]:
+            return {
+                "error": {
+                    "message": "A webapp with this name already exists.",
+                    "details": {"webapp": {"id": "conflicting-webapp-id"}},
+                }
+            }
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: MockPostResp())
+    monkeypatch.setattr(slcli.webapp_click, "get_workspace_id_with_fallback", lambda _: "ws1")
+    monkeypatch.setattr(slcli.webapp_click, "get_workspace_map", lambda: {"ws1": "Default"})
+    monkeypatch.setattr(slcli.webapp_click, "get_web_url", lambda: "https://web.example.test")
+
+    result = runner.invoke(
+        cli, ["webapp", "publish", str(package), "--name", "Existing App", "--workspace", "Default"]
+    )
+
+    assert result.exit_code == ExitCodes.INVALID_INPUT
+    assert "A webapp with this name already exists." in result.output
+    assert "Conflicting Webapp ID: conflicting-webapp-id" in result.output
+    assert (
+        "Conflicting Webapp URL: https://web.example.test/webapps/app/Default/Existing%20App"
+        in result.output
+    )
+
+
 def test_webapp_publish_existing_id_includes_published_url(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Show the conflicting webapp ID and published URL when publishing a new webapp with a duplicate name. Handle the conflict consistently for folder and `.nipkg` publish flows.

## Testing

- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest tests/unit -q`
- `poetry run pytest -q`
- `poetry run towncrier check --compare-with origin/main`

## Release Notes

- Added `webapp-conflict-details.patch.md` to report duplicate webapp details in the next patch release.