### PR TITLE
Add alarm management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ SystemLink CLI (`slcli`) is a cross-platform Python CLI for SystemLink integrato
 
 ## Features
 
-- **20+ resource types** — test results, assets, systems, specifications, work items, notebooks, feeds, tags, files, users, policies, webapps, and more
-- **DataFrame tables** — inspect schema, query rows, export CSV, append data, and manage DataFrame table metadata
-- **Systems state lifecycle** — list saved states, inspect versions, and import or export portable `.sls` content
+- **20+ resource types** — test results, assets, systems, alarms, specifications, work items, notebooks, feeds, tags, files, users, policies, webapps, and more
 - **Multi-platform** — supports SystemLink Enterprise (SLE) and SystemLink Server (SLS) with automatic detection
 - **Multi-profile** — manage dev, staging, and prod environments with named profiles
 - **AI agent skills** — bundled skills for most AI agents (Copilot, Codex, etc.) and Claude

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ SystemLink CLI (`slcli`) is a cross-platform Python CLI for SystemLink integrato
 ## Features
 
 - **20+ resource types** — test results, assets, systems, alarms, specifications, work items, notebooks, feeds, tags, files, users, policies, webapps, and more
+- **DataFrame tables** — inspect schema, query rows, export CSV, append data, and manage DataFrame table metadata
+- **Systems state lifecycle** — list saved states, inspect versions, and import or export portable `.sls` content
 - **Multi-platform** — supports SystemLink Enterprise (SLE) and SystemLink Server (SLS) with automatic detection
 - **Multi-profile** — manage dev, staging, and prod environments with named profiles
 - **AI agent skills** — bundled skills for most AI agents (Copilot, Codex, etc.) and Claude

--- a/newsfragments/alarm-support.minor.md
+++ b/newsfragments/alarm-support.minor.md
@@ -1,0 +1,1 @@
+Add alarm listing, inspection, acknowledgment, force-clear, deletion, transition, and terminal monitoring commands.

--- a/site/commands.html
+++ b/site/commands.html
@@ -51,6 +51,7 @@
         <a href="#mcp" class="sidebar-link">mcp</a>
         <a href="#testmonitor" class="sidebar-link">testmonitor</a>
         <a href="#asset" class="sidebar-link">asset</a>
+        <a href="#alarm" class="sidebar-link">alarm</a>
         <a href="#system" class="sidebar-link">system</a>
         <a href="#state" class="sidebar-link">state</a>
         <a href="#dataframe" class="sidebar-link">dataframe</a>
@@ -83,6 +84,7 @@
         <div class="cmd-group"><h3>mcp</h3><p>Model Context Protocol server install and serve commands</p><code>slcli mcp install</code></div>
         <div class="cmd-group"><h3>testmonitor</h3><p>Test results, products, steps, measurements</p><code>slcli testmonitor result list</code></div>
         <div class="cmd-group"><h3>asset</h3><p>Hardware assets, calibration, fleet summary</p><code>slcli asset list</code></div>
+        <div class="cmd-group"><h3>alarm</h3><p>Alarm listing, lifecycle actions, transitions, and monitoring</p><code>slcli alarm list</code></div>
         <div class="cmd-group"><h3>system</h3><p>Managed systems, package comparison, jobs, reports</p><code>slcli system list</code></div>
         <div class="cmd-group"><h3>state</h3><p>Saved software states, .sls import/export, history, versioning</p><code>slcli state list</code></div>
         <div class="cmd-group"><h3>dataframe</h3><p>DataFrame tables, schema inspection, row queries, CSV export</p><code>slcli dataframe schema &lt;table-id&gt;</code></div>
@@ -240,6 +242,37 @@ slcli asset location-history &lt;asset-id&gt; \
       <pre><code>slcli asset create --model-name "PXI-4071" --serial-number "SN-123" --bus-type PCI_PXI
 slcli asset update &lt;asset-id&gt; --name "Updated Name"
 slcli asset delete &lt;asset-id&gt; --force</code></pre>
+
+      <!-- ─── ALARM ─── -->
+      <h2 id="alarm">alarm</h2>
+      <p>Query alarm instances, inspect and acknowledge conditions, clear or delete records, report transitions, and monitor active alarms.</p>
+
+      <h3>List &amp; Filter</h3>
+      <pre><code># List active alarms in the effective workspace
+    slcli alarm list
+
+    # Search alarm history across all workspaces
+    slcli alarm list --state all --workspace all --format json
+
+    # Filter by severity and resource
+    slcli alarm list --min-severity 3 --resource-type Tag</code></pre>
+
+      <h3>Inspect &amp; Manage</h3>
+      <pre><code># Inspect one alarm instance
+    slcli alarm get &lt;instance-id&gt;
+
+    # Acknowledge, force-clear, or delete alarm instances
+    slcli alarm acknowledge &lt;instance-id&gt;
+    slcli alarm force-clear &lt;instance-id&gt; --yes
+    slcli alarm delete &lt;instance-id&gt; --yes
+
+    # Create an alarm or report a SET/CLEAR transition
+    slcli alarm transition &lt;alarm-id&gt; --severity 3 --display-name "High disk use"
+    slcli alarm transition &lt;alarm-id&gt; --transition CLEAR
+
+    # Render a live dashboard or a single snapshot
+    slcli alarm monitor
+    slcli alarm monitor --once --format json</code></pre>
 
       <!-- ─── SYSTEM ─── -->
       <h2 id="system">system</h2>

--- a/slcli/alarm_click.py
+++ b/slcli/alarm_click.py
@@ -177,27 +177,29 @@ def _query_alarm_page(
 def _query_all_alarms(
     filter_expr: Optional[str],
     substitutions: List[Any],
+    max_items: int,
     include_transitions: bool,
     most_recent_only: bool,
 ) -> List[Dict[str, Any]]:
-    """Fetch every page of a query for JSON output."""
+    """Fetch pages up to the requested JSON result limit."""
     alarms: List[Dict[str, Any]] = []
     continuation_token: Optional[str] = None
 
-    while True:
+    while len(alarms) < max_items:
+        remaining = max_items - len(alarms)
         page, continuation_token, _ = _query_alarm_page(
             filter_expr,
             substitutions,
-            _MAX_QUERY_TAKE,
+            min(_MAX_QUERY_TAKE, remaining),
             continuation_token,
             include_transitions,
             most_recent_only,
         )
-        alarms.extend(page)
+        alarms.extend(page[:remaining])
         if not continuation_token or not page:
             break
 
-    return alarms
+    return alarms[:max_items]
 
 
 def _format_timestamp(value: Any) -> str:
@@ -235,6 +237,12 @@ def _alarm_formatter(item: Dict[str, Any], workspace_map: Dict[str, str]) -> Lis
     ]
 
 
