### PR TITLE
Add tag history queries and terminal graphing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ slcli config trust remove --url https://systemlink.example.local
 
 Managed certificates are stored under the `trust` directory next to the slcli configuration file. Hostname verification is still enforced. `SLCLI_SSL_VERIFY=false` disables certificate verification entirely and should only be used as a temporary diagnostic override; it does not add a trusted certificate.
 
+When the operating system trust store is available, it remains the default even if `SSL_CERT_FILE` points to a single corporate root certificate. Use `REQUESTS_CA_BUNDLE` when an explicit complete CA bundle is required.
+
 ## Documentation
 
 | Section                                                                            | Description                                                |

--- a/newsfragments/tag-history-graph.minor.md
+++ b/newsfragments/tag-history-graph.minor.md
@@ -1,0 +1,1 @@
+Add a `--graph` option to render numeric tag history as a terminal sparkline.

--- a/site/commands.html
+++ b/site/commands.html
@@ -638,6 +638,9 @@ slcli tag get-value "sensor.temp" --include-aggregates
 # View historical values
 slcli tag history "sensor.temp" --take 100 --format table
 
+# View numeric history as a terminal sparkline
+slcli tag history "sensor.temp" --take 100 --graph
+
 # View details with aggregates
 slcli tag get "sensor.temp" --include-aggregates
 

--- a/site/commands.html
+++ b/site/commands.html
@@ -93,7 +93,7 @@
         <div class="cmd-group"><h3>routine</h3><p>Event-action routines (v1 &amp; v2)</p><code>slcli routine list</code></div>
         <div class="cmd-group"><h3>feed</h3><p>NI Package Manager feeds &amp; packages</p><code>slcli feed list</code></div>
         <div class="cmd-group"><h3>file</h3><p>File upload, download, query, watch</p><code>slcli file list</code></div>
-        <div class="cmd-group"><h3>tag</h3><p>Tags: create, read, set values</p><code>slcli tag list</code></div>
+        <div class="cmd-group"><h3>tag</h3><p>Tags: create, read, values, and value history</p><code>slcli tag list</code></div>
         <div class="cmd-group"><h3>user</h3><p>User &amp; service account management</p><code>slcli user list</code></div>
         <div class="cmd-group"><h3>auth</h3><p>Authorization policies &amp; templates</p><code>slcli auth policy list</code></div>
         <div class="cmd-group"><h3>workspace</h3><p>Workspace listing, info, disable</p><code>slcli workspace list</code></div>
@@ -634,6 +634,9 @@ slcli tag create "sensor.temp" --type DOUBLE --keywords "lab" --collect-aggregat
 # Set / get values
 slcli tag set-value "sensor.temp" "42.5"
 slcli tag get-value "sensor.temp" --include-aggregates
+
+# View historical values
+slcli tag history "sensor.temp" --take 100 --format table
 
 # View details with aggregates
 slcli tag get "sensor.temp" --include-aggregates

--- a/slcli/mcp_server.py
+++ b/slcli/mcp_server.py
@@ -254,12 +254,27 @@ def query_tag_history(path: str, take: int = 100) -> str:
     from .utils import get_base_url
 
     path = _require(path, "path")
-    encoded_path = urllib.parse.quote(path, safe="")
-    url = f"{get_base_url()}/nitag/v2/tags/{encoded_path}/values/history?take={take}"
-    data = _get_json(url)
+    url = f"{get_base_url()}/nitaghistorian/v2/tags/query-history"
+    data = _post_json(
+        url,
+        {
+            "path": path,
+            "startTime": "0001-01-01T00:00:00Z",
+            "endTime": "9999-12-31T23:59:59Z",
+            "take": take,
+            "sortOrder": "DESCENDING",
+        },
+    )
     if isinstance(data, list):
         return _dump(data)
-    return _dump(data.get("values", data.get("tagsWithAggregates", [])))
+    values = data.get("values", [])
+    value_type = data.get("type")
+    if isinstance(values, list) and isinstance(value_type, str):
+        values = [
+            {**item, "type": value_type} if isinstance(item, dict) and "type" not in item else item
+            for item in values
+        ]
+    return _dump(values)
 
 
 @server.tool()

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -378,6 +378,7 @@ slcli dataframe delete <TABLE_ID>... [--yes]
 slcli tag list [OPTIONS]                            # List tags (filter by path glob, workspace)
 slcli tag get <TAG_PATH> [-f json]                  # Get tag metadata
 slcli tag get-value <TAG_PATH>                      # Read current tag value
