### PR TITLE
Fix PKCE platform detection

### DIFF
--- a/newsfragments/pkce-platform-detection.patch.md
+++ b/newsfragments/pkce-platform-detection.patch.md
@@ -1,0 +1,1 @@
+Use the Web URL service probes during PKCE login and health checks so the active SystemLink platform is detected correctly.

--- a/slcli/config_click.py
+++ b/slcli/config_click.py
@@ -179,10 +179,7 @@ def _trust_certificate_if_requested(
 
     try:
         save_managed_certificate(certificate)
-        if auth_scheme == "bearer":
-            retry_status = check_web_server_auth(url, credential, auth_scheme=auth_scheme)
-        else:
-            retry_status = check_service_status(url, credential, auth_scheme=auth_scheme)
+        retry_status = check_service_status(url, credential, auth_scheme=auth_scheme)
     except (OSError, ValueError) as exc:
         _exit_with_validation_error(
             f"Could not save the trusted certificate: {exc}. Profile was not saved.",
@@ -306,10 +303,10 @@ def _add_profile_impl(
 
     assert isinstance(api_key, str)
 
-    # Validate PKCE against the Web Server identity route; API-key login retains API probes.
+    # PKCE uses the Web URL for bearer service probes; API-key login uses the API URL.
     click.echo("Checking server connectivity and services...")
     if auth_mode == "pkce":
-        status = check_web_server_auth(web_url, api_key, auth_scheme="bearer")
+        status = check_service_status(web_url, api_key, auth_scheme="bearer")
     else:
         status = check_service_status(url, api_key)
 

--- a/slcli/platform.py
+++ b/slcli/platform.py
@@ -422,7 +422,7 @@ def _get_service_status_snapshot(force_refresh: bool = False) -> Optional[Dict[s
 
     _, api_url, credential, auth_scheme = api_context
     if auth_scheme == "bearer":
-        status = check_web_server_auth(api_url, credential, auth_scheme)
+        status = check_service_status(api_url, credential, auth_scheme)
     else:
         status = check_service_status(api_url, credential)
     _save_service_status_snapshot(api_context, status)

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -506,7 +506,7 @@ class TestTrustedCertificates:
             "slcli.config_click.inspect_server_certificate", lambda _url: certificate
         )
         monkeypatch.setattr("slcli.config_click.save_managed_certificate", lambda _cert: None)
-        monkeypatch.setattr("slcli.config_click.check_web_server_auth", mock_check)
+        monkeypatch.setattr("slcli.config_click.check_service_status", mock_check)
 
         result = _trust_certificate_if_requested(
             "https://web.example.com",
@@ -835,7 +835,7 @@ class TestAddProfileTrailingSlash:
 
 
 class TestPkceProfileVerification:
-    """Tests for PKCE verification against Web Server routes."""
+    """Tests for PKCE verification against Web Server and service routes."""
 
     def test_pkce_trusts_web_certificate_before_browser_login(
         self, tmp_path: Path, monkeypatch: Any
@@ -879,9 +879,21 @@ class TestPkceProfileVerification:
             events.append("login")
             return PkceLoginResult("access-token", "refresh-token")
 
+        def mock_service_probe(
+            url: str, credential: str, auth_scheme: str = "bearer"
+        ) -> dict[str, Any]:
+            events.append(f"service-probe:{credential}")
+            return {
+                "server_reachable": True,
+                "auth_valid": True,
+                "services": {"Auth": "ok", "Work Order": "ok"},
+                "platform": "SLE",
+            }
+
         monkeypatch.setattr("slcli.config_click._trust_certificate_if_requested", trust_certificate)
         monkeypatch.setattr("slcli.pkce.perform_pkce_login", perform_login)
         monkeypatch.setattr("slcli.pkce.save_pkce_credentials", lambda *args: None)
+        monkeypatch.setattr("slcli.config_click.check_service_status", mock_service_probe)
 
         _add_profile_impl(
             profile="pkce",
@@ -896,12 +908,16 @@ class TestPkceProfileVerification:
             client_id="client-id",
         )
 
-        assert events == ["probe:", "trust", "probe:trusted", "login", "probe:access-token"]
+        assert events == [
+            "probe:",
+            "trust",
+            "probe:trusted",
+            "login",
+            "service-probe:access-token",
+        ]
 
-    def test_pkce_login_uses_web_server_identity_probe(
-        self, tmp_path: Path, monkeypatch: Any
-    ) -> None:
-        """PKCE login must not probe the separate API host during the prototype."""
+    def test_pkce_login_uses_web_service_probe(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """PKCE login detects the platform through the Web URL service routes."""
         from slcli.config_click import _add_profile_impl
         from slcli.pkce import PkceLoginResult
 
@@ -924,6 +940,15 @@ class TestPkceProfileVerification:
             }
         )
         monkeypatch.setattr("slcli.config_click.check_web_server_auth", mock_web_probe)
+        mock_service_probe = MagicMock(
+            return_value={
+                "server_reachable": True,
+                "platform": "SLE",
+                "auth_valid": True,
+                "services": {"Auth": "ok", "Work Order": "ok"},
+            }
+        )
+        monkeypatch.setattr("slcli.config_click.check_service_status", mock_service_probe)
         monkeypatch.setattr("slcli.pkce.save_pkce_credentials", lambda *args: None)
 
         _add_profile_impl(
@@ -942,12 +967,15 @@ class TestPkceProfileVerification:
             ("https://web.example.com", ""),
             {"auth_scheme": "bearer"},
         )
-        assert mock_web_probe.call_args_list[-1] == (
-            ("https://web.example.com", "access-token"),
-            {"auth_scheme": "bearer"},
+        assert mock_web_probe.call_args_list == [
+            (("https://web.example.com", ""), {"auth_scheme": "bearer"})
+        ]
+        mock_service_probe.assert_called_once_with(
+            "https://web.example.com", "access-token", auth_scheme="bearer"
         )
         saved = json.loads(config_file.read_text())
         assert saved["profiles"]["pkce"]["server"] == "https://api.example.com"
+        assert saved["profiles"]["pkce"]["platform"] == "SLE"
 
     def test_pkce_credential_failure_restores_existing_profile(
         self, tmp_path: Path, monkeypatch: Any
@@ -985,6 +1013,15 @@ class TestPkceProfileVerification:
                 "auth_valid": True,
                 "services": {"Web Server": "ok"},
                 "platform": "unknown",
+            },
+        )
+        monkeypatch.setattr(
+            "slcli.config_click.check_service_status",
+            lambda *_args, **_kwargs: {
+                "server_reachable": True,
+                "auth_valid": True,
+                "services": {"Auth": "ok", "Work Order": "ok"},
+                "platform": "SLE",
             },
         )
         monkeypatch.setattr(

--- a/tests/unit/test_config_click.py
+++ b/tests/unit/test_config_click.py
@@ -963,13 +963,7 @@ class TestPkceProfileVerification:
             client_id="client-id",
         )
 
-        assert mock_web_probe.call_args_list[0] == (
-            ("https://web.example.com", ""),
-            {"auth_scheme": "bearer"},
-        )
-        assert mock_web_probe.call_args_list == [
-            (("https://web.example.com", ""), {"auth_scheme": "bearer"})
-        ]
+        mock_web_probe.assert_called_once_with("https://web.example.com", "", auth_scheme="bearer")
         mock_service_probe.assert_called_once_with(
             "https://web.example.com", "access-token", auth_scheme="bearer"
         )

--- a/tests/unit/test_pkce.py
+++ b/tests/unit/test_pkce.py
@@ -385,7 +385,7 @@ def test_login_pkce_uses_bearer_token_and_stores_metadata(monkeypatch: Any, tmp_
             "server_reachable": True,
             "auth_valid": True,
             "services": {"Web Server": "ok"},
-            "platform": "SLE",
+            "platform": "unknown",
         }
     )
     monkeypatch.setattr(config_click, "check_web_server_auth", mock_web_probe)

--- a/tests/unit/test_pkce.py
+++ b/tests/unit/test_pkce.py
@@ -389,6 +389,16 @@ def test_login_pkce_uses_bearer_token_and_stores_metadata(monkeypatch: Any, tmp_
         }
     )
     monkeypatch.setattr(config_click, "check_web_server_auth", mock_web_probe)
+    monkeypatch.setattr(
+        config_click,
+        "check_service_status",
+        lambda *_args, **_kwargs: {
+            "server_reachable": True,
+            "auth_valid": True,
+            "services": {"Auth": "ok", "Work Order": "ok"},
+            "platform": "SLE",
+        },
+    )
 
     result = CliRunner().invoke(
         cli,
@@ -415,7 +425,6 @@ def test_login_pkce_uses_bearer_token_and_stores_metadata(monkeypatch: Any, tmp_
     assert profile["pkce-client-id"] == "client-id"
     assert "api-key" not in profile
     assert "PKCE bearer token:  ✓ Authorized" in result.output
-    assert mock_web_probe.call_args_list[-1] == (
-        ("https://web.example", "access-token"),
-        {"auth_scheme": "bearer"},
-    )
+    assert mock_web_probe.call_args_list == [
+        (("https://web.example", ""), {"auth_scheme": "bearer"})
+    ]

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1103,29 +1103,31 @@ class TestGetPlatformInfo:
             assert result["auth_valid"] is None
             assert "features" not in result
 
-    def test_bearer_snapshot_uses_web_server_probe(self) -> None:
-        """Bearer health checks use the Web Server identity route."""
+    def test_bearer_snapshot_uses_service_probe(self) -> None:
+        """Bearer health checks use service routes to detect the platform."""
         from slcli.platform import _get_service_status_snapshot
 
         status = {
             "server_reachable": True,
             "auth_valid": True,
-            "services": {"Web Server": "ok"},
-            "platform": PLATFORM_UNKNOWN,
+            "services": {"Auth": "ok", "Work Order": "ok"},
+            "platform": PLATFORM_SLE,
         }
         with patch(
             "slcli.platform._get_current_api_context",
             return_value=("pkce", "https://web.example.com", "access-token", "bearer"),
         ), patch("slcli.platform._save_service_status_snapshot"), patch(
-            "slcli.platform.check_web_server_auth", return_value=status
-        ) as mock_web_probe, patch(
-            "slcli.platform.check_service_status"
-        ) as mock_api_probe:
+            "slcli.platform.check_service_status", return_value=status
+        ) as mock_service_probe, patch(
+            "slcli.platform.check_web_server_auth"
+        ) as mock_web_probe:
             result = _get_service_status_snapshot(force_refresh=True)
 
         assert result == status
-        mock_web_probe.assert_called_once_with("https://web.example.com", "access-token", "bearer")
-        mock_api_probe.assert_not_called()
+        mock_service_probe.assert_called_once_with(
+            "https://web.example.com", "access-token", "bearer"
+        )
+        mock_web_probe.assert_not_called()
 
     def test_get_platform_info_unauthorized(self) -> None:
         """Test that auth_valid=False is reported when API key is unauthorized."""


### PR DESCRIPTION
## Summary

PKCE profiles previously validated only the Web Server identity route, whose health result intentionally reports `platform: unknown`. As a result, `slcli info` showed `Unknown` even when the bearer token and SystemLink services were healthy.

This change:
- Uses the existing Web URL service probes for PKCE login verification and runtime health checks.
- Preserves the Web Server identity probe for certificate preflight.
- Retries the full service probe after certificate trust so platform information is retained.
- Adds regression coverage and a Towncrier patch fragment.

## Validation

- Live `slcli info --format json` reports `SLE` and all Web URL service probes are `ok`.
- `SLCLI_CONFIG=build/ai/full-test-config-final.json poetry run pytest -q` -> 1442 passed
- `poetry run ni-python-styleguide lint` -> passed
- `poetry run mypy slcli tests` -> no issues