### PR TITLE
Fix Windows release validation

### DIFF
--- a/newsfragments/windows-self-signed-trust.patch.md
+++ b/newsfragments/windows-self-signed-trust.patch.md
@@ -1,0 +1,1 @@
+Fix Windows release validation for self-signed certificate trust support.

--- a/tests/unit/test_ssl_trust.py
+++ b/tests/unit/test_ssl_trust.py
@@ -94,7 +94,8 @@ def test_managed_certificate_persistence_is_origin_scoped(monkeypatch: Any, tmp_
 
     path = save_managed_certificate(certificate)
     assert path.read_bytes() == certificate.pem
-    assert path.stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert path.stat().st_mode & 0o777 == 0o600
     assert get_managed_trust_path("https://example.com/path") == path
     assert get_managed_trust_path("https://other.example.com") is None
     assert get_managed_trust_records()[0]["fingerprint"] == "A" * 64


### PR DESCRIPTION
## Summary
- Skip the POSIX-only file mode assertion on Windows.
- Add the required Towncrier patch fragment.

## Testing
- `poetry run pytest tests/unit/test_ssl_trust.py -q`
- `poetry run towncrier check --compare-with origin/main`