+def _get_transition_count(item: Dict[str, Any]) -> int:
+    """Return the number of transitions when the response contains a list."""
+    transitions = item.get("transitions")
+    return len(transitions) if isinstance(transitions, list) else 0
+
+
 def _display_alarm_list(
     alarms: List[Dict[str, Any]],
     format_output: str,
@@ -264,7 +272,7 @@ def _display_alarm_list(
     )
 
     if include_transitions and format_output.lower() == "table":
-        transition_count = sum(len(item.get("transitions", [])) for item in alarms)
+        transition_count = sum(_get_transition_count(item) for item in alarms)
         if transition_count:
             click.echo(f"Transitions included: {transition_count}")
 
@@ -293,7 +301,7 @@ def _get_alarm_details(data: Dict[str, Any], format_output: str) -> None:
         ("Keywords", ", ".join(data.get("keywords", []))),
         ("Properties", json.dumps(data.get("properties", {}), sort_keys=True)),
         ("Notes", json.dumps(data.get("notes", []), sort_keys=True)),
-        ("Transitions", str(len(data.get("transitions", [])))),
+        ("Transitions", str(_get_transition_count(data))),
     ]
     render_table(
         headers=["FIELD", "VALUE"],
@@ -377,7 +385,7 @@ def _list_alarm_options(function: Any) -> Any:
             type=click.IntRange(min=1, max=_MAX_QUERY_TAKE),
             default=25,
             show_default=True,
-            help="Items per page (table output only)",
+            help="Maximum alarms to return (table page/snapshot size; JSON list total)",
         ),
         click.option(
             "--state",
@@ -457,6 +465,7 @@ def _run_list_alarms(
         alarms = _query_all_alarms(
             filter_expr,
             filter_substitutions,
+            take,
             include_transitions,
             most_recent_only,
         )

--- a/slcli/alarm_click.py
+++ b/slcli/alarm_click.py
@@ -1,0 +1,872 @@
+"""CLI commands for SystemLink Alarm Management."""
+
+import datetime
+import json
+import re
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import click
+import questionary
+
+from .cli_utils import confirm_bulk_operation, validate_output_format
+from .rich_output import render_table
+from .universal_handlers import FilteredResponse, UniversalResponseHandler
+from .utils import (
+    ExitCodes,
+    check_readonly_mode,
+    format_success,
+    get_base_url,
+    get_workspace_map,
+    handle_api_error,
+    make_api_request,
+)
+from .workspace_utils import get_effective_workspace, resolve_workspace_filter
+
+_MAX_QUERY_TAKE = 1000
+_MAX_ACKNOWLEDGE_IDS = 1000
+_MAX_DELETE_IDS = 5000
+_MAX_SEVERITY = 2_147_483_647
+
+
+def _get_alarm_base_url() -> str:
+    """Get the base URL for the Alarm Management API."""
+    return f"{get_base_url()}/nialarm/v1"
+
+
+def _parse_substitutions(values: Tuple[str, ...]) -> List[Any]:
+    """Parse CLI substitution values as JSON when possible."""
+    parsed: List[Any] = []
+    for value in values:
+        try:
+            parsed.append(json.loads(value))
+        except (json.JSONDecodeError, TypeError):
+            parsed.append(value)
+    return parsed
+
+
+def _append_filter(parts: List[str], substitutions: List[Any], expression: str, value: Any) -> None:
+    """Append a parameterized filter expression when a value is provided."""
+    if value is None or value == "":
+        return
+    index = len(substitutions)
+    parts.append(expression.format(index=index))
+    substitutions.append(value)
+
+
+def _offset_filter_substitutions(filter_query: str, offset: int) -> str:
+    """Offset substitution indexes in a user-provided filter expression."""
+    return re.sub(
+        r"@(\d+)",
+        lambda match: f"@{int(match.group(1)) + offset}",
+        filter_query,
+    )
+
+
+def _build_alarm_filter(
+    state: str,
+    alarm_id: Optional[str],
+    display_name: Optional[str],
+    channel: Optional[str],
+    resource_type: Optional[str],
+    min_severity: Optional[int],
+    max_severity: Optional[int],
+    workspace: Optional[str],
+    filter_query: Optional[str],
+    substitutions: Tuple[str, ...],
+) -> Tuple[Optional[str], List[Any], Dict[str, str]]:
+    """Build a Dynamic LINQ alarm filter and resolve workspace display data."""
+    parts: List[str] = []
+    filter_substitutions: List[Any] = []
+    workspace_map: Dict[str, str] = {}
+
+    if state == "active":
+        parts.append("active == true")
+    elif state == "inactive":
+        parts.append("active == false")
+
+    _append_filter(parts, filter_substitutions, "alarmId == @{index}", alarm_id)
+    _append_filter(parts, filter_substitutions, "displayName.Contains(@{index})", display_name)
+    _append_filter(parts, filter_substitutions, "channel.Contains(@{index})", channel)
+    _append_filter(parts, filter_substitutions, "resourceType == @{index}", resource_type)
+    _append_filter(parts, filter_substitutions, "currentSeverityLevel >= @{index}", min_severity)
+    _append_filter(parts, filter_substitutions, "currentSeverityLevel <= @{index}", max_severity)
+
+    effective_workspace = get_effective_workspace(workspace)
+    if effective_workspace:
+        try:
+            workspace_map = get_workspace_map()
+        except Exception:
+            workspace_map = {}
+        workspace_id = resolve_workspace_filter(effective_workspace, workspace_map)
+        _append_filter(parts, filter_substitutions, "workspace == @{index}", workspace_id)
+
+    user_substitutions = _parse_substitutions(substitutions)
+    if filter_query:
+        if parts:
+            offset_filter = _offset_filter_substitutions(filter_query, len(filter_substitutions))
+            parts.append(f"({offset_filter})")
+            filter_substitutions.extend(user_substitutions)
+        else:
+            parts.append(filter_query)
+            filter_substitutions = user_substitutions
+
+    return (" && ".join(parts) if parts else None), filter_substitutions, workspace_map
+
+
+def _extract_json(resp: Any) -> Any:
+    """Return a response body when it contains JSON, otherwise an empty object."""
+    try:
+        return resp.json()
+    except (AttributeError, ValueError):
+        return {}
+
+
+def _extract_alarm_items(data: Any) -> List[Dict[str, Any]]:
+    """Extract alarm records from current and legacy response shapes."""
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if not isinstance(data, dict):
+        return []
+    for key in ("alarms", "alarmInstances", "filterMatches", "instances", "items"):
+        values = data.get(key)
+        if isinstance(values, list):
+            return [item for item in values if isinstance(item, dict)]
+    return []
+
+
+def _query_alarm_page(
+    filter_expr: Optional[str],
+    substitutions: List[Any],
+    take: int,
+    continuation_token: Optional[str] = None,
+    include_transitions: bool = False,
+    most_recent_only: bool = False,
+) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[int]]:
+    """Query one page of alarms using the non-deprecated filter endpoint."""
+    payload: Dict[str, Any] = {
+        "take": take,
+        "returnCount": True,
+        "orderBy": "UPDATED_AT",
+        "orderByDescending": True,
+    }
+    if filter_expr:
+        payload["filter"] = filter_expr
+    if substitutions:
+        payload["substitutions"] = substitutions
+    if continuation_token:
+        payload["continuationToken"] = continuation_token
+    if include_transitions:
+        payload["transitionInclusionOption"] = "ALL"
+    if most_recent_only:
+        payload["returnMostRecentlyOccurredOnly"] = True
+
+    resp = make_api_request(
+        "POST",
+        f"{_get_alarm_base_url()}/query-instances-with-filter",
+        payload=payload,
+    )
+    data = _extract_json(resp)
+    total_count = data.get("totalCount") if isinstance(data, dict) else None
+    next_token = data.get("continuationToken") if isinstance(data, dict) else None
+    return _extract_alarm_items(data), next_token, total_count
+
+
+def _query_all_alarms(
+    filter_expr: Optional[str],
+    substitutions: List[Any],
+    include_transitions: bool,
+    most_recent_only: bool,
+) -> List[Dict[str, Any]]:
+    """Fetch every page of a query for JSON output."""
+    alarms: List[Dict[str, Any]] = []
+    continuation_token: Optional[str] = None
+
+    while True:
+        page, continuation_token, _ = _query_alarm_page(
+            filter_expr,
+            substitutions,
+            _MAX_QUERY_TAKE,
+            continuation_token,
+            include_transitions,
+            most_recent_only,
+        )
+        alarms.extend(page)
+        if not continuation_token or not page:
+            break
+
+    return alarms
+
+
+def _format_timestamp(value: Any) -> str:
+    """Format a timestamp for a compact table cell."""
+    if not value:
+        return ""
+    text = str(value)
+    return text.replace("T", " ", 1).replace("Z", "", 1)[:19]
+
+
+def _alarm_formatter(item: Dict[str, Any], workspace_map: Dict[str, str]) -> List[str]:
+    """Format an alarm for table output."""
+    state = "ACTIVE" if item.get("active") else "INACTIVE"
+    flags = []
+    if item.get("clear"):
+        flags.append("CLEAR")
+    if item.get("acknowledged"):
+        flags.append("ACK")
+    if flags:
+        state = f"{state}/{'+'.join(flags)}"
+
+    workspace_id = item.get("workspace", "")
+    workspace_name = (
+        workspace_map.get(workspace_id, workspace_id) if workspace_map else workspace_id
+    )
+
+    return [
+        state,
+        str(item.get("currentSeverityLevel", "")),
+        item.get("displayName") or item.get("alarmId", ""),
+        item.get("alarmId", ""),
+        _format_timestamp(item.get("occurredAt")),
+        workspace_name,
+        item.get("instanceId", ""),
+    ]
+
+
+def _display_alarm_list(
+    alarms: List[Dict[str, Any]],
+    format_output: str,
+    workspace_map: Dict[str, str],
+    total_count: Optional[int] = None,
+    shown_count: Optional[int] = None,
+    include_transitions: bool = False,
+) -> None:
+    """Render alarms in JSON or a compact operational table."""
+
+    def formatter(item: Dict[str, Any]) -> List[str]:
+        return _alarm_formatter(item, workspace_map)
+
+    UniversalResponseHandler.handle_list_response(
+        resp=FilteredResponse({"alarms": alarms}),
+        data_key="alarms",
+        item_name="alarm",
+        format_output=format_output,
+        formatter_func=formatter,
+        headers=["State", "Severity", "Name", "Alarm ID", "Occurred", "Workspace", "Instance ID"],
+        column_widths=[18, 8, 28, 28, 20, 20, 28],
+        empty_message="No alarms found.",
+        enable_pagination=False,
+        page_size=len(alarms) or 1,
+        total_count=total_count,
+        shown_count=shown_count,
+    )
+
+    if include_transitions and format_output.lower() == "table":
+        transition_count = sum(len(item.get("transitions", [])) for item in alarms)
+        if transition_count:
+            click.echo(f"Transitions included: {transition_count}")
+
+
+def _get_alarm_details(data: Dict[str, Any], format_output: str) -> None:
+    """Render one alarm record."""
+    if format_output.lower() == "json":
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    scalar_fields = [
+        ("Instance ID", data.get("instanceId", "")),
+        ("Alarm ID", data.get("alarmId", "")),
+        ("Display Name", data.get("displayName", "")),
+        ("State", "ACTIVE" if data.get("active") else "INACTIVE"),
+        ("Clear", data.get("clear", "")),
+        ("Acknowledged", data.get("acknowledged", "")),
+        ("Current Severity", data.get("currentSeverityLevel", "")),
+        ("Highest Severity", data.get("highestSeverityLevel", "")),
+        ("Occurred", data.get("occurredAt", "")),
+        ("Updated", data.get("updatedAt", "")),
+        ("Workspace", data.get("workspace", "")),
+        ("Channel", data.get("channel", "")),
+        ("Resource Type", data.get("resourceType", "")),
+        ("Description", data.get("description", "")),
+        ("Keywords", ", ".join(data.get("keywords", []))),
+        ("Properties", json.dumps(data.get("properties", {}), sort_keys=True)),
+        ("Notes", json.dumps(data.get("notes", []), sort_keys=True)),
+        ("Transitions", str(len(data.get("transitions", [])))),
+    ]
+    render_table(
+        headers=["FIELD", "VALUE"],
+        column_widths=[20, 100],
+        rows=[[label, str(value)] for label, value in scalar_fields],
+        show_total=False,
+    )
+
+
+def _parse_properties(values: Tuple[str, ...]) -> Dict[str, str]:
+    """Parse repeated key=value options."""
+    properties: Dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(f"Invalid property '{value}'. Use key=value.")
+        key, property_value = value.split("=", 1)
+        if not key.strip():
+            raise ValueError(f"Invalid property '{value}'. The key cannot be empty.")
+        properties[key.strip()] = property_value.strip()
+    return properties
+
+
+def _emit_action_result(
+    data: Any,
+    format_output: str,
+    message: str,
+    success_key: Optional[str] = None,
+    failed_key: Optional[str] = None,
+) -> None:
+    """Render an action response consistently."""
+    if format_output.lower() == "json":
+        click.echo(json.dumps(data if data else {}, indent=2))
+        return
+
+    format_success(message)
+    if isinstance(data, dict):
+        if success_key and data.get(success_key):
+            click.echo(f"  {success_key}: {', '.join(data[success_key])}")
+        if failed_key and data.get(failed_key):
+            click.echo(f"  {failed_key}: {', '.join(data[failed_key])}", err=True)
+        if data.get("error"):
+            error = data["error"]
+            if isinstance(error, dict):
+                click.echo(f"  Error: {error.get('message', error)}", err=True)
+            else:
+                click.echo(f"  Error: {error}", err=True)
+
+
+def _validate_ids(instance_ids: Tuple[str, ...], maximum: int, action: str) -> None:
+    """Validate a batch of instance IDs."""
+    if not instance_ids:
+        click.echo(f"No alarm instance IDs supplied for {action}.", err=True)
+        sys.exit(ExitCodes.INVALID_INPUT)
+    if len(instance_ids) > maximum:
+        click.echo(
+            f"A maximum of {maximum} alarm instance IDs can be supplied for {action}.",
+            err=True,
+        )
+        sys.exit(ExitCodes.INVALID_INPUT)
+
+
+def _confirm_alarm_operation(action: str, count: int, force: bool) -> bool:
+    """Confirm an alarm operation unless explicitly skipped."""
+    return confirm_bulk_operation(action, "alarm", count, force=force)
+
+
+def _list_alarm_options(function: Any) -> Any:
+    """Apply shared list/search options to a Click command."""
+    options = [
+        click.option(
+            "--format",
+            "-f",
+            type=click.Choice(["table", "json"]),
+            default="table",
+            show_default=True,
+            help="Output format",
+        ),
+        click.option(
+            "--take",
+            "-t",
+            type=click.IntRange(min=1, max=_MAX_QUERY_TAKE),
+            default=25,
+            show_default=True,
+            help="Items per page (table output only)",
+        ),
+        click.option(
+            "--state",
+            type=click.Choice(["active", "inactive", "all"]),
+            default="active",
+            show_default=True,
+            help="Alarm state to include",
+        ),
+        click.option("--alarm-id", help="Match an exact alarm ID"),
+        click.option("--display-name", help="Match display name text"),
+        click.option("--channel", help="Match channel text"),
+        click.option("--resource-type", help="Match an exact resource type"),
+        click.option("--min-severity", type=int, help="Minimum current severity"),
+        click.option("--max-severity", type=int, help="Maximum current severity"),
+        click.option(
+            "--workspace", "-w", help="Workspace name or ID; use 'all' for every workspace"
+        ),
+        click.option("--filter", "filter_query", help="Dynamic LINQ filter expression"),
+        click.option(
+            "--substitution",
+            "substitutions",
+            multiple=True,
+            help="Value for --filter substitutions (repeatable; JSON is parsed when valid)",
+        ),
+        click.option(
+            "--include-transitions",
+            is_flag=True,
+            help="Include all stored alarm transitions",
+        ),
+        click.option(
+            "--most-recent-only",
+            is_flag=True,
+            help="Return only the most recent instance for each alarm ID",
+        ),
+    ]
+    for option in options:
+        function = option(function)
+    return function
+
+
+def _run_list_alarms(
+    format: str,
+    take: int,
+    state: str,
+    alarm_id: Optional[str],
+    display_name: Optional[str],
+    channel: Optional[str],
+    resource_type: Optional[str],
+    min_severity: Optional[int],
+    max_severity: Optional[int],
+    workspace: Optional[str],
+    filter_query: Optional[str],
+    substitutions: Tuple[str, ...],
+    include_transitions: bool,
+    most_recent_only: bool,
+) -> None:
+    """Execute the shared alarm list/search workflow."""
+    format_output = validate_output_format(format)
+    if min_severity is not None and max_severity is not None and min_severity > max_severity:
+        click.echo("✗ --min-severity cannot be greater than --max-severity", err=True)
+        sys.exit(ExitCodes.INVALID_INPUT)
+
+    filter_expr, filter_substitutions, workspace_map = _build_alarm_filter(
+        state,
+        alarm_id,
+        display_name,
+        channel,
+        resource_type,
+        min_severity,
+        max_severity,
+        workspace,
+        filter_query,
+        substitutions,
+    )
+
+    if format_output.lower() == "json":
+        alarms = _query_all_alarms(
+            filter_expr,
+            filter_substitutions,
+            include_transitions,
+            most_recent_only,
+        )
+        _display_alarm_list(
+            alarms, format_output, workspace_map, include_transitions=include_transitions
+        )
+        return
+
+    continuation_token: Optional[str] = None
+    shown_count = 0
+    while True:
+        alarms, continuation_token, total_count = _query_alarm_page(
+            filter_expr,
+            filter_substitutions,
+            take,
+            continuation_token,
+            include_transitions,
+            most_recent_only,
+        )
+        if not alarms:
+            if shown_count == 0:
+                click.echo("No alarms found.")
+            break
+
+        shown_count += len(alarms)
+        _display_alarm_list(
+            alarms,
+            format_output,
+            workspace_map,
+            total_count=total_count,
+            shown_count=shown_count,
+            include_transitions=include_transitions,
+        )
+        if not continuation_token:
+            break
+        if not questionary.confirm("Show next set of alarms?", default=True).ask():
+            break
+
+
+def register_alarm_commands(cli: Any) -> None:
+    """Register the 'alarm' command group and its subcommands."""
+
+    @cli.group()
+    def alarm() -> None:
+        """View and manage SystemLink alarms."""
+
+    @alarm.command(name="list")
+    @_list_alarm_options
+    def list_alarms(
+        format: str,
+        take: int,
+        state: str,
+        alarm_id: Optional[str],
+        display_name: Optional[str],
+        channel: Optional[str],
+        resource_type: Optional[str],
+        min_severity: Optional[int],
+        max_severity: Optional[int],
+        workspace: Optional[str],
+        filter_query: Optional[str],
+        substitutions: Tuple[str, ...],
+        include_transitions: bool,
+        most_recent_only: bool,
+    ) -> None:
+        """List active alarms or search alarm history."""
+        try:
+            _run_list_alarms(
+                format,
+                take,
+                state,
+                alarm_id,
+                display_name,
+                channel,
+                resource_type,
+                min_severity,
+                max_severity,
+                workspace,
+                filter_query,
+                substitutions,
+                include_transitions,
+                most_recent_only,
+            )
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="get")
+    @click.argument("instance_id")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def get_alarm(instance_id: str, format: str) -> None:
+        """View a single alarm instance by INSTANCE_ID."""
+        try:
+            format_output = validate_output_format(format)
+            resp = make_api_request(
+                "GET",
+                f"{_get_alarm_base_url()}/instances/{quote(instance_id, safe='')}",
+            )
+            data = _extract_json(resp)
+            if not isinstance(data, dict):
+                raise ValueError("Alarm response was not an object")
+            _get_alarm_details(data, format_output)
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="acknowledge")
+    @click.argument("instance_ids", nargs=-1, required=True)
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def acknowledge_alarms(instance_ids: Tuple[str, ...], format: str) -> None:
+        """Acknowledge one or more alarm instances."""
+        check_readonly_mode("acknowledge alarms")
+        _validate_ids(instance_ids, _MAX_ACKNOWLEDGE_IDS, "acknowledgment")
+        try:
+            format_output = validate_output_format(format)
+            resp = make_api_request(
+                "POST",
+                f"{_get_alarm_base_url()}/acknowledge-instances-by-instance-id",
+                payload={"instanceIds": list(instance_ids), "forceClear": False},
+            )
+            data = _extract_json(resp)
+            _emit_action_result(
+                data,
+                format_output,
+                "Alarm acknowledgment completed",
+                success_key="acknowledged",
+                failed_key="failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="force-clear")
+    @click.argument("instance_ids", nargs=-1, required=True)
+    @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def force_clear_alarms(instance_ids: Tuple[str, ...], yes: bool, format: str) -> None:
+        """Acknowledge and clear one or more alarm instances."""
+        check_readonly_mode("force-clear alarms")
+        _validate_ids(instance_ids, _MAX_ACKNOWLEDGE_IDS, "force-clear")
+        if not _confirm_alarm_operation("force-clear", len(instance_ids), yes):
+            return
+        try:
+            format_output = validate_output_format(format)
+            resp = make_api_request(
+                "POST",
+                f"{_get_alarm_base_url()}/acknowledge-instances-by-instance-id",
+                payload={"instanceIds": list(instance_ids), "forceClear": True},
+            )
+            data = _extract_json(resp)
+            _emit_action_result(
+                data,
+                format_output,
+                "Alarm force-clear completed",
+                success_key="acknowledged",
+                failed_key="failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="delete")
+    @click.argument("instance_ids", nargs=-1, required=True)
+    @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def delete_alarms(instance_ids: Tuple[str, ...], yes: bool, format: str) -> None:
+        """Permanently delete one or more alarm instances."""
+        check_readonly_mode("delete alarms")
+        _validate_ids(instance_ids, _MAX_DELETE_IDS, "deletion")
+        if not _confirm_alarm_operation("delete", len(instance_ids), yes):
+            return
+        try:
+            format_output = validate_output_format(format)
+            resp = make_api_request(
+                "POST",
+                f"{_get_alarm_base_url()}/delete-instances-by-instance-id",
+                payload={"instanceIds": list(instance_ids)},
+            )
+            data = _extract_json(resp)
+            if not data:
+                data = {"deleted": list(instance_ids), "failed": []}
+            _emit_action_result(
+                data,
+                format_output,
+                "Alarm deletion completed",
+                success_key="deleted",
+                failed_key="failed",
+            )
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="transition")
+    @click.argument("alarm_id")
+    @click.option(
+        "--transition",
+        type=click.Choice(["SET", "CLEAR"], case_sensitive=False),
+        default="SET",
+        show_default=True,
+        help="Transition to report",
+    )
+    @click.option("--workspace", "-w", help="Workspace name or ID")
+    @click.option("--severity", type=int, help="Severity level; CLEAR defaults to -1")
+    @click.option("--value", help="Value that caused the transition")
+    @click.option("--condition", help="Condition associated with the transition")
+    @click.option("--short-text", help="Short condition description")
+    @click.option("--detail-text", help="Detailed condition description")
+    @click.option("--channel", help="Tag or resource associated with the alarm")
+    @click.option("--resource-type", help="Type of resource associated with the alarm")
+    @click.option("--display-name", help="Display name used when creating the alarm")
+    @click.option("--description", help="Description used when creating the alarm")
+    @click.option("--created-by", help="Identifier for the creating rule or application")
+    @click.option("--keyword", "keywords", multiple=True, help="Alarm keyword (repeatable)")
+    @click.option(
+        "--property",
+        "properties",
+        multiple=True,
+        help="Alarm property in key=value form (repeatable)",
+    )
+    @click.option(
+        "--format",
+        "-f",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format",
+    )
+    def transition_alarm(
+        alarm_id: str,
+        transition: str,
+        workspace: Optional[str],
+        severity: Optional[int],
+        value: Optional[str],
+        condition: Optional[str],
+        short_text: Optional[str],
+        detail_text: Optional[str],
+        channel: Optional[str],
+        resource_type: Optional[str],
+        display_name: Optional[str],
+        description: Optional[str],
+        created_by: Optional[str],
+        keywords: Tuple[str, ...],
+        properties: Tuple[str, ...],
+        format: str,
+    ) -> None:
+        """Create an alarm or report a SET/CLEAR transition for ALARM_ID."""
+        check_readonly_mode("report an alarm transition")
+        try:
+            format_output = validate_output_format(format)
+            effective_workspace = get_effective_workspace(workspace)
+            workspace_id: Optional[str] = None
+            if effective_workspace:
+                try:
+                    workspace_id = resolve_workspace_filter(
+                        effective_workspace, get_workspace_map()
+                    )
+                except Exception:
+                    workspace_id = effective_workspace
+
+            transition_type = transition.upper()
+            if severity is not None and severity > _MAX_SEVERITY:
+                raise ValueError(f"Severity cannot be greater than {_MAX_SEVERITY}.")
+            if transition_type == "CLEAR" and severity not in (None, -1):
+                raise ValueError("CLEAR transitions require --severity -1.")
+            if transition_type == "SET" and severity is not None and severity < 1:
+                raise ValueError("SET transitions require --severity at least 1.")
+            transition_data: Dict[str, Any] = {"transitionType": transition_type}
+            if severity is not None:
+                transition_data["severityLevel"] = severity
+            elif transition_type == "CLEAR":
+                transition_data["severityLevel"] = -1
+            for key, value in (
+                ("value", value),
+                ("condition", condition),
+                ("shortText", short_text),
+                ("detailText", detail_text),
+            ):
+                if value is not None:
+                    transition_data[key] = value
+
+            payload: Dict[str, Any] = {"alarmId": alarm_id, "transition": transition_data}
+            if workspace_id:
+                payload["workspace"] = workspace_id
+            for key, value in (
+                ("channel", channel),
+                ("resourceType", resource_type),
+                ("displayName", display_name),
+                ("description", description),
+                ("createdBy", created_by),
+            ):
+                if value is not None:
+                    payload[key] = value
+            if keywords:
+                payload["keywords"] = list(keywords)
+            if properties:
+                payload["properties"] = _parse_properties(properties)
+
+            resp = make_api_request("POST", f"{_get_alarm_base_url()}/instances", payload=payload)
+            data = _extract_json(resp)
+            _emit_action_result(data, format_output, "Alarm transition recorded")
+        except ValueError as exc:
+            click.echo(f"✗ {exc}", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)
+
+    @alarm.command(name="monitor")
+    @_list_alarm_options
+    @click.option(
+        "--interval",
+        type=click.FloatRange(min=0.1),
+        default=5.0,
+        show_default=True,
+        help="Seconds between refreshes",
+    )
+    @click.option("--once", is_flag=True, help="Render one snapshot and exit")
+    @click.option("--no-clear", is_flag=True, help="Keep previous snapshots in the terminal")
+    def monitor_alarms(
+        format: str,
+        take: int,
+        state: str,
+        alarm_id: Optional[str],
+        display_name: Optional[str],
+        channel: Optional[str],
+        resource_type: Optional[str],
+        min_severity: Optional[int],
+        max_severity: Optional[int],
+        workspace: Optional[str],
+        filter_query: Optional[str],
+        substitutions: Tuple[str, ...],
+        include_transitions: bool,
+        most_recent_only: bool,
+        interval: float,
+        once: bool,
+        no_clear: bool,
+    ) -> None:
+        """Continuously refresh an alarm dashboard until Ctrl+C."""
+        format_output = validate_output_format(format)
+        if min_severity is not None and max_severity is not None and min_severity > max_severity:
+            click.echo("✗ --min-severity cannot be greater than --max-severity", err=True)
+            sys.exit(ExitCodes.INVALID_INPUT)
+
+        try:
+            filter_expr, filter_substitutions, workspace_map = _build_alarm_filter(
+                state,
+                alarm_id,
+                display_name,
+                channel,
+                resource_type,
+                min_severity,
+                max_severity,
+                workspace,
+                filter_query,
+                substitutions,
+            )
+            previous_snapshot: Optional[str] = None
+            while True:
+                alarms, _, _ = _query_alarm_page(
+                    filter_expr,
+                    filter_substitutions,
+                    take,
+                    include_transitions=include_transitions,
+                    most_recent_only=most_recent_only,
+                )
+                snapshot = json.dumps(alarms, sort_keys=True, default=str)
+                if snapshot != previous_snapshot:
+                    if (
+                        format_output.lower() == "table"
+                        and previous_snapshot is not None
+                        and not no_clear
+                    ):
+                        click.clear()
+                    if format_output.lower() == "table":
+                        click.echo(
+                            f"Alarm monitor | {datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='seconds')} | {len(alarms)} alarm(s)"
+                        )
+                    _display_alarm_list(
+                        alarms,
+                        format_output,
+                        workspace_map,
+                        include_transitions=include_transitions,
+                    )
+                    previous_snapshot = snapshot
+
+                if once:
+                    break
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            click.echo("\nAlarm monitor stopped.")
+        except Exception as exc:  # noqa: BLE001
+            handle_api_error(exc)

--- a/slcli/asset_click.py
+++ b/slcli/asset_click.py
@@ -468,7 +468,7 @@ def register_asset_commands(cli: Any) -> None:
         type=int,
         default=25,
         show_default=True,
-        help="Items per page (table output only)",
+        help="Maximum assets to return (table page size; JSON list total)",
     )
     @click.option("--model", help="Filter by model name (contains match)")
     @click.option("--serial-number", help="Filter by serial number (exact match)")