+slcli tag history <TAG_PATH> [-w WORKSPACE] [-t TAKE] [-f json]  # Read historical tag values
 slcli tag set-value <TAG_PATH> <VALUE>              # Write a tag value
 slcli tag create --path <PATH> --data-type <TYPE>   # Create a new tag
 slcli tag update <TAG_PATH> [OPTIONS]               # Update tag metadata

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -378,7 +378,7 @@ slcli dataframe delete <TABLE_ID>... [--yes]
 slcli tag list [OPTIONS]                            # List tags (filter by path glob, workspace)
 slcli tag get <TAG_PATH> [-f json]                  # Get tag metadata
 slcli tag get-value <TAG_PATH>                      # Read current tag value
-slcli tag history <TAG_PATH> [-w WORKSPACE] [-t TAKE] [-f json]  # Read historical tag values
+slcli tag history <TAG_PATH> [-w WORKSPACE] [-t TAKE] [-f json] [--graph]  # Read or graph history
 slcli tag set-value <TAG_PATH> <VALUE>              # Write a tag value
 slcli tag create --path <PATH> --data-type <TYPE>   # Create a new tag
 slcli tag update <TAG_PATH> [OPTIONS]               # Update tag metadata

--- a/slcli/skills/slcli/references/webapp/systemlink-services.md
+++ b/slcli/skills/slcli/references/webapp/systemlink-services.md
@@ -177,7 +177,7 @@ path = "cpu" or path = "mem"           OR
 keywords.Contains("production")        array contains
 ```
 
-String values must be double-quoted in the filter string. Build filters by joining parts with `and`.
+String values must be double-quoted in the filter string. Build filters by joining parts with ` and `, including the surrounding spaces.
 
 ---
 

--- a/slcli/skills/slcli/references/webapp/systemlink-services.md
+++ b/slcli/skills/slcli/references/webapp/systemlink-services.md
@@ -14,9 +14,11 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ---
 
-## Tag Historian (`/nitag`)
+## Tag Services
 
-**Base URL:** `window.location.origin + '/nitag'`
+**Tag service base URL:** `window.location.origin + '/nitag'`
+
+**Tag Historian service base URL:** `window.location.origin + '/nitaghistorian'`
 
 ### Key endpoints
 
@@ -25,7 +27,7 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 | Query tags with current values | POST | `/nitag/v2/query-tags-with-values` |
 | Get single tag | GET | `/nitag/v2/tags/{path}` |
 | Write tag value | PUT | `/nitag/v2/tags/{path}/values/current` |
-| Query tag history | POST | `/nitag/v2/history-data/query-decimated-data` |
+| Query tag history | POST | `/nitaghistorian/v2/tags/query-history` |
 
 ### Query body (`POST /query-tags-with-values`)
 

--- a/slcli/skills/slcli/references/webapp/systemlink-services.md
+++ b/slcli/skills/slcli/references/webapp/systemlink-services.md
@@ -7,6 +7,7 @@ https://<server>/<service-prefix>/swagger/v2/<service-name>.yaml
 ```
 
 Examples:
+
 - `https://myserver.com/nitag/swagger/v2/nitag.yaml`
 - `https://myserver.com/nitest/swagger/v2/nitest.yaml`
 
@@ -22,12 +23,12 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ### Key endpoints
 
-| Operation | Method | Path |
-|-----------|--------|------|
-| Query tags with current values | POST | `/nitag/v2/query-tags-with-values` |
-| Get single tag | GET | `/nitag/v2/tags/{path}` |
-| Write tag value | PUT | `/nitag/v2/tags/{path}/values/current` |
-| Query tag history | POST | `/nitaghistorian/v2/tags/query-history` |
+| Operation                      | Method | Path                                    |
+| ------------------------------ | ------ | --------------------------------------- |
+| Query tags with current values | POST   | `/nitag/v2/query-tags-with-values`      |
+| Get single tag                 | GET    | `/nitag/v2/tags/{path}`                 |
+| Write tag value                | PUT    | `/nitag/v2/tags/{path}/values/current`  |
+| Query tag history              | POST   | `/nitaghistorian/v2/tags/query-history` |
 
 ### Query body (`POST /query-tags-with-values`)
 
@@ -71,12 +72,12 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ### Key endpoints
 
