### PR TITLE
Fix webapp bootstrap on Windows

### DIFF
--- a/newsfragments/webapp-new-windows-bootstrap.patch.md
+++ b/newsfragments/webapp-new-windows-bootstrap.patch.md
@@ -1,0 +1,1 @@
+Make `webapp new` reliably detect Node.js and npm on Windows and decode npm output without locale errors.

--- a/slcli/webapp_bootstrap.py
+++ b/slcli/webapp_bootstrap.py
@@ -1,6 +1,7 @@
 """Hosted Angular webapp bootstrap commands and template generation helpers."""
 
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -1006,15 +1007,45 @@ def _initialize_plugin_manager_files(directory: Path, project_name: str, publish
     save_json_file(config, str(directory / "nipkg.config.json"))
 
 
+def _npm_executable() -> str:
+    """Return the npm executable name for the current platform."""
+    return "npm.cmd" if sys.platform == "win32" else "npm"
+
+
+def _validate_webapp_prerequisites() -> None:
+    """Verify the external runtimes required to install and build a webapp."""
+    required_commands = [("Node.js", "node"), ("npm", _npm_executable())]
+    missing_commands = [
+        display_name
+        for display_name, executable in required_commands
+        if shutil.which(executable) is None
+    ]
+    if missing_commands:
+        click.echo(
+            "✗ Missing required webapp dependencies: " + ", ".join(missing_commands),
+            err=True,
+        )
+        click.echo(
+            "Install Node.js 24+ and ensure both node and npm are available on PATH.",
+            err=True,
+        )
+        sys.exit(ExitCodes.GENERAL_ERROR)
+
+
 def _run_webapp_local_command(directory: Path, command: List[str], label: str) -> None:
     """Run a local process for webapp generation and surface actionable failures."""
     click.echo(f"→ {label}")
+    local_command = list(command)
+    if sys.platform == "win32" and local_command and local_command[0] == "npm":
+        local_command[0] = _npm_executable()
     try:
         result = subprocess.run(
-            command,
+            local_command,
             cwd=directory,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
     except FileNotFoundError as exc:
@@ -1130,6 +1161,9 @@ def _generate_new_webapp(
             plugin_manager=plugin_manager,
         )
         return
+
+    if not skip_install:
+        _validate_webapp_prerequisites()
 
     _ensure_generation_directory(target_dir, force)
     _write_rendered_template_tree(template_dir, target_dir, replacements)

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -620,6 +620,7 @@ def test_resolve_webapp_template_directory_reports_selected_template_name(
 def test_webapp_new_runs_install_and_build(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     runner = CliRunner()
     patch_keyring(monkeypatch)
+    monkeypatch.setattr(webapp_bootstrap.shutil, "which", lambda command: command)
 
     commands: List[List[str]] = []
 
@@ -632,6 +633,8 @@ def test_webapp_new_runs_install_and_build(tmp_path: Path, monkeypatch: MonkeyPa
     def fake_run(*args: Any, **kwargs: Any) -> Completed:
         commands.append(list(args[0]))
         assert kwargs["cwd"] == tmp_path / "build-check"
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
         return Completed()
 
     monkeypatch.setattr("slcli.webapp_bootstrap.subprocess.run", fake_run)
@@ -642,8 +645,45 @@ def test_webapp_new_runs_install_and_build(tmp_path: Path, monkeypatch: MonkeyPa
     )
 
     assert result.exit_code == 0
-    assert commands == [["npm", "install"], ["npm", "run", "build"]]
+    npm_executable = "npm.cmd" if webapp_bootstrap.sys.platform == "win32" else "npm"
+    assert commands == [[npm_executable, "install"], [npm_executable, "run", "build"]]
     assert "npm run build passed" in result.output
+
+
+def test_webapp_new_reports_missing_prerequisites(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    runner = CliRunner()
+    patch_keyring(monkeypatch)
+    monkeypatch.setattr(webapp_bootstrap.shutil, "which", lambda command: None)
+
+    target = tmp_path / "missing-tools"
+    result = runner.invoke(cli, ["webapp", "new", "missing-tools", "--directory", str(target)])
+
+    assert result.exit_code == ExitCodes.GENERAL_ERROR
+    assert "Missing required webapp dependencies: Node.js, npm" in result.output
+    assert "Node.js 24+" in result.output
+    assert not target.exists()
+
+
+def test_webapp_local_command_uses_npm_cmd_on_windows(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    commands: List[List[str]] = []
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(*args: Any, **kwargs: Any) -> Completed:
+        commands.append(list(args[0]))
+        return Completed()
+
+    monkeypatch.setattr(webapp_bootstrap.sys, "platform", "win32")
+    monkeypatch.setattr("slcli.webapp_bootstrap.subprocess.run", fake_run)
+
+    webapp_bootstrap._run_webapp_local_command(tmp_path, ["npm", "install"], "npm install")
+
+    assert commands == [["npm.cmd", "install"]]
 
 
 def test_webapp_manifest_init_writes_pack_config_only(


### PR DESCRIPTION
## Summary

Improves `slcli webapp new` bootstrap reliability on Windows by (1) validating Node.js/npm availability before generating files and (2) making npm invocation and output handling more robust across locales and Windows process launching semantics.

**Changes:**
- Added a prerequisite check for Node.js and npm, with fail-fast behavior before writing the generation directory when install/build is requested.
- Updated local npm subprocess execution to use `npm.cmd` on Windows and decode output as UTF-8 with replacement on decode errors.
- Extended unit tests and added a Towncrier patch fragment documenting the fix.

## Testing

- `poetry run pytest tests/unit -q`
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run black --check .`
- GitHub build/test/lint, mypy, and E2E checks passed.

## Release Notes

- Added `newsfragments/webapp-new-windows-bootstrap.patch.md` as a patch release fragment.