@@ -617,7 +617,11 @@ def register_asset_commands(cli: Any) -> None:
             if format_output.lower() == "json":
                 _warn_if_large_dataset(filter_expr, calibratable)
                 assets = _query_all_assets(
-                    filter_expr, order_by, descending, calibratable_only=calibratable
+                    filter_expr,
+                    order_by,
+                    descending,
+                    take=take,
+                    calibratable_only=calibratable,
                 )
 
                 if summary:

--- a/slcli/dataframe_click.py
+++ b/slcli/dataframe_click.py
@@ -413,14 +413,28 @@ def _display_table_pages(initial_payload: Dict[str, Any], workspace_map: Dict[st
         payload["continuationToken"] = continuation_token
 
 
-def _fetch_all_table_pages(initial_payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Fetch every table page for JSON output."""
+def _fetch_all_table_pages(
+    initial_payload: Dict[str, Any], max_items: Optional[int] = None
+) -> Dict[str, Any]:
+    """Fetch table pages up to the JSON result limit."""
     payload = dict(initial_payload)
     all_tables: List[Dict[str, Any]] = []
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_tables)
+            if remaining <= 0:
+                return {"tables": all_tables[:max_items], "continuationToken": None}
+            payload["take"] = min(int(payload.get("take", remaining)), remaining)
+
         data = _fetch_table_page(payload)
-        all_tables.extend(data.get("tables", []) or [])
+        page_tables = data.get("tables", []) or []
+        if max_items is not None:
+            page_tables = page_tables[: max_items - len(all_tables)]
+        all_tables.extend(page_tables)
+        if max_items is not None and len(all_tables) >= max_items:
+            return {"tables": all_tables[:max_items], "continuationToken": None}
+
         continuation_token = data.get("continuationToken")
         if not continuation_token:
             return {"tables": all_tables, "continuationToken": None}
@@ -676,7 +690,14 @@ def register_dataframe_commands(cli: Any) -> None:
         help="Sort field for tables",
     )
     @click.option("--descending/--ascending", default=False, help="Sort descending")
-    @click.option("--take", "-t", type=int, default=25, show_default=True, help="Page size")
+    @click.option(
+        "--take",
+        "-t",
+        type=int,
+        default=25,
+        show_default=True,
+        help="Maximum tables to return (table page size; JSON list total)",
+    )
     @click.option(
         "--format",
         "-f",
@@ -713,7 +734,7 @@ def register_dataframe_commands(cli: Any) -> None:
 
         try:
             if format_output == "json":
-                click.echo(json.dumps(_fetch_all_table_pages(payload), indent=2))
+                click.echo(json.dumps(_fetch_all_table_pages(payload, max_items=take), indent=2))
                 return
 
             _display_table_pages(payload, get_workspace_map())

--- a/slcli/dff_click.py
+++ b/slcli/dff_click.py
@@ -336,7 +336,9 @@ def _query_all_fields(
 
 
 def _query_all_configurations(
-    workspace_filter: Optional[str] = None, workspace_map: Optional[dict] = None
+    workspace_filter: Optional[str] = None,
+    workspace_map: Optional[dict] = None,
+    max_items: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Query all configurations using continuation token pagination.
 
@@ -348,12 +350,20 @@ def _query_all_configurations(
         List of all configurations, optionally filtered by workspace
     """
     url = f"{get_base_url()}/nidynamicformfields/v1/configurations"
-    all_configurations = []
+    all_configurations: List[Dict[str, Any]] = []
     continuation_token = None
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_configurations)
+            if remaining <= 0:
+                break
+            page_size = min(100, remaining)
+        else:
+            page_size = 100
+
         # Build parameters for the request
-        params = {"Take": 100}  # Use smaller page size for efficient pagination
+        params = {"Take": page_size}
         if continuation_token:
             params["ContinuationToken"] = continuation_token
 
@@ -364,22 +374,20 @@ def _query_all_configurations(
         resp = make_api_request("GET", full_url)
         data = resp.json()
 
-        # Extract configurations from this page
+        # Extract configurations from this page, applying client-side workspace filtering
         configurations = data.get("configurations", [])
+        if workspace_filter and workspace_map:
+            configurations = filter_by_workspace(configurations, workspace_filter, workspace_map)
         all_configurations.extend(configurations)
 
         # Check if there are more pages
         continuation_token = data.get("continuationToken")
-        if not continuation_token:
+        if not continuation_token or (
+            max_items is not None and len(all_configurations) >= max_items
+        ):
             break
 
-    # Filter by workspace if specified
-    if workspace_filter and workspace_map:
-        all_configurations = filter_by_workspace(
-            all_configurations, workspace_filter, workspace_map
-        )
-
-    return all_configurations
+    return all_configurations[:max_items] if max_items is not None else all_configurations
 
 
 def register_dff_commands(cli: Any) -> None:
@@ -423,11 +431,13 @@ def register_dff_commands(cli: Any) -> None:
             format_config_row = WorkspaceFormatter.create_config_row_formatter(workspace_map)
 
             # Use continuation token pagination following user_click.py pattern
-            all_configurations = _query_all_configurations(workspace, workspace_map)
+            all_configurations = _query_all_configurations(
+                workspace,
+                workspace_map,
+                max_items=take if format.lower() == "json" else None,
+            )
 
             # Use UniversalResponseHandler for consistent pagination
-            from typing import Any
-
             # Create a mock response with all data
             filtered_resp: Any = FilteredResponse({"configurations": all_configurations})
 
@@ -442,6 +452,7 @@ def register_dff_commands(cli: Any) -> None:
                 [36, 40, 36],
                 "No custom field configurations found.",
                 enable_pagination=True,
+                page_size=take,
             )
 
         except Exception as exc:

--- a/slcli/function_click.py
+++ b/slcli/function_click.py
@@ -96,6 +96,7 @@ def _query_all_functions(
     interface_filter: Optional[str] = None,
     custom_filter: Optional[str] = None,
     workspace_map: Optional[Dict[str, Any]] = None,
+    max_items: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Query all function definitions using continuation token pagination.
 
@@ -110,13 +111,21 @@ def _query_all_functions(
         List of all function definitions matching the filters
     """
     url = f"{get_unified_v2_base()}/query-functions"
-    all_functions = []
+    all_functions: List[Dict[str, Any]] = []
     continuation_token = None
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_functions)
+            if remaining <= 0:
+                break
+            page_size = min(100, remaining)
+        else:
+            page_size = 100
+
         # Build payload for the request
         payload: Dict[str, Union[int, str, List[str]]] = {
-            "take": 100,  # Use smaller page size for efficient pagination
+            "take": page_size,
         }
 
         # Build filter expression
@@ -162,7 +171,7 @@ def _query_all_functions(
         if not continuation_token:
             break
 
-    return all_functions
+    return all_functions[:max_items] if max_items is not None else all_functions
 
 
 def _query_all_executions(
@@ -170,6 +179,7 @@ def _query_all_executions(
     status_filter: Optional[str] = None,
     function_id_filter: Optional[str] = None,
     workspace_map: Optional[Dict[str, Any]] = None,
+    max_items: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Query all function executions using continuation token pagination.
 
@@ -183,13 +193,21 @@ def _query_all_executions(
         List of all function executions matching the filters
     """
     url = f"{get_unified_v2_base()}/query-executions"
-    all_executions = []
+    all_executions: List[Dict[str, Any]] = []
     continuation_token = None
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_executions)
+            if remaining <= 0:
+                break
+            page_size = min(100, remaining)
+        else:
+            page_size = 100
+
         # Build payload for the request
         payload: Dict[str, Union[int, str, List[str]]] = {
-            "take": 100,  # Use smaller page size for efficient pagination
+            "take": page_size,
         }
 
         # Build filter expression
@@ -223,7 +241,7 @@ def _query_all_executions(
         if not continuation_token:
             break
 
-    return all_executions
+    return all_executions[:max_items] if max_items is not None else all_executions
 
 
 def register_function_commands(cli: Any) -> None:
@@ -411,6 +429,7 @@ def register_function_commands(cli: Any) -> None:
                 interface_filter=interface_contains,
                 custom_filter=filter,
                 workspace_map=workspace_map,
+                max_items=take if format_output.lower() == "json" else None,
             )
 
             # Create a mock response with all data
@@ -1024,7 +1043,7 @@ def register_function_commands(cli: Any) -> None:
         type=int,
         default=25,
         show_default=True,
-        help="Maximum number of executions to return",
+        help="Maximum executions to return (table page size; JSON list total)",
     )
     @click.option(
         "--format",
@@ -1057,7 +1076,11 @@ def register_function_commands(cli: Any) -> None:
 
             # Use continuation token pagination to get all executions
             all_executions = _query_all_executions(
-                workspace_id, status_filter, function_id, workspace_map
+                workspace_id,
+                status_filter,
+                function_id,
+                workspace_map,
+                max_items=take if format_output.lower() == "json" else None,
             )
 
             # Create a mock response with all data

--- a/slcli/main.py
+++ b/slcli/main.py
@@ -15,6 +15,7 @@ import click as base_click
 import keyring
 import questionary
 
+from .alarm_click import register_alarm_commands
 from .asset_click import register_asset_commands
 from .comment_click import register_comment_commands
 from .completion_click import register_completion_command
@@ -79,6 +80,7 @@ def _configure_rich_click_command_groups() -> None:
             {
                 "name": "Operate",
                 "commands": [
+                    "alarm",
                     "asset",
                     "system",
                     "state",
@@ -699,6 +701,7 @@ def info(format: str, skip_health: bool, debug: bool) -> None:
 
 
 register_completion_command(cli)
+register_alarm_commands(cli)
 register_asset_commands(cli)
 register_comment_commands(cli)
 register_dataframe_commands(cli)

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -134,17 +134,21 @@ def _get_notebook_base_url() -> str:
 def _query_notebooks_http(
     filter_str: Optional[str] = None, take: int = 1000
 ) -> List[Dict[str, Any]]:
-    """Query notebooks using continuation token pagination for better performance."""
+    """Query notebooks using continuation token pagination up to ``take`` items."""
     base_url = _get_notebook_base_url()
     headers = get_headers("application/json")
     is_sls = get_platform() == PLATFORM_SLS
 
-    all_notebooks = []
+    if take <= 0:
+        return []
+
+    all_notebooks: List[Dict[str, Any]] = []
     continuation_token = None
 
-    while True:
+    while len(all_notebooks) < take:
+        remaining = take - len(all_notebooks)
         # Build payload for the request
-        payload: Dict[str, Any] = {"take": 100}  # Use consistent page size for efficient pagination
+        payload: Dict[str, Any] = {"take": min(100, remaining)}
         if filter_str:
             payload["filter"] = filter_str
         if continuation_token:
@@ -165,6 +169,8 @@ def _query_notebooks_http(
 
             # Handle invalid parameters gracefully and add notebooks to results
             for nb in raw_notebooks:
+                if len(all_notebooks) >= take:
+                    break
                 try:
                     # Fix parameters field if it's a list instead of dict
                     if "parameters" in nb and isinstance(nb["parameters"], list):
@@ -185,7 +191,7 @@ def _query_notebooks_http(
 
             # Check if there are more pages
             continuation_token = data.get("continuationToken")
-            if not continuation_token:
+            if not continuation_token or len(all_notebooks) >= take:
                 break
 
         except requests.exceptions.RequestException as exc:
@@ -193,7 +199,7 @@ def _query_notebooks_http(
         except Exception as exc:
             raise Exception(f"Failed to query notebooks: {exc}")
 
-    return all_notebooks
+    return all_notebooks[:take]
 
 
 def _get_notebook_http(notebook_id: str) -> Dict[str, Any]:
@@ -919,7 +925,8 @@ def register_notebook_commands(cli: Any) -> None:
             combined_filter = " and ".join(filter_parts) if filter_parts else None
 
             try:
-                notebooks_raw = _query_notebooks_http(combined_filter, take=1000)
+                query_take = take if format_output.lower() == "json" else 1000
+                notebooks_raw = _query_notebooks_http(combined_filter, take=query_take)
             except Exception as exc:
                 click.echo(
                     f"✗ Error querying notebooks: {exc}",

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -925,8 +925,7 @@ def register_notebook_commands(cli: Any) -> None:
             combined_filter = " and ".join(filter_parts) if filter_parts else None
 
             try:
-                query_take = 1000
-                notebooks_raw = _query_notebooks_http(combined_filter, take=query_take)
+                notebooks_raw = _query_notebooks_http(combined_filter, take=1000)
             except Exception as exc:
                 click.echo(
                     f"✗ Error querying notebooks: {exc}",

--- a/slcli/notebook_click.py
+++ b/slcli/notebook_click.py
@@ -925,7 +925,7 @@ def register_notebook_commands(cli: Any) -> None:
             combined_filter = " and ".join(filter_parts) if filter_parts else None
 
             try:
-                query_take = take if format_output.lower() == "json" else 1000
+                query_take = 1000
                 notebooks_raw = _query_notebooks_http(combined_filter, take=query_take)
             except Exception as exc:
                 click.echo(

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -58,6 +58,7 @@ Load only what the current task needs.
 | Group | Purpose | Key subcommands |
 | --- | --- | --- |
 | `testmonitor` | Test results and products | `result list/get`, `product list/create/update` |
+| `alarm` | Alarm monitoring and lifecycle actions | `list`, `get`, `acknowledge`, `force-clear`, `delete`, `transition`, `monitor` |
 | `spec` | Specifications | `list`, `query`, `get`, `create`, `import`, `export` |
 | `asset` | Assets and calibration | `list`, `get`, `summary`, `calibration` |
 | `system` | System fleet | `list`, `get`, `compare`, `summary`, `job` |

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -5,6 +5,7 @@ Complete option reference for all `slcli` command groups.
 ## Contents
 
 - [testmonitor — Test data analysis](#testmonitor--test-data-analysis)
+- [alarm — Alarm monitoring and lifecycle management](#alarm--alarm-monitoring-and-lifecycle-management)
 - [spec — Specification management](#spec--specification-management)
 - [asset — Asset and calibration management](#asset--asset-and-calibration-management)
 - [system — System fleet management](#system--system-fleet-management)
@@ -172,6 +173,56 @@ slcli asset location-history <ASSET_ID> [-f json]   # Location/connection histor
 slcli asset create --model-name TEXT [OPTIONS]       # Create an asset
 slcli asset update <ASSET_ID> [OPTIONS]              # Update an asset
 slcli asset delete <ASSET_ID>                        # Delete an asset
+```
+
+## alarm — Alarm monitoring and lifecycle management
+
+Alarm list queries default to active alarms in the effective workspace. Use
+`--state all --workspace all` for an unrestricted history search.
+
+```bash
+# List active alarms or search alarm history with filters
+slcli alarm list [OPTIONS]
+
+  --state [active|inactive|all]  # Default: active
+  --alarm-id TEXT                # Exact alarm ID
+  --display-name TEXT            # Display name text
+  --channel TEXT                 # Channel text
+  --resource-type TEXT           # Exact resource type
+  --min-severity INTEGER         # Minimum current severity
+  --max-severity INTEGER         # Maximum current severity
+  --workspace, -w TEXT           # Workspace name/ID, or all
+  --filter TEXT                  # Dynamic LINQ filter
+  --substitution TEXT            # Value for --filter (repeatable)
+  --include-transitions          # Include all stored transitions
+  --most-recent-only             # Group by alarm ID and keep the latest instance
+  --take, -t INTEGER             # Default 25; maximum 1000
+  -f [table|json]
+
+# Inspect an alarm instance
+slcli alarm get <INSTANCE_ID> [-f json]
+
+# Acknowledge or force-clear alarm instances
+slcli alarm acknowledge <INSTANCE_ID>...
+slcli alarm force-clear <INSTANCE_ID>... [--yes]
+
+# Permanently remove alarm instances
+slcli alarm delete <INSTANCE_ID>... [--yes]
+
+# Create an alarm or report a SET/CLEAR transition
+slcli alarm transition <ALARM_ID> --transition [SET|CLEAR] [OPTIONS]
+  --severity INTEGER             # CLEAR defaults to -1
+  --workspace TEXT
+  --value TEXT --condition TEXT --short-text TEXT --detail-text TEXT
+  --channel TEXT --resource-type TEXT --display-name TEXT --description TEXT
+  --keyword TEXT                 # Repeatable
+  --property KEY=VALUE           # Repeatable
+
+# Leave a live active-alarm dashboard running in a terminal
+slcli alarm monitor [OPTIONS]
+  --interval FLOAT               # Seconds between refreshes, default 5.0
+  --once                         # Render one snapshot and exit
+  --no-clear                     # Keep prior snapshots in the terminal
 ```
 
 ## system — System fleet management

--- a/slcli/skills/slcli/references/webapp/systemlink-services.md
+++ b/slcli/skills/slcli/references/webapp/systemlink-services.md
@@ -116,6 +116,26 @@ Use the spec URL as the `input` in your `openapi-ts.config.ts`.
 
 ---
 
+## Alarm Management (`/nialarm`)
+
+**Base URL:** `window.location.origin + '/nialarm'`
+
+### Key endpoints
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| Query alarms with Dynamic LINQ | POST | `/nialarm/v1/query-instances-with-filter` |
+| Get alarm instance | GET | `/nialarm/v1/instances/{instanceId}` |
+| Create or update alarm transition | POST | `/nialarm/v1/instances` |
+| Acknowledge or force-clear alarms | POST | `/nialarm/v1/acknowledge-instances-by-instance-id` |
+| Delete alarms in a batch | POST | `/nialarm/v1/delete-instances-by-instance-id` |
+
+The query response uses an `alarms` array and may include `totalCount` and
+`continuationToken`. The CLI uses the Dynamic LINQ endpoint because the older
+`query-instances` endpoint is deprecated.
+
+---
+
 ## Work Orders (`/niworkorder`)
 
 **Base URL:** `window.location.origin + '/niworkorder'`

--- a/slcli/state_click.py
+++ b/slcli/state_click.py
@@ -280,6 +280,7 @@ def _fetch_all_states(
     workspace: Optional[str],
     architecture: Optional[str],
     distribution: Optional[str],
+    max_items: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Fetch all matching states using API paging."""
     states: List[Dict[str, Any]] = []
@@ -288,7 +289,15 @@ def _fetch_all_states(
     total_count = 0
 
     while True:
-        params = [f"Skip={skip}", f"Take={DEFAULT_FETCH_BATCH_SIZE}"]
+        if max_items is not None:
+            remaining = max_items - len(states)
+            if remaining <= 0:
+                break
+            page_take = min(DEFAULT_FETCH_BATCH_SIZE, remaining)
+        else:
+            page_take = DEFAULT_FETCH_BATCH_SIZE
+
+        params = [f"Skip={skip}", f"Take={page_take}"]
         if workspace_id:
             params.append(f"Workspace={workspace_id}")
         if architecture:
@@ -309,7 +318,10 @@ def _fetch_all_states(
 
         skip += len(page_states)
 
-    return {"totalCount": total_count, "states": states}
+    return {
+        "totalCount": total_count,
+        "states": states[:max_items] if max_items is not None else states,
+    }
 
 
 def _fetch_state_history(state_id: str) -> Dict[str, Any]:
@@ -506,7 +518,7 @@ def register_state_commands(cli: Any) -> None:
         type=int,
         default=25,
         show_default=True,
-        help="Number of items per page in table output",
+        help="Maximum states to return (table page size; JSON list total)",
     )
     @click.option(
         "--format",
@@ -530,6 +542,7 @@ def register_state_commands(cli: Any) -> None:
                 workspace=workspace_name,
                 architecture=architecture,
                 distribution=distribution,
+                max_items=take if format_output.lower() == "json" else None,
             )
             workspace_map = get_workspace_map()
             filtered_resp: Any = FilteredResponse(response_data)

--- a/slcli/templates_click.py
+++ b/slcli/templates_click.py
@@ -63,6 +63,7 @@ def _query_all_templates(
     workspace_filter: Optional[str] = None,
     workspace_map: Optional[dict] = None,
     search_text: Optional[str] = None,
+    max_items: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Query all test plan templates using continuation token pagination.
 
@@ -74,13 +75,21 @@ def _query_all_templates(
         List of all templates, optionally filtered by workspace
     """
     url = f"{get_base_url()}/niworkorder/v1/query-testplan-templates"
-    all_templates = []
+    all_templates: List[Dict[str, Any]] = []
     continuation_token = None
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_templates)
+            if remaining <= 0:
+                break
+            page_size = min(100, remaining)
+        else:
+            page_size = 100
+
         # Build payload for the request
         payload = {
-            "take": 100,  # Use smaller page size for efficient pagination
+            "take": page_size,
             "orderBy": "TEMPLATE_GROUP",
             "descending": False,
             "projection": ["ID", "NAME", "WORKSPACE", "TEMPLATE_GROUP"],
@@ -111,7 +120,7 @@ def _query_all_templates(
         if not continuation_token:
             break
 
-    return all_templates
+    return all_templates[:max_items] if max_items is not None else all_templates
 
 
 def register_templates_commands(cli: Any) -> None:
@@ -304,8 +313,13 @@ def register_templates_commands(cli: Any) -> None:
             if workspace:
                 workspace_id = resolve_workspace_filter(workspace, workspace_map)
 
-            # Use continuation token pagination to get all templates
-            all_templates = _query_all_templates(workspace_id, workspace_map, filter_text)
+            # Bound JSON output while retaining interactive table paging.
+            all_templates = _query_all_templates(
+                workspace_id,
+                workspace_map,
+                filter_text,
+                max_items=take if format_output.lower() == "json" else None,
+            )
 
             # Create a mock response with all data
             resp: Any = FilteredResponse({"testPlanTemplates": all_templates})

--- a/slcli/testmonitor_click.py
+++ b/slcli/testmonitor_click.py
@@ -862,7 +862,7 @@ def register_testmonitor_commands(cli: Any) -> None:
                     item.get("id", ""),
                 ]
 
-            # If JSON output, fetch all pages
+            # If JSON output, fetch up to --take items.
             if format_output.lower() == "json":
                 # Check total count first to warn about large datasets
                 _warn_if_large_dataset(
@@ -874,7 +874,9 @@ def register_testmonitor_commands(cli: Any) -> None:
                     order_by=order_by,
                     descending=descending,
                 )
-                products = _query_all_products(filter_expr, merged_subs, order_by, descending)
+                products = _query_all_products(
+                    filter_expr, merged_subs, order_by, descending, take=take
+                )
 
                 # Handle --summary flag for JSON output
                 if summary:

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -1265,7 +1265,14 @@ def register_webapp_commands(cli: Any) -> None:
         default="",
         help="Case-insensitive substring match on name",
     )
-    @click.option("--take", "take", type=int, default=25, show_default=True, help="Max rows/page")
+    @click.option(
+        "--take",
+        "take",
+        type=int,
+        default=25,
+        show_default=True,
+        help="Maximum webapps to return (table page size; JSON list total)",
+    )
     @click.option(
         "--format",
         "format_output",
@@ -1281,14 +1288,9 @@ def register_webapp_commands(cli: Any) -> None:
             # Validate and normalize format option
             format_output = validate_output_format(format_output)
 
-            # Determine how many items to request from the API
-            if format_output.lower() == "json":
-                # For JSON output we want to return all matching items (no
-                # interactive pagination). Use a falsy api_take (0) to indicate
-                # "fetch all" to the helper.
-                api_take = 0
-            else:
-                api_take = take if take != 25 else 1000
+            # JSON uses --take as a total cap; table mode keeps fetching pages
+            # so the user can choose whether to continue after each page.
+            api_take = take if format_output.lower() == "json" else (take if take != 25 else 1000)
             # Use server-side query to only retrieve WebVI documents
             base_filter = 'type == "WebVI"'
             workspace = get_effective_workspace(workspace) or workspace
@@ -1316,11 +1318,8 @@ def register_webapp_commands(cli: Any) -> None:
                 name_clause = f"({' or '.join(variants)})"
                 base_filter = f"({base_filter}) and ({name_clause})"
 
-            # If the user requested JSON output or did not request a specific take,
-            # fetch all matching items (using server-side paging). Otherwise, if
-            # the user specified a take and wants table output, perform interactive
-            # server-side paging: fetch a page, show total (if available), and offer
-            # to fetch the next page(s).
+            # JSON is bounded by --take. Table output remains interactive and
+            # fetches the next page only after the user confirms.
             webapps: List[Dict[str, Any]] = []
             if format_output.lower() == "json" or take == 0:
                 webapps = _query_webapps_http(base_filter, max_items=api_take)

--- a/slcli/workflows_click.py
+++ b/slcli/workflows_click.py
@@ -44,7 +44,9 @@ removed; import the public helpers directly from that module.
 
 
 def _query_all_workflows(
-    workspace_filter: Optional[str] = None, workspace_map: Optional[dict] = None
+    workspace_filter: Optional[str] = None,
+    workspace_map: Optional[dict] = None,
+    max_items: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Query all workflows using continuation token pagination.
 
@@ -56,13 +58,21 @@ def _query_all_workflows(
         List of all workflows, optionally filtered by workspace
     """
     url = f"{get_base_url()}/niworkorder/v1/query-workflows?ff-userdefinedworkflowsfortestplaninstances=true"
-    all_workflows = []
+    all_workflows: List[Dict[str, Any]] = []
     continuation_token = None
 
     while True:
+        if max_items is not None:
+            remaining = max_items - len(all_workflows)
+            if remaining <= 0:
+                break
+            page_size = min(100, remaining)
+        else:
+            page_size = 100
+
         # Build payload for the request
         payload: Dict[str, Union[int, str]] = {
-            "take": 100,  # Use smaller page size for efficient pagination
+            "take": page_size,
         }
 
         # Add workspace filter if specified
@@ -85,7 +95,7 @@ def _query_all_workflows(
         if not continuation_token:
             break
 
-    return all_workflows
+    return all_workflows[:max_items] if max_items is not None else all_workflows
 
 
 def register_workflows_commands(cli: Any) -> None:
@@ -386,8 +396,12 @@ def register_workflows_commands(cli: Any) -> None:
             if workspace:
                 workspace_id = resolve_workspace_filter(workspace, workspace_map)
 
-            # Use continuation token pagination to get all workflows
-            all_workflows = _query_all_workflows(workspace_id, workspace_map)
+            # Bound JSON output while retaining interactive table paging.
+            all_workflows = _query_all_workflows(
+                workspace_id,
+                workspace_map,
+                max_items=take if format_output.lower() == "json" else None,
+            )
 
             # Create a mock response with all data
             resp = FilteredResponse({"workflows": all_workflows})

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -509,6 +509,7 @@ def pytest_configure(config: Any) -> None:
     config.addinivalue_line("markers", "tag: mark test as tag service related")
     config.addinivalue_line("markers", "system: mark test as system management related")
     config.addinivalue_line("markers", "asset: mark test as asset management related")
+    config.addinivalue_line("markers", "alarm: mark test as alarm management related")
     config.addinivalue_line("markers", "testmonitor: mark test as test monitor related")
     config.addinivalue_line("markers", "comment: mark test as comment management related")
     config.addinivalue_line("markers", "routine: mark test as routine management related")

--- a/tests/e2e/test_alarm_e2e.py
+++ b/tests/e2e/test_alarm_e2e.py
@@ -1,0 +1,84 @@
+"""E2E tests for alarm commands against a configured SystemLink environment."""
+
+import uuid
+from typing import Any, Optional
+
+import pytest
+
+
+@pytest.mark.e2e
+@pytest.mark.alarm
+class TestAlarmLifecycleE2E:
+    """End-to-end tests for alarm creation and lifecycle commands."""
+
+    def test_create_inspect_acknowledge_clear_delete(
+        self, cli_runner: Any, cli_helper: Any, configured_workspace: str
+    ) -> None:
+        """Test the alarm lifecycle through the public CLI commands."""
+        alarm_id = f"slcli-e2e-alarm-{uuid.uuid4().hex}"
+        instance_id: Optional[str] = None
+
+        try:
+            result = cli_runner(
+                [
+                    "alarm",
+                    "transition",
+                    alarm_id,
+                    "--workspace",
+                    configured_workspace,
+                    "--severity",
+                    "2",
+                    "--channel",
+                    "slcli-e2e",
+                    "--resource-type",
+                    "E2E",
+                    "--display-name",
+                    "slcli E2E alarm",
+                    "--created-by",
+                    "slcli-e2e",
+                    "--format",
+                    "json",
+                ],
+                check=False,
+            )
+            if "readonly" in result.stderr.lower():
+                pytest.skip("Profile is in readonly mode")
+            cli_helper.assert_success(result)
+
+            created = cli_helper.get_json_output(result)
+            instance_id = created.get("instanceId") if isinstance(created, dict) else None
+            assert instance_id
+
+            result = cli_runner(
+                [
+                    "alarm",
+                    "list",
+                    "--alarm-id",
+                    alarm_id,
+                    "--workspace",
+                    configured_workspace,
+                    "--state",
+                    "all",
+                    "--format",
+                    "json",
+                ]
+            )
+            alarms = cli_helper.get_json_output(result)
+            assert any(item.get("instanceId") == instance_id for item in alarms)
+
+            result = cli_runner(["alarm", "get", instance_id, "--format", "json"])
+            alarm = cli_helper.get_json_output(result)
+            assert alarm.get("alarmId") == alarm_id
+
+            result = cli_runner(["alarm", "acknowledge", instance_id])
+            cli_helper.assert_success(result)
+
+            result = cli_runner(["alarm", "force-clear", instance_id, "--yes", "--format", "json"])
+            cli_helper.assert_success(result)
+
+            result = cli_runner(["alarm", "delete", instance_id, "--yes", "--format", "json"])
+            cli_helper.assert_success(result)
+            instance_id = None
+        finally:
+            if instance_id:
+                cli_runner(["alarm", "delete", instance_id, "--yes"], check=False)

--- a/tests/unit/test_alarm_click.py
+++ b/tests/unit/test_alarm_click.py
@@ -194,13 +194,36 @@ def test_list_outputs_json_and_uses_alarm_filter_endpoint(
     ]
     assert requests[0]["url"].endswith("/nialarm/v1/query-instances-with-filter")
     assert requests[0]["payload"] == {
-        "take": 1000,
+        "take": 25,
         "returnCount": True,
         "orderBy": "UPDATED_AT",
         "orderByDescending": True,
         "filter": "alarmId == @0 && (channel == @1)",
         "substitutions": ["alarm-1", "tag-channel"],
     }
+
+
+def test_alarm_list_json_stops_paging_at_take(runner: CliRunner, monkeypatch: Any) -> None:
+    """JSON list output should stop requesting pages at the requested limit."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        requests.append(kwargs["payload"])
+        return MockResponse(
+            {
+                "alarms": [{"instanceId": "instance-1"}],
+                "continuationToken": "next",
+            }
+        )
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    result = runner.invoke(make_cli(), ["alarm", "list", "--format", "json", "--take", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == [{"instanceId": "instance-1"}]
+    assert len(requests) == 1
+    assert requests[0]["take"] == 1
 
 
 def test_get_alarm_quotes_instance_id(runner: CliRunner, monkeypatch: Any) -> None:
@@ -356,6 +379,23 @@ def test_alarm_list_empty_table(runner: CliRunner, monkeypatch: Any) -> None:
 
     assert result.exit_code == 0, result.output
     assert "No alarms found." in result.output
+
+
+def test_alarm_list_ignores_malformed_transitions(runner: CliRunner, monkeypatch: Any) -> None:
+    """Malformed transition values should not crash table rendering."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {"alarms": [{"instanceId": "instance-1", "transitions": None}]}
+        ),
+    )
+
+    result = runner.invoke(make_cli(), ["alarm", "list", "--include-transitions"])
+
+    assert result.exit_code == 0, result.output
+    assert "instance-1" in result.output
+    assert "Transitions included" not in result.output
 
 
 def test_transition_clear_defaults_to_negative_one(runner: CliRunner, monkeypatch: Any) -> None:

--- a/tests/unit/test_alarm_click.py
+++ b/tests/unit/test_alarm_click.py
@@ -1,0 +1,590 @@
+"""Unit tests for alarm CLI commands."""
+
+import json
+from typing import Any, Dict, List
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from slcli.alarm_click import (
+    _build_alarm_filter,
+    _extract_alarm_items,
+    _extract_json,
+    _parse_properties,
+    _query_alarm_page,
+    _validate_ids,
+    register_alarm_commands,
+)
+
+
+class MockResponse:
+    """Minimal response object for alarm command tests."""
+
+    def __init__(self, data: Any, status_code: int = 200) -> None:
+        """Initialize a response with JSON data."""
+        self._data = data
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        """Return response JSON."""
+        return self._data
+
+
+def make_cli() -> click.Group:
+    """Create a CLI containing alarm commands."""
+
+    @click.group()
+    def test_cli() -> None:
+        pass
+
+    register_alarm_commands(test_cli)
+    return test_cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a Click test runner."""
+    return CliRunner()
+
+
+def patch_alarm_config(monkeypatch: Any) -> None:
+    """Patch connection and workspace lookups for isolated command tests."""
+    monkeypatch.setattr("slcli.alarm_click.get_base_url", lambda: "https://server.example")
+    monkeypatch.setattr("slcli.alarm_click.get_workspace_map", lambda: {})
+
+
+def test_build_alarm_filter_offsets_user_substitutions() -> None:
+    """Convenience filters must not capture raw filter substitutions."""
+    expression, substitutions, _ = _build_alarm_filter(
+        state="active",
+        alarm_id="alarm-1",
+        display_name=None,
+        channel=None,
+        resource_type=None,
+        min_severity=None,
+        max_severity=None,
+        workspace=None,
+        filter_query="channel == @0",
+        substitutions=("tag-channel",),
+    )
+
+    assert expression == "active == true && alarmId == @0 && (channel == @1)"
+    assert substitutions == ["alarm-1", "tag-channel"]
+
+
+def test_build_alarm_filter_resolves_workspace(monkeypatch: Any) -> None:
+    """Workspace names should be converted to IDs in the query filter."""
+    monkeypatch.setattr(
+        "slcli.alarm_click.get_workspace_map",
+        lambda: {"workspace-1": "Production"},
+    )
+
+    expression, substitutions, workspace_map = _build_alarm_filter(
+        state="inactive",
+        alarm_id=None,
+        display_name="disk",
+        channel=None,
+        resource_type=None,
+        min_severity=2,
+        max_severity=4,
+        workspace="Production",
+        filter_query=None,
+        substitutions=(),
+    )
+
+    assert expression == (
+        "active == false && displayName.Contains(@0) && currentSeverityLevel >= @1 "
+        "&& currentSeverityLevel <= @2 && workspace == @3"
+    )
+    assert substitutions == ["disk", 2, 4, "workspace-1"]
+    assert workspace_map == {"workspace-1": "Production"}
+
+
+def test_extract_alarm_items_supports_legacy_shapes() -> None:
+    """The parser should tolerate list and legacy service response keys."""
+    assert _extract_alarm_items([{"id": "one"}, "ignored"]) == [{"id": "one"}]
+    assert _extract_alarm_items({"alarmInstances": [{"id": "two"}]}) == [{"id": "two"}]
+    assert _extract_alarm_items({"filterMatches": [{"id": "three"}]}) == [{"id": "three"}]
+    assert _extract_alarm_items({"unexpected": []}) == []
+    assert _extract_json(object()) == {}
+
+
+def test_query_alarm_page_includes_optional_query_flags(monkeypatch: Any) -> None:
+    """Query pagination and transition options should be sent to the service."""
+    patch_alarm_config(monkeypatch)
+    payloads: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        payloads.append(kwargs["payload"])
+        return MockResponse(
+            {
+                "alarms": [{"instanceId": "one"}],
+                "continuationToken": "next",
+                "totalCount": 3,
+            }
+        )
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    alarms, token, total = _query_alarm_page(
+        "active == true",
+        ["value"],
+        10,
+        continuation_token="previous",
+        include_transitions=True,
+        most_recent_only=True,
+    )
+
+    assert alarms == [{"instanceId": "one"}]
+    assert token == "next"
+    assert total == 3
+    assert payloads == [
+        {
+            "take": 10,
+            "returnCount": True,
+            "orderBy": "UPDATED_AT",
+            "orderByDescending": True,
+            "filter": "active == true",
+            "substitutions": ["value"],
+            "continuationToken": "previous",
+            "transitionInclusionOption": "ALL",
+            "returnMostRecentlyOccurredOnly": True,
+        }
+    ]
+
+
+def test_list_outputs_json_and_uses_alarm_filter_endpoint(
+    runner: CliRunner, monkeypatch: Any
+) -> None:
+    """List should use the current filter endpoint and return alarm records."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        requests.append({"method": method, "url": url, "payload": kwargs.get("payload")})
+        return MockResponse(
+            {
+                "alarms": [{"instanceId": "instance-1", "alarmId": "alarm-1", "active": True}],
+                "totalCount": 1,
+            }
+        )
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    result = runner.invoke(
+        make_cli(),
+        [
+            "alarm",
+            "list",
+            "--state",
+            "all",
+            "--alarm-id",
+            "alarm-1",
+            "--filter",
+            "channel == @0",
+            "--substitution",
+            "tag-channel",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == [
+        {"instanceId": "instance-1", "alarmId": "alarm-1", "active": True}
+    ]
+    assert requests[0]["url"].endswith("/nialarm/v1/query-instances-with-filter")
+    assert requests[0]["payload"] == {
+        "take": 1000,
+        "returnCount": True,
+        "orderBy": "UPDATED_AT",
+        "orderByDescending": True,
+        "filter": "alarmId == @0 && (channel == @1)",
+        "substitutions": ["alarm-1", "tag-channel"],
+    }
+
+
+def test_get_alarm_quotes_instance_id(runner: CliRunner, monkeypatch: Any) -> None:
+    """Get should safely encode an instance ID in the URL path."""
+    patch_alarm_config(monkeypatch)
+    requests: List[str] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        requests.append(url)
+        return MockResponse({"instanceId": "id/with space", "active": True})
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    result = runner.invoke(make_cli(), ["alarm", "get", "id/with space", "-f", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert requests == ["https://server.example/nialarm/v1/instances/id%2Fwith%20space"]
+    assert json.loads(result.output)["instanceId"] == "id/with space"
+
+
+def test_get_alarm_table_includes_details(runner: CliRunner, monkeypatch: Any) -> None:
+    """The default get format should render useful alarm metadata."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {
+                "instanceId": "instance-1",
+                "alarmId": "alarm-1",
+                "active": False,
+                "keywords": ["system-health"],
+                "properties": {"rack": "12"},
+                "transitions": [{"transitionType": "CLEAR"}],
+            }
+        ),
+    )
+    result = runner.invoke(make_cli(), ["alarm", "get", "instance-1"])
+
+    assert result.exit_code == 0, result.output
+    assert "alarm-1" in result.output
+    assert "system-health" in result.output
+    assert "Transitions" in result.output
+
+
+def test_acknowledge_alarms_posts_instance_ids(runner: CliRunner, monkeypatch: Any) -> None:
+    """Acknowledge should post the selected IDs without a destructive prompt."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        requests.append({"method": method, "url": url, "payload": kwargs.get("payload")})
+        return MockResponse({"acknowledged": ["one", "two"], "failed": []})
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    result = runner.invoke(make_cli(), ["alarm", "acknowledge", "one", "two"])
+
+    assert result.exit_code == 0, result.output
+    assert requests[0]["payload"] == {"instanceIds": ["one", "two"], "forceClear": False}
+    assert "acknowledged: one, two" in result.output
+
+
+def test_force_clear_uses_force_clear_payload(runner: CliRunner, monkeypatch: Any) -> None:
+    """Force-clear should acknowledge and clear in one API request."""
+    patch_alarm_config(monkeypatch)
+    payloads: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        payloads.append(kwargs["payload"])
+        return MockResponse({"acknowledged": ["one"], "failed": []})
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    result = runner.invoke(make_cli(), ["alarm", "force-clear", "one", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert payloads == [{"instanceIds": ["one"], "forceClear": True}]
+
+
+def test_delete_uses_bulk_endpoint_and_yes_flag(runner: CliRunner, monkeypatch: Any) -> None:
+    """Delete should use the partial-success batch endpoint."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        requests.append({"method": method, "url": url, "payload": kwargs.get("payload")})
+        return MockResponse({}, status_code=204)
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    result = runner.invoke(make_cli(), ["alarm", "delete", "one", "two", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert requests[0]["url"].endswith("/nialarm/v1/delete-instances-by-instance-id")
+    assert requests[0]["payload"] == {"instanceIds": ["one", "two"]}
+    assert "deleted: one, two" in result.output
+
+
+def test_force_clear_can_be_cancelled(runner: CliRunner, monkeypatch: Any) -> None:
+    """A declined force-clear should not make an API request."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    monkeypatch.setattr("slcli.alarm_click.confirm_bulk_operation", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: requests.append(kwargs),
+    )
+
+    result = runner.invoke(make_cli(), ["alarm", "force-clear", "one"])
+
+    assert result.exit_code == 0, result.output
+    assert requests == []
+
+
+def test_alarm_list_renders_table_and_transitions(runner: CliRunner, monkeypatch: Any) -> None:
+    """Table list output should show state and transition summary."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {
+                "alarms": [
+                    {
+                        "instanceId": "instance-1",
+                        "alarmId": "alarm-1",
+                        "active": True,
+                        "clear": True,
+                        "acknowledged": True,
+                        "currentSeverityLevel": 3,
+                        "occurredAt": "2026-08-06T12:00:00Z",
+                        "transitions": [{}],
+                    }
+                ],
+                "totalCount": 1,
+            }
+        ),
+    )
+    result = runner.invoke(make_cli(), ["alarm", "list", "--include-transitions"])
+
+    assert result.exit_code == 0, result.output
+    assert "ACTIVE/CLEAR+ACK" in result.output
+    assert "Transitions included: 1" in result.output
+
+
+def test_alarm_list_empty_table(runner: CliRunner, monkeypatch: Any) -> None:
+    """Empty table queries should produce a descriptive message."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse({"alarms": []}),
+    )
+    result = runner.invoke(make_cli(), ["alarm", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "No alarms found." in result.output
+
+
+def test_transition_clear_defaults_to_negative_one(runner: CliRunner, monkeypatch: Any) -> None:
+    """CLEAR transitions should send the service's sentinel severity."""
+    patch_alarm_config(monkeypatch)
+    payloads: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        payloads.append(kwargs["payload"])
+        return MockResponse({"instanceId": "instance-1"})
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    result = runner.invoke(
+        make_cli(),
+        ["alarm", "transition", "alarm-1", "--transition", "clear"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert payloads == [
+        {
+            "alarmId": "alarm-1",
+            "transition": {"transitionType": "CLEAR", "severityLevel": -1},
+        }
+    ]
+
+
+def test_transition_includes_optional_fields_and_properties(
+    runner: CliRunner, monkeypatch: Any
+) -> None:
+    """Transition should pass supported alarm metadata to the API."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.get_workspace_map",
+        lambda: {"workspace-1": "Production"},
+    )
+    payloads: List[Dict[str, Any]] = []
+
+    def mock_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        payloads.append(kwargs["payload"])
+        return MockResponse({"instanceId": "instance-1"})
+
+    monkeypatch.setattr("slcli.alarm_click.make_api_request", mock_request)
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+    result = runner.invoke(
+        make_cli(),
+        [
+            "alarm",
+            "transition",
+            "alarm-1",
+            "--workspace",
+            "Production",
+            "--severity",
+            "4",
+            "--value",
+            "95",
+            "--condition",
+            "> 90",
+            "--short-text",
+            "High disk use",
+            "--detail-text",
+            "Disk use exceeded threshold",
+            "--channel",
+            "disk",
+            "--resource-type",
+            "Tag",
+            "--display-name",
+            "Disk alarm",
+            "--description",
+            "Disk is nearly full",
+            "--created-by",
+            "Monitor",
+            "--keyword",
+            "system-health",
+            "--property",
+            "rack=12",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert payloads == [
+        {
+            "alarmId": "alarm-1",
+            "workspace": "workspace-1",
+            "transition": {
+                "transitionType": "SET",
+                "severityLevel": 4,
+                "value": "95",
+                "condition": "> 90",
+                "shortText": "High disk use",
+                "detailText": "Disk use exceeded threshold",
+            },
+            "channel": "disk",
+            "resourceType": "Tag",
+            "displayName": "Disk alarm",
+            "description": "Disk is nearly full",
+            "createdBy": "Monitor",
+            "keywords": ["system-health"],
+            "properties": {"rack": "12"},
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("transition", "severity", "message"),
+    [
+        ("SET", "0", "SET transitions require --severity at least 1."),
+        ("CLEAR", "1", "CLEAR transitions require --severity -1."),
+        ("SET", "2147483648", "Severity cannot be greater than 2147483647."),
+    ],
+)
+def test_transition_rejects_invalid_severity(
+    runner: CliRunner,
+    monkeypatch: Any,
+    transition: str,
+    severity: str,
+    message: str,
+) -> None:
+    """Transition severity must match the service's SET/CLEAR contract."""
+    patch_alarm_config(monkeypatch)
+    requests: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request", lambda *args, **kwargs: requests.append(kwargs)
+    )
+    monkeypatch.setattr("slcli.alarm_click.check_readonly_mode", lambda operation: None)
+
+    result = runner.invoke(
+        make_cli(),
+        [
+            "alarm",
+            "transition",
+            "alarm-1",
+            "--transition",
+            transition,
+            "--severity",
+            severity,
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert message in result.output
+    assert requests == []
+
+
+def test_parse_properties_rejects_missing_equals() -> None:
+    """Property options must use key=value syntax."""
+    with pytest.raises(ValueError, match="Use key=value"):
+        _parse_properties(("invalid",))
+
+
+def test_validate_ids_rejects_oversized_batch() -> None:
+    """Batch actions should reject IDs beyond the service limit."""
+    with pytest.raises(SystemExit) as exc_info:
+        _validate_ids(tuple(str(index) for index in range(2)), 1, "test")
+    assert exc_info.value.code == 2
+
+
+def test_monitor_once_queries_and_exits(runner: CliRunner, monkeypatch: Any) -> None:
+    """One-shot monitoring should render a snapshot and return."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {"alarms": [{"instanceId": "instance-1", "active": True}]}
+        ),
+    )
+    result = runner.invoke(make_cli(), ["alarm", "monitor", "--once"])
+
+    assert result.exit_code == 0, result.output
+    assert "Alarm monitor" in result.output
+    assert "instance-1" in result.output
+
+
+def test_monitor_once_json_is_parseable(runner: CliRunner, monkeypatch: Any) -> None:
+    """One-shot JSON monitoring should emit only the JSON snapshot."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {"alarms": [{"instanceId": "instance-1", "active": True}]}
+        ),
+    )
+
+    result = runner.invoke(make_cli(), ["alarm", "monitor", "--once", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == [{"instanceId": "instance-1", "active": True}]
+
+
+def test_alarm_table_does_not_refetch_empty_workspace_map(
+    runner: CliRunner, monkeypatch: Any
+) -> None:
+    """Formatting all-workspace results should not fetch workspace data per alarm."""
+    calls = 0
+
+    def get_workspace_map() -> Dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    monkeypatch.setattr("slcli.alarm_click.get_workspace_map", get_workspace_map)
+    monkeypatch.setattr("slcli.alarm_click.get_base_url", lambda: "https://server.example")
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse(
+            {"alarms": [{"instanceId": "instance-1", "workspace": "workspace-1"}]}
+        ),
+    )
+
+    result = runner.invoke(make_cli(), ["alarm", "list", "--workspace", "all"])
+
+    assert result.exit_code == 0, result.output
+    assert "workspace-1" in result.output
+    assert calls == 0
+
+
+def test_monitor_stops_cleanly_on_keyboard_interrupt(runner: CliRunner, monkeypatch: Any) -> None:
+    """A long-running monitor should provide a clean Ctrl+C exit message."""
+    patch_alarm_config(monkeypatch)
+    monkeypatch.setattr(
+        "slcli.alarm_click.make_api_request",
+        lambda method, url, **kwargs: MockResponse({"alarms": []}),
+    )
+
+    def stop_monitor(interval: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("slcli.alarm_click.time.sleep", stop_monitor)
+    result = runner.invoke(make_cli(), ["alarm", "monitor", "--interval", "0.1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Alarm monitor stopped." in result.output

--- a/tests/unit/test_dff_click.py
+++ b/tests/unit/test_dff_click.py
@@ -3,7 +3,7 @@
 import json
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
 import click
 import pytest
@@ -136,6 +136,37 @@ def test_dff_config_list_json_format(monkeypatch: Any, runner: CliRunner) -> Non
     output_json = json.loads(result.output)
     assert len(output_json) == 1
     assert output_json[0]["name"] == "Test Configuration"
+
+
+def test_dff_config_list_json_honors_take(monkeypatch: Any, runner: CliRunner) -> None:
+    """JSON configuration output should stop paging at the requested limit."""
+    patch_keyring(monkeypatch)
+    requests: List[str] = []
+
+    def mock_request(method: str, url: str, *args: Any, **kwargs: Any) -> Any:
+        requests.append(url)
+
+        class R:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return {
+                    "configurations": [{"id": "config1", "name": "First Configuration"}],
+                    "continuationToken": "next",
+                }
+
+        return R()
+
+    monkeypatch.setattr("slcli.dff_click.get_workspace_map", lambda: {})
+    monkeypatch.setattr("slcli.dff_click.make_api_request", mock_request)
+
+    result = runner.invoke(make_cli(), ["customfield", "list", "--format", "json", "--take", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == [{"id": "config1", "name": "First Configuration"}]
+    assert len(requests) == 1
+    assert "Take=1" in requests[0]
 
 
 def test_dff_config_get_success(monkeypatch: Any, runner: CliRunner) -> None:

--- a/tests/unit/test_notebook_click.py
+++ b/tests/unit/test_notebook_click.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List
 
 from click.testing import CliRunner
 from pytest import MonkeyPatch
@@ -106,6 +106,46 @@ def test_notebook_list_with_filter(monkeypatch: MonkeyPatch) -> None:
     # New implementation avoids ToLower() and uses multiple case variants
     assert 'name.Contains("test")' in built or 'name.Contains("Test")' in built
     assert "TestNotebook" in result.output
+
+
+def test_query_notebooks_http_respects_take(monkeypatch: MonkeyPatch) -> None:
+    """Notebook pagination should stop once the requested limit is reached."""
+    import slcli.notebook_click
+
+    class MockResponse:
+        def __init__(self, data: Dict[str, Any]) -> None:
+            self._data = data
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> Dict[str, Any]:
+            return self._data
+
+    requests: List[Dict[str, Any]] = []
+
+    def mock_post(url: str, **kwargs: Any) -> MockResponse:
+        requests.append(kwargs["json"])
+        return MockResponse(
+            {
+                "notebooks": [
+                    {"id": "notebook-1", "name": "First"},
+                    {"id": "notebook-2", "name": "Second"},
+                ],
+                "continuationToken": "next",
+            }
+        )
+
+    monkeypatch.setattr(slcli.notebook_click, "get_platform", lambda: PLATFORM_SLE)
+    monkeypatch.setattr(slcli.notebook_click, "get_base_url", lambda: "https://server.example")
+    monkeypatch.setattr(slcli.notebook_click, "get_headers", lambda content_type: {})
+    monkeypatch.setattr(slcli.notebook_click, "get_ssl_verify", lambda: True)
+    monkeypatch.setattr(slcli.notebook_click.requests, "post", mock_post)
+
+    notebooks = slcli.notebook_click._query_notebooks_http(take=1)
+
+    assert notebooks == [{"id": "notebook-1", "name": "First", "parameters": {}}]
+    assert requests == [{"take": 1}]
 
 
 def test_notebook_download_by_id(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Add an `alarm` command group for querying and inspecting alarm instances, acknowledging and force-clearing conditions, deleting records, reporting SET/CLEAR transitions, and monitoring alarms from a terminal.

The implementation uses the current Alarm Service filter endpoint, parameterized Dynamic LINQ substitutions, API batch limits, workspace resolution, consistent table/JSON output, and API-contract validation for transition severity. Documentation and an E2E lifecycle test are included.

## Testing
- `poetry run ni-python-styleguide lint slcli tests scripts`
- `poetry run mypy slcli tests`
- `poetry run black --check slcli/alarm_click.py tests/unit/test_alarm_click.py tests/e2e/test_alarm_e2e.py tests/e2e/conftest.py`
- `poetry run pytest` (`1337 passed`)
- `poetry run towncrier check --compare-with origin/main`
- `git diff --check origin/main...HEAD`

## Release Notes
- Added `newsfragments/alarm-support.minor.md` for the new alarm management commands.

## Notes
The focused live Alarm Service E2E test reaches the configured dev API but is currently blocked by the local environment's TLS trust configuration (`SSLCertVerificationError` for `dev-api.lifecyclesolutions.ni.com`). The request failed before creating an alarm record; unit coverage and E2E collection pass.