-| Operation | Method | Path |
-|-----------|--------|------|
-| Query results | POST | `/nitest/v2/query-results` |
-| Get result by ID | GET | `/nitest/v2/results/{id}` |
-| Query steps | POST | `/nitest/v2/query-steps` |
-| Get products | GET | `/nitest/v2/products` |
+| Operation        | Method | Path                       |
+| ---------------- | ------ | -------------------------- |
+| Query results    | POST   | `/nitest/v2/query-results` |
+| Get result by ID | GET    | `/nitest/v2/results/{id}`  |
+| Query steps      | POST   | `/nitest/v2/query-steps`   |
+| Get products     | GET    | `/nitest/v2/products`      |
 
 ### Query body
 
@@ -97,11 +98,11 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ### Key endpoints
 
-| Operation | Method | Path |
-|-----------|--------|------|
-| Query assets | POST | `/niapm/v1/query-assets` |
-| Get asset | GET | `/niapm/v1/assets/{id}` |
-| Get calibration forecast | GET | `/niapm/v1/assets/{id}/policies` |
+| Operation                | Method | Path                             |
+| ------------------------ | ------ | -------------------------------- |
+| Query assets             | POST   | `/niapm/v1/query-assets`         |
+| Get asset                | GET    | `/niapm/v1/assets/{id}`          |
+| Get calibration forecast | GET    | `/niapm/v1/assets/{id}/policies` |
 
 ---
 
@@ -111,10 +112,10 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ### Key endpoints
 
-| Operation | Method | Path |
-|-----------|--------|------|
-| Get systems | GET | `/nisysmgmt/v1/systems` |
-| Query systems | POST | `/nisysmgmt/v1/query-systems` |
+| Operation     | Method | Path                          |
+| ------------- | ------ | ----------------------------- |
+| Get systems   | GET    | `/nisysmgmt/v1/systems`       |
+| Query systems | POST   | `/nisysmgmt/v1/query-systems` |
 
 ---
 
@@ -124,10 +125,10 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ### Key endpoints
 
-| Operation | Method | Path |
-|-----------|--------|------|
-| Query work orders | POST | `/niworkorder/v1/query` |
-| Update work order | PATCH | `/niworkorder/v1/work-orders/{id}` |
+| Operation         | Method | Path                               |
+| ----------------- | ------ | ---------------------------------- |
+| Query work orders | POST   | `/niworkorder/v1/query`            |
+| Update work order | PATCH  | `/niworkorder/v1/work-orders/{id}` |
 
 ---
 
@@ -139,11 +140,11 @@ The app is served by SystemLink and calls SystemLink. Browser session cookies ar
 
 ```typescript
 // hey-api client setup
-import { createClient } from '@hey-api/client-fetch';
+import { createClient } from "@hey-api/client-fetch";
 
 export const apiClient = createClient({
   baseUrl: `${window.location.origin}/nitag`,
-  credentials: 'include',
+  credentials: "include",
 });
 ```
 
@@ -155,7 +156,7 @@ No API key needed. The user must be logged in to SystemLink in that browser tab.
 export const apiClient = createClient({
   baseUrl: `${window.location.origin}/nitag`,
   headers: {
-    'x-ni-api-key': localStorage.getItem('sl_api_key') ?? '',
+    "x-ni-api-key": localStorage.getItem("sl_api_key") ?? "",
   },
 });
 ```
@@ -176,7 +177,7 @@ path = "cpu" or path = "mem"           OR
 keywords.Contains("production")        array contains
 ```
 
-String values must be double-quoted in the filter string. Build filters by joining parts with ` and `.
+String values must be double-quoted in the filter string. Build filters by joining parts with `and`.
 
 ---
 
@@ -184,11 +185,11 @@ String values must be double-quoted in the filter string. Build filters by joini
 
 SystemLink APIs return standard HTTP status codes. Common ones:
 
-| Code | Meaning |
-|------|---------|
-| 401 | Not authenticated — user needs to log in, or API key is invalid |
-| 403 | Authenticated but not authorized for this workspace/resource |
-| 404 | Resource not found |
-| 422 | Invalid request body (e.g., bad LINQ filter) |
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| 401  | Not authenticated — user needs to log in, or API key is invalid |
+| 403  | Authenticated but not authorized for this workspace/resource    |
+| 404  | Resource not found                                              |
+| 422  | Invalid request body (e.g., bad LINQ filter)                    |
 
 Show errors in a `<nimble-banner severity="error">` with the status code and message from the response body.

--- a/slcli/tag_click.py
+++ b/slcli/tag_click.py
@@ -52,6 +52,23 @@ def _tag_formatter(item: Dict[str, Any]) -> List[str]:
     return [path, tag_type, value, last_updated]
 
 
+def _tag_history_formatter(item: Dict[str, Any]) -> List[str]:
+    """Format one historical tag value for table output."""
+    value_data = item.get("value", {})
+    if isinstance(value_data, dict):
+        value = value_data.get("value", "N/A")
+        tag_type = value_data.get("type", item.get("type", "N/A"))
+    else:
+        value = value_data if value_data is not None else "N/A"
+        tag_type = item.get("type", "N/A")
+
+    return [
+        str(item.get("timestamp", "N/A")),
+        str(value),
+        str(tag_type),
+    ]
+
+
 def _calculate_column_widths() -> List[int]:
     """Calculate dynamic column widths based on terminal size.
 
@@ -162,6 +179,59 @@ def _detect_value_type(value_str: str) -> Tuple[Any, str]:
 
     # Default to string
     return value_str, "STRING"
+
+
+def _get_tag_history(tag_path: str, workspace_id: Optional[str], take: int) -> List[Dict[str, Any]]:
+    """Fetch historical values for a tag.
+
+    Args:
+        tag_path: Tag path.
+        workspace_id: Optional workspace ID.
+        take: Maximum number of history entries to return.
+
+    Returns:
+        Historical tag value dictionaries, most recent first.
+    """
+    query_payload: Dict[str, Any] = {
+        "path": tag_path,
+        "startTime": "0001-01-01T00:00:00Z",
+        "endTime": "9999-12-31T23:59:59Z",
+        "take": take,
+        "sortOrder": "DESCENDING",
+    }
+    if workspace_id:
+        query_payload["workspace"] = workspace_id
+
+    url = f"{get_base_url()}/nitaghistorian/v2/tags/query-history"
+    resp = make_api_request("POST", url, payload=query_payload)
+    data = resp.json()
+
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+
+    if not isinstance(data, dict):
+        return []
+
+    value_type = data.get("type")
+
+    def normalize_entries(entries: Any) -> List[Dict[str, Any]]:
+        if not isinstance(entries, list):
+            return []
+        normalized: List[Dict[str, Any]] = []
+        for item in entries:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(value_type, str) and "type" not in item:
+                item = {**item, "type": value_type}
+            normalized.append(item)
+        return normalized
+
+    for key in ("values", "history", "tagsWithAggregates", "data"):
+        entries = data.get(key)
+        if isinstance(entries, list):
+            return normalize_entries(entries)
+
+    return []
 
 
 def register_tag_commands(cli: Any) -> None:
@@ -317,6 +387,59 @@ def register_tag_commands(cli: Any) -> None:
                 if format == "table" and total_count > len(tags):
                     click.echo(f"\nShowing {len(tags)} of {total_count} tags")
 
+        except Exception as exc:
+            handle_api_error(exc)
+
+    @tag.command(name="history")
+    @click.argument("tag_path")
+    @click.option(
+        "--workspace",
+        "-w",
+        type=str,
+        default=None,
+        help="Workspace ID or name (defaults to default workspace)",
+    )
+    @click.option(
+        "--take",
+        "-t",
+        type=click.IntRange(min=1),
+        default=100,
+        show_default=True,
+        help="Maximum number of historical values to return",
+    )
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def tag_history(tag_path: str, workspace: Optional[str], take: int, format: str) -> None:
+        """Show historical values for a tag.
+
+        TAG_PATH is the path identifier of the tag.
+        """
+        validate_output_format(format)
+
+        try:
+            ws_id = resolve_workspace_id(workspace)
+            history = _get_tag_history(tag_path, ws_id, take)
+            history_resp = FilteredResponse({"values": history})
+            workspace_label = ws_id or workspace or "default workspace"
+
+            UniversalResponseHandler.handle_list_response(
+                resp=history_resp,
+                data_key="values",
+                item_name="tag history entry",
+                format_output=format,
+                formatter_func=_tag_history_formatter,
+                headers=["Timestamp", "Value", "Type"],
+                column_widths=[28, 30, 12],
+                empty_message=f"No tag history found in workspace '{workspace_label}'",
+                enable_pagination=False,
+                page_size=take,
+            )
         except Exception as exc:
             handle_api_error(exc)
 

--- a/slcli/tag_click.py
+++ b/slcli/tag_click.py
@@ -5,6 +5,7 @@ tag values. All tag operations are scoped to workspaces with proper error handli
 """
 
 import json
+import math
 import shutil
 import sys
 import urllib.parse
@@ -23,6 +24,8 @@ from .utils import (
     make_api_request,
 )
 from .workspace_utils import resolve_workspace_id
+
+_TAG_HISTORY_GRAPH_HEIGHT = 6
 
 
 def _tag_formatter(item: Dict[str, Any]) -> List[str]:
@@ -67,6 +70,107 @@ def _tag_history_formatter(item: Dict[str, Any]) -> List[str]:
         str(value),
         str(tag_type),
     ]
+
+
+def _tag_history_numeric_value(item: Dict[str, Any]) -> Optional[float]:
+    """Return a finite numeric history value, if one is available."""
+    value_data = item.get("value")
+    value = value_data.get("value") if isinstance(value_data, dict) else value_data
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return numeric_value if math.isfinite(numeric_value) else None
+
+
+def _downsample_history(values: List[float], width: int) -> List[float]:
+    """Downsample values to fit the available graph width."""
+    if len(values) <= width:
+        return values
+    if width <= 1:
+        return [values[-1]]
+
+    return [values[round(index * (len(values) - 1) / (width - 1))] for index in range(width)]
+
+
+def _format_graph_value(value: float) -> str:
+    """Format a graph statistic without unnecessary trailing zeroes."""
+    return f"{value:.6g}"
+
+
+def _render_tag_history_graph(
+    tag_path: str, workspace_label: str, history: List[Dict[str, Any]]
+) -> None:
+    """Render numeric tag history as a terminal sparkline."""
+    if not history:
+        click.echo(f"No tag history found in workspace '{workspace_label}'")
+        return
+
+    chronological_history = list(reversed(history))
+    numeric_values = [_tag_history_numeric_value(item) for item in chronological_history]
+    if any(value is None for value in numeric_values):
+        click.echo(
+            f"Cannot graph non-numeric tag history for '{tag_path}' "
+            f"in workspace '{workspace_label}'."
+        )
+        click.echo("Run without --graph to view the history table.")
+        return
+
+    values = [value for value in numeric_values if value is not None]
+    minimum = min(values)
+    maximum = max(values)
+    latest = values[-1]
+    terminal_width = max(shutil.get_terminal_size().columns, 1)
+    graph_width = max(1, min(len(values), terminal_width - 16))
+    graph_values = _downsample_history(values, graph_width)
+    value_range = maximum - minimum
+    point_rows = [
+        (
+            _TAG_HISTORY_GRAPH_HEIGHT // 2
+            if value_range == 0
+            else round((maximum - value) / value_range * (_TAG_HISTORY_GRAPH_HEIGHT - 1))
+        )
+        for value in graph_values
+    ]
+    graph_rows = [[" "] * len(graph_values) for _ in range(_TAG_HISTORY_GRAPH_HEIGHT)]
+    for index, point_row in enumerate(point_rows):
+        graph_rows[point_row][index] = "●"
+        if index == 0:
+            continue
+
+        previous_row = point_rows[index - 1]
+        if previous_row == point_row:
+            continue
+
+        step = 1 if point_row > previous_row else -1
+        for row in range(previous_row + step, point_row, step):
+            graph_rows[row][index] = "│"
+
+    first_timestamp = chronological_history[0].get("timestamp", "N/A")
+    last_timestamp = chronological_history[-1].get("timestamp", "N/A")
+    click.echo(f"Tag history graph for '{tag_path}'")
+    click.echo(f"Workspace: {workspace_label}")
+    click.echo(f"Range: {first_timestamp} to {last_timestamp}")
+    click.echo(
+        f"Min: {_format_graph_value(minimum)}  "
+        f"Max: {_format_graph_value(maximum)}  "
+        f"Latest: {_format_graph_value(latest)}"
+    )
+    for row, graph_row in enumerate(graph_rows):
+        if value_range == 0:
+            row_label = (
+                _format_graph_value(maximum) if row == _TAG_HISTORY_GRAPH_HEIGHT // 2 else ""
+            )
+        else:
+            row_value = maximum - value_range * row / (_TAG_HISTORY_GRAPH_HEIGHT - 1)
+            row_label = _format_graph_value(row_value)
+        click.echo(f"  {row_label:>8} ┤{''.join(graph_row)}")
+    click.echo(f"  {_format_graph_value(minimum):>8} └{'─' * len(graph_values)}")
+    click.echo(f"  oldest{' ' * max(len(graph_values) - 12, 1)}newest")
 
 
 def _calculate_column_widths() -> List[int]:
@@ -415,18 +519,37 @@ def register_tag_commands(cli: Any) -> None:
         show_default=True,
         help="Output format",
     )
-    def tag_history(tag_path: str, workspace: Optional[str], take: int, format: str) -> None:
+    @click.option(
+        "--graph",
+        is_flag=True,
+        help="Render numeric history as a terminal sparkline (table format only)",
+    )
+    def tag_history(
+        tag_path: str,
+        workspace: Optional[str],
+        take: int,
+        format: str,
+        graph: bool,
+    ) -> None:
         """Show historical values for a tag.
 
         TAG_PATH is the path identifier of the tag.
         """
         validate_output_format(format)
+        if graph and format == "json":
+            click.echo("✗ --graph cannot be used with --format json", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
 
         try:
             ws_id = resolve_workspace_id(workspace)
             history = _get_tag_history(tag_path, ws_id, take)
-            history_resp = FilteredResponse({"values": history})
             workspace_label = ws_id or workspace or "default workspace"
+
+            if graph:
+                _render_tag_history_graph(tag_path, workspace_label, history)
+                return
+
+            history_resp = FilteredResponse({"values": history})
 
             UniversalResponseHandler.handle_list_response(
                 resp=history_resp,

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -11,8 +11,9 @@ import click
 import keyring
 import requests
 
+from . import ssl_trust
 from .rich_output import print_json
-from .ssl_trust import OS_TRUST_INJECTED, use_standard_ssl_context
+from .ssl_trust import use_standard_ssl_context
 
 
 class SystemLinkConfig:
@@ -590,7 +591,7 @@ def get_ssl_verify(server_uri: Optional[str] = None) -> Union[bool, str]:
         return requests_ca_bundle
 
     ssl_cert_file = os.environ.get("SSL_CERT_FILE")
-    if ssl_cert_file and not OS_TRUST_INJECTED:
+    if ssl_cert_file and not ssl_trust.OS_TRUST_INJECTED:
         return ssl_cert_file
 
     return True

--- a/slcli/utils.py
+++ b/slcli/utils.py
@@ -12,7 +12,7 @@ import keyring
 import requests
 
 from .rich_output import print_json
-from .ssl_trust import use_standard_ssl_context
+from .ssl_trust import OS_TRUST_INJECTED, use_standard_ssl_context
 
 
 class SystemLinkConfig:
@@ -585,8 +585,13 @@ def get_ssl_verify(server_uri: Optional[str] = None) -> Union[bool, str]:
         except (OSError, ValueError):
             pass
 
-    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
-        return os.environ.get("REQUESTS_CA_BUNDLE") or os.environ["SSL_CERT_FILE"]
+    requests_ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE")
+    if requests_ca_bundle:
+        return requests_ca_bundle
+
+    ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+    if ssl_cert_file and not OS_TRUST_INJECTED:
+        return ssl_cert_file
 
     return True
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -185,6 +185,39 @@ def test_read_tag_values_reads_each_path(monkeypatch: Any) -> None:
     assert all("values/current" in url for url in seen_urls)
 
 
+def test_query_tag_history_uses_tag_historian(monkeypatch: Any) -> None:
+    """query_tag_history calls the Tag Historian query endpoint."""
+    from slcli.mcp_server import query_tag_history
+
+    seen_calls: list = []
+    monkeypatch.setattr("slcli.utils.get_base_url", lambda: "https://test.host")
+
+    def mock_request(method: str, url: str, payload: Any = None, **kw: Any) -> Any:
+        seen_calls.append({"method": method, "url": url, "payload": payload})
+        return make_mock_response(
+            {"type": "DOUBLE", "values": [{"timestamp": "2024-01-01T00:00:00Z", "value": "42"}]}
+        )
+
+    monkeypatch.setattr("slcli.utils.make_api_request", mock_request)
+
+    result = json.loads(query_tag_history(path="tag.one", take=2))
+
+    assert result == [{"timestamp": "2024-01-01T00:00:00Z", "value": "42", "type": "DOUBLE"}]
+    assert seen_calls == [
+        {
+            "method": "POST",
+            "url": "https://test.host/nitaghistorian/v2/tags/query-history",
+            "payload": {
+                "path": "tag.one",
+                "startTime": "0001-01-01T00:00:00Z",
+                "endTime": "9999-12-31T23:59:59Z",
+                "take": 2,
+                "sortOrder": "DESCENDING",
+            },
+        }
+    ]
+
+
 def test_query_systems_normalizes_wrapped_response(monkeypatch: Any) -> None:
     """query_systems prefers search-systems and normalizes materialized responses."""
     from slcli.mcp_server import query_systems

--- a/tests/unit/test_tag_click.py
+++ b/tests/unit/test_tag_click.py
@@ -245,6 +245,146 @@ class TestTagList:
                 assert "Query Failed" in result.output
 
 
+class TestTagHistory:
+    """Tests for tag history command."""
+
+    def test_history_json_output(self, monkeypatch: Any) -> None:
+        """Test historical values are returned as normalized JSON."""
+
+        def mock_get_password(service: str, key: str) -> Optional[str]:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps({"api_url": "http://localhost", "api_key": "test"})
+            return None
+
+        monkeypatch.setattr(keyring, "get_password", mock_get_password)
+
+        cli = make_cli()
+        runner = CliRunner()
+        history = [
+            {
+                "timestamp": "2024-01-02T00:00:00Z",
+                "value": "23.5",
+            }
+        ]
+
+        with patch("slcli.tag_click.get_base_url", return_value="http://localhost"):
+            with patch("slcli.tag_click.make_api_request") as mock_request:
+                with patch("slcli.tag_click.resolve_workspace_id") as mock_resolve:
+                    mock_resolve.return_value = "ws-123"
+                    mock_request.return_value = mock_response({"type": "DOUBLE", "values": history})
+
+                    result = runner.invoke(
+                        cli,
+                        [
+                            "tag",
+                            "history",
+                            "sensor/temperature",
+                            "--workspace",
+                            "ws-123",
+                            "--take",
+                            "2",
+                            "--format",
+                            "json",
+                        ],
+                    )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == [{**entry, "type": "DOUBLE"} for entry in history]
+        mock_request.assert_called_once_with(
+            "POST",
+            "http://localhost/nitaghistorian/v2/tags/query-history",
+            payload={
+                "path": "sensor/temperature",
+                "workspace": "ws-123",
+                "startTime": "0001-01-01T00:00:00Z",
+                "endTime": "9999-12-31T23:59:59Z",
+                "take": 2,
+                "sortOrder": "DESCENDING",
+            },
+        )
+
+    def test_history_table_output(self, monkeypatch: Any) -> None:
+        """Test historical values are rendered in table format."""
+
+        def mock_get_password(service: str, key: str) -> Optional[str]:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps({"api_url": "http://localhost", "api_key": "test"})
+            return None
+
+        monkeypatch.setattr(keyring, "get_password", mock_get_password)
+
+        cli = make_cli()
+        runner = CliRunner()
+        history: Any = [
+            {
+                "timestamp": "2024-01-02T00:00:00Z",
+                "value": "23.5",
+            }
+        ]
+
+        with patch("slcli.tag_click.make_api_request") as mock_request:
+            with patch("slcli.tag_click.resolve_workspace_id") as mock_resolve:
+                mock_resolve.return_value = None
+                mock_request.return_value = mock_response({"type": "DOUBLE", "values": history})
+
+                result = runner.invoke(cli, ["tag", "history", "temperature"])
+
+        assert result.exit_code == 0
+        assert "Timestamp" in result.output
+        assert "2024-01-02T00:00:00Z" in result.output
+        assert "23.5" in result.output
+        assert "DOUBLE" in result.output
+
+    def test_history_empty_output(self, monkeypatch: Any) -> None:
+        """Test an empty history response has a useful table message."""
+
+        def mock_get_password(service: str, key: str) -> Optional[str]:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps({"api_url": "http://localhost", "api_key": "test"})
+            return None
+
+        monkeypatch.setattr(keyring, "get_password", mock_get_password)
+
+        cli = make_cli()
+        runner = CliRunner()
+
+        with patch("slcli.tag_click.make_api_request") as mock_request:
+            with patch("slcli.tag_click.resolve_workspace_id") as mock_resolve:
+                mock_resolve.return_value = "ws-123"
+                mock_request.return_value = mock_response({"values": []})
+
+                result = runner.invoke(
+                    cli,
+                    ["tag", "history", "temperature", "--workspace", "ws-123"],
+                )
+
+        assert result.exit_code == 0
+        assert "No tag history found in workspace 'ws-123'" in result.output
+
+    def test_history_api_error(self, monkeypatch: Any) -> None:
+        """Test history API errors use standard CLI error handling."""
+
+        def mock_get_password(service: str, key: str) -> Optional[str]:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps({"api_url": "http://localhost", "api_key": "test"})
+            return None
+
+        monkeypatch.setattr(keyring, "get_password", mock_get_password)
+
+        cli = make_cli()
+        runner = CliRunner()
+
+        with patch("slcli.tag_click.make_api_request") as mock_request:
+            with patch("slcli.tag_click.resolve_workspace_id") as mock_resolve:
+                mock_resolve.return_value = None
+                mock_request.side_effect = Exception("History query failed")
+
+                result = runner.invoke(cli, ["tag", "history", "temperature"])
+
+        assert result.exit_code != 0
+        assert "History query failed" in result.output
+
+
 class TestTagGet:
     """Tests for tag get command."""
 

--- a/tests/unit/test_tag_click.py
+++ b/tests/unit/test_tag_click.py
@@ -335,6 +335,57 @@ class TestTagHistory:
         assert "23.5" in result.output
         assert "DOUBLE" in result.output
 
+    def test_history_graph_output(self, monkeypatch: Any) -> None:
+        """Test numeric history is rendered chronologically as a sparkline."""
+
+        def mock_get_password(service: str, key: str) -> Optional[str]:
+            if key == "SYSTEMLINK_CONFIG":
+                return json.dumps({"api_url": "http://localhost", "api_key": "test"})
+            return None
+
+        monkeypatch.setattr(keyring, "get_password", mock_get_password)
+
+        cli = make_cli()
+        runner = CliRunner()
+        history: Any = [
+            {"timestamp": "2024-01-02T00:00:03Z", "value": "30"},
+            {"timestamp": "2024-01-02T00:00:02Z", "value": "20"},
+            {"timestamp": "2024-01-02T00:00:01Z", "value": "10"},
+        ]
+
+        with patch("slcli.tag_click.make_api_request") as mock_request:
+            with patch("slcli.tag_click.resolve_workspace_id") as mock_resolve:
+                mock_resolve.return_value = "ws-123"
+                mock_request.return_value = mock_response({"type": "DOUBLE", "values": history})
+
+                result = runner.invoke(
+                    cli,
+                    ["tag", "history", "temperature", "--workspace", "ws-123", "--graph"],
+                )
+
+        assert result.exit_code == 0
+        assert "Tag history graph for 'temperature'" in result.output
+        assert "Workspace: ws-123" in result.output
+        assert "Range: 2024-01-02T00:00:01Z to 2024-01-02T00:00:03Z" in result.output
+        assert "Min: 10  Max: 30  Latest: 30" in result.output
+        graph_rows = [line for line in result.output.splitlines() if "┤" in line]
+        assert len(graph_rows) == 6
+        assert "●" in graph_rows[0]
+        assert "●" in graph_rows[-1]
+
+    def test_history_graph_rejects_json_format(self, monkeypatch: Any) -> None:
+        """Test graph mode cannot be combined with JSON output."""
+        cli = make_cli()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["tag", "history", "temperature", "--graph", "--format", "json"],
+        )
+
+        assert result.exit_code != 0
+        assert "--graph cannot be used with --format json" in result.output
+
     def test_history_empty_output(self, monkeypatch: Any) -> None:
         """Test an empty history response has a useful table message."""
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -168,3 +168,14 @@ def test_ssl_verify_uses_managed_certificate(monkeypatch: Any, tmp_path: Path) -
 
     monkeypatch.setenv("SLCLI_SSL_VERIFY", "false")
     assert get_ssl_verify("https://example.com") is False
+
+
+def test_ssl_verify_prefers_os_trust_over_ssl_cert_file(monkeypatch: Any) -> None:
+    """The OS trust store should not be replaced by a single SSL_CERT_FILE root."""
+    from slcli.utils import get_ssl_verify
+
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("SSL_CERT_FILE", "/path/to/corporate-root.pem")
+    monkeypatch.setattr("slcli.utils.OS_TRUST_INJECTED", True)
+
+    assert get_ssl_verify("https://example.com") is True

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -176,6 +176,6 @@ def test_ssl_verify_prefers_os_trust_over_ssl_cert_file(monkeypatch: Any) -> Non
 
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     monkeypatch.setenv("SSL_CERT_FILE", "/path/to/corporate-root.pem")
-    monkeypatch.setattr("slcli.utils.OS_TRUST_INJECTED", True)
+    monkeypatch.setattr("slcli.ssl_trust.OS_TRUST_INJECTED", True)
 
     assert get_ssl_verify("https://example.com") is True


### PR DESCRIPTION
## Summary

- Query tag history through the `nitaghistorian` service and preserve response-level type metadata.
- Include the searched workspace in empty-history output.
- Add `slcli tag history TAG_PATH --graph` for six-row terminal graphs of numeric history, with width-aware downsampling and statistics.
- Update CLI/service references and add focused regression coverage.

## Testing

- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest --no-cov -q` (`1321 passed`)
- `poetry run black --check slcli/tag_click.py tests/unit/test_tag_click.py`
- `git diff --check`

## Release Notes

- Added `newsfragments/tag-history-graph.minor.md` for the new terminal graph option.

## Notes

- History queries are workspace-scoped; duplicate tag paths may require `--workspace` to select the workspace containing retained history.