### PR TITLE
Fix Windows E2E non-interactive handling

### DIFF
--- a/newsfragments/windows-e2e-noninteractive.patch.md
+++ b/newsfragments/windows-e2e-noninteractive.patch.md
@@ -1,0 +1,1 @@
+Prevent interactive pagination prompts from blocking captured CLI output and improve Windows E2E subprocess configuration handling.

--- a/slcli/alarm_click.py
+++ b/slcli/alarm_click.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 import click
 import questionary
 
-from .cli_utils import confirm_bulk_operation, validate_output_format
+from .cli_utils import confirm_bulk_operation, is_interactive_environment, validate_output_format
 from .rich_output import render_table
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
@@ -500,6 +500,8 @@ def _run_list_alarms(
             include_transitions=include_transitions,
         )
         if not continuation_token:
+            break
+        if not is_interactive_environment():
             break
         if not questionary.confirm("Show next set of alarms?", default=True).ask():
             break

--- a/slcli/asset_click.py
+++ b/slcli/asset_click.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 import questionary
 
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
     ExitCodes,
@@ -300,6 +300,9 @@ def _handle_asset_interactive_pagination(
 
         # Check if there are more results
         if shown_count >= total_count:
+            break
+
+        if not is_interactive_environment():
             break
 
         if not questionary.confirm("Show next set of results?", default=True).ask():

--- a/slcli/cli_utils.py
+++ b/slcli/cli_utils.py
@@ -428,7 +428,7 @@ def paginate_list_output(
                 current_page += 1
                 continue
 
-            if not questionary.confirm("Show next 25 results?", default=True).ask():
+            if not questionary.confirm(f"Show next {page_size} results?", default=True).ask():
                 break
 
             click.echo()  # Add blank line between pages

--- a/slcli/cli_utils.py
+++ b/slcli/cli_utils.py
@@ -1,5 +1,6 @@
 """Common utility functions for all CLI commands."""
 
+import os
 import sys
 from typing import Any, Callable, Dict, List, Optional
 
@@ -9,6 +10,19 @@ import requests
 
 from .rich_output import print_json, render_table
 from .utils import ExitCodes, handle_api_error
+
+
+def is_interactive_environment() -> bool:
+    """Return whether interactive prompts should be displayed.
+
+    In-process pytest callers remain interactive so prompt behavior can be tested with mocks.
+    Captured E2E subprocesses set ``SLCLI_NON_INTERACTIVE`` explicitly.
+    """
+    if os.getenv("SLCLI_NON_INTERACTIVE", "").lower() == "true":
+        return False
+    if os.getenv("PYTEST_CURRENT_TEST") is not None:
+        return True
+    return sys.stdin.isatty() and sys.stdout.isatty() and os.getenv("CI", "").lower() != "true"
 
 
 def resolve_resource_by_name_or_id(
@@ -408,20 +422,7 @@ def paginate_list_output(
                 f"{remaining} more available."
             )
 
-            # Check if we're in an interactive environment
-            # If stdin is not a TTY or we're in a test environment, disable interactive pagination
-            import os
-            import sys
-
-            is_non_interactive = (
-                not sys.stdin.isatty()  # Piped input
-                or not sys.stdout.isatty()  # Piped output
-                or os.getenv("CI") == "true"  # CI environment
-                or os.getenv("PYTEST_CURRENT_TEST") is not None  # pytest
-                or os.getenv("SLCLI_NON_INTERACTIVE") == "true"  # Explicit override
-            )
-
-            if is_non_interactive:
+            if not is_interactive_environment():
                 click.echo("Non-interactive environment detected. Showing all remaining results...")
                 # Continue to show all remaining pages without prompting
                 current_page += 1

--- a/slcli/spec_click.py
+++ b/slcli/spec_click.py
@@ -8,7 +8,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 import questionary
 
-from .cli_utils import confirm_bulk_operation, validate_output_format
+from .cli_utils import (
+    confirm_bulk_operation,
+    is_interactive_environment,
+    validate_output_format,
+)
 from .rich_output import render_table
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
@@ -1068,6 +1072,9 @@ def _handle_spec_interactive_pagination(
             pass
 
         if not cont:
+            break
+
+        if not is_interactive_environment():
             break
 
         if not questionary.confirm("Show next set of results?", default=True).ask():

--- a/slcli/system_click.py
+++ b/slcli/system_click.py
@@ -18,7 +18,7 @@ import click
 import questionary
 import requests as requests_lib
 
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .rich_output import render_table
 from .system_query_utils import (
     DEFAULT_SYSTEM_JSON_FIELDS,
@@ -682,6 +682,9 @@ def _handle_interactive_pagination(
         if not page_was_full:
             break
 
+        if not is_interactive_environment():
+            break
+
         if not questionary.confirm(
             "More results may be available. Show next set?", default=True
         ).ask():
@@ -766,6 +769,9 @@ def _handle_materialized_system_pagination_with_fallback(
             pass
 
         if len(page_items) < take:
+            break
+
+        if not is_interactive_environment():
             break
 
         if not questionary.confirm(

--- a/slcli/tag_click.py
+++ b/slcli/tag_click.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 import questionary
 
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
     ExitCodes,
@@ -460,6 +460,9 @@ def register_tag_commands(cli: Any) -> None:
                         break
 
                     # Ask if user wants more
+                    if not is_interactive_environment():
+                        break
+
                     if questionary.confirm(f"Show next {take} results?", default=True).ask():
                         query_params["continuationToken"] = continuation_token
                         resp = make_api_request("POST", url, payload=query_params)

--- a/slcli/testmonitor_click.py
+++ b/slcli/testmonitor_click.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import click
 import questionary
 
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
     ExitCodes,
@@ -205,6 +205,9 @@ def _handle_interactive_pagination(
 
         # Ask if user wants to fetch the next page
         if not cont:
+            break
+
+        if not is_interactive_environment():
             break
 
         if not questionary.confirm("Show next set of results?", default=True).ask():

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -19,7 +19,7 @@ import click
 import questionary
 import requests
 
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .skill_click import install_skills_to_directory
 from .universal_handlers import UniversalResponseHandler
 from .utils import (
@@ -1415,6 +1415,9 @@ def register_webapp_commands(cli: Any) -> None:
                         break
 
                     # Ask the user if they want to fetch the next set
+                    if not is_interactive_environment():
+                        break
+
                     if not questionary.confirm("Show next set of results?", default=True).ask():
                         break
 

--- a/slcli/workitem_click.py
+++ b/slcli/workitem_click.py
@@ -12,7 +12,7 @@ import click
 import requests
 
 from . import workflow_preview
-from .cli_utils import validate_output_format
+from .cli_utils import is_interactive_environment, validate_output_format
 from .platform import require_feature
 from .universal_handlers import FilteredResponse, UniversalResponseHandler
 from .utils import (
@@ -574,6 +574,8 @@ def register_workitem_commands(cli: Any) -> None:
                 if not cont:
                     break
                 click.echo(f"\nShowing {displayed} work item(s). More may be available.")
+                if not is_interactive_environment():
+                    break
                 if not click.confirm(f"Show next {take} results?", default=True):
                     break
 
@@ -1280,6 +1282,8 @@ def register_workitem_commands(cli: Any) -> None:
                 if not cont:
                     break
                 click.echo(f"\nShowing {displayed} template(s). More may be available.")
+                if not is_interactive_environment():
+                    break
                 if not click.confirm(f"Show next {take} results?", default=True):
                     break
 
@@ -1864,6 +1868,8 @@ def register_workitem_commands(cli: Any) -> None:
                 if not cont:
                     break
                 click.echo(f"\nShowing {displayed} workflow(s). More may be available.")
+                if not is_interactive_environment():
+                    break
                 if not click.confirm(f"Show next {take} results?", default=True):
                     break
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -62,9 +62,9 @@ def _select_platform_config(
 
 def _load_config_file() -> Dict[str, Any]:
     """Load configuration from file if it exists."""
-    config_file = Path("tests/e2e/e2e_config.json")
+    config_file = Path(__file__).resolve().with_name("e2e_config.json")
     if config_file.exists():
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             return json.load(f)
     return {}
 
@@ -91,11 +91,17 @@ def e2e_config() -> Dict[str, Any]:
     # Check for new multi-platform config structure
     if "sle" in file_config or "sls" in file_config:
         # New format - return the whole config with platform sections
+        timeout = int(os.getenv("SLCLI_E2E_TIMEOUT", str(file_config.get("timeout", 60))))
+        cleanup_value = os.getenv("SLCLI_E2E_CLEANUP")
         return {
             "sle": file_config.get("sle", {}),
             "sls": file_config.get("sls", {}),
-            "timeout": file_config.get("timeout", 60),
-            "cleanup": file_config.get("cleanup", True),
+            "timeout": timeout,
+            "cleanup": (
+                cleanup_value.lower() == "true"
+                if cleanup_value is not None
+                else file_config.get("cleanup", True)
+            ),
         }
 
     # Legacy format - convert to new format for compatibility
@@ -240,11 +246,14 @@ def _make_cli_runner(config: Dict[str, Any], timeout: int = 60) -> Any:
         # Use explicit platform if specified in config (most reliable method)
         if config.get("platform"):
             env["SYSTEMLINK_PLATFORM"] = config["platform"]
+        env["PYTHONIOENCODING"] = "utf-8"
+        env["SLCLI_NON_INTERACTIVE"] = "true"
 
         result = subprocess.run(
             cmd,
             input=input_data,
             text=True,
+            encoding="utf-8",
             capture_output=True,
             timeout=timeout,
             env=env,

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -11,8 +12,9 @@ def run_e2e_tests() -> int:
     # Check for required environment variables
     required_env = ["SLCLI_E2E_BASE_URL", "SLCLI_E2E_API_KEY"]
     missing_env = [var for var in required_env if not os.getenv(var)]
+    config_file = Path(__file__).resolve().with_name("e2e_config.json")
 
-    if missing_env:
+    if missing_env and not config_file.is_file():
         print("❌ Missing required environment variables for E2E tests:")
         for var in missing_env:
             print(f"  - {var}")

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,8 +1,8 @@
 """Tests for shared CLI utility behavior."""
 
-from typing import Any
+from typing import Any, List
 
-from slcli.cli_utils import is_interactive_environment
+from slcli.cli_utils import is_interactive_environment, paginate_list_output
 
 
 def test_is_interactive_environment_honors_explicit_override(monkeypatch: Any) -> None:
@@ -29,3 +29,23 @@ def test_is_interactive_environment_rejects_ci(monkeypatch: Any) -> None:
     monkeypatch.setenv("CI", "true")
 
     assert is_interactive_environment() is False
+
+
+def test_paginate_list_output_uses_configured_page_size_in_prompt(monkeypatch: Any) -> None:
+    """Pagination prompts should describe the actual page size being fetched."""
+    monkeypatch.delenv("SLCLI_NON_INTERACTIVE", raising=False)
+    prompt_messages: List[str] = []
+
+    class Prompt:
+        def ask(self) -> bool:
+            return False
+
+    def confirm(message: str, default: bool = True) -> Prompt:
+        prompt_messages.append(message)
+        return Prompt()
+
+    monkeypatch.setattr("slcli.cli_utils.questionary.confirm", confirm)
+
+    paginate_list_output([{"id": str(index)} for index in range(11)], page_size=10)
+
+    assert prompt_messages == ["Show next 10 results?"]

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,31 @@
+"""Tests for shared CLI utility behavior."""
+
+from typing import Any
+
+from slcli.cli_utils import is_interactive_environment
+
+
+def test_is_interactive_environment_honors_explicit_override(monkeypatch: Any) -> None:
+    """The explicit non-interactive flag takes precedence over other signals."""
+    monkeypatch.setenv("SLCLI_NON_INTERACTIVE", "TRUE")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_is_interactive_environment")
+
+    assert is_interactive_environment() is False
+
+
+def test_is_interactive_environment_allows_in_process_prompt_tests(monkeypatch: Any) -> None:
+    """Pytest callers can exercise prompt paths with mocked prompt implementations."""
+    monkeypatch.delenv("SLCLI_NON_INTERACTIVE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_is_interactive_environment")
+
+    assert is_interactive_environment() is True
+
+
+def test_is_interactive_environment_rejects_ci(monkeypatch: Any) -> None:
+    """CI execution is non-interactive when no explicit test override is present."""
+    monkeypatch.delenv("SLCLI_NON_INTERACTIVE", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("CI", "true")
+
+    assert is_interactive_environment() is False

--- a/tests/unit/test_e2e_config.py
+++ b/tests/unit/test_e2e_config.py
@@ -1,0 +1,28 @@
+"""Tests for E2E configuration loading behavior."""
+
+import importlib
+from typing import Any, Dict
+
+e2e_conftest: Any = importlib.import_module("tests.e2e.conftest")
+
+
+def _load_fixture_config() -> Dict[str, Any]:
+    """Call the underlying E2E config fixture function."""
+    fixture_function = getattr(e2e_conftest.e2e_config, "__wrapped__")
+    return fixture_function()
+
+
+def test_e2e_config_env_overrides_multi_platform_values(monkeypatch: Any) -> None:
+    """Environment overrides apply when the config contains platform sections."""
+    monkeypatch.setattr(
+        e2e_conftest,
+        "_load_config_file",
+        lambda: {"sle": {"base_url": "https://example.invalid"}, "timeout": 30, "cleanup": True},
+    )
+    monkeypatch.setenv("SLCLI_E2E_TIMEOUT", "120")
+    monkeypatch.setenv("SLCLI_E2E_CLEANUP", "false")
+
+    config = _load_fixture_config()
+
+    assert config["timeout"] == 120
+    assert config["cleanup"] is False

--- a/tests/unit/test_workitem_click.py
+++ b/tests/unit/test_workitem_click.py
@@ -281,6 +281,43 @@ def test_list_workitems_shows_pagination_prompt(monkeypatch: Any, runner: CliRun
     assert call_count[0] == 1  # second page never fetched
 
 
+def test_list_workitems_stops_pagination_when_non_interactive(
+    monkeypatch: Any, runner: CliRunner
+) -> None:
+    """Captured output stops before prompting for another work-item page."""
+    patch_keyring(monkeypatch)
+    monkeypatch.setenv("SLCLI_NON_INTERACTIVE", "true")
+
+    call_count: List[int] = [0]
+
+    def mock_post(*a: Any, **kw: Any) -> Any:
+        call_count[0] += 1
+
+        class R:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return {
+                    "workItems": [_make_workitem(wi_id=str(i)) for i in range(5)],
+                    "continuationToken": "next-page-token",
+                }
+
+        return R()
+
+    monkeypatch.setattr("requests.post", mock_post)
+    monkeypatch.setattr("slcli.workitem_click.get_workspace_map", lambda: {"ws1": "Default"})
+
+    cli = make_cli()
+    result = runner.invoke(cli, ["workitem", "list", "--take", "5"])
+
+    assert result.exit_code == 0
+    assert "Showing 5 work item(s). More may be available." in result.output
+    assert call_count[0] == 1
+
+
 def test_list_workitems_stale_token_no_prompt(monkeypatch: Any, runner: CliRunner) -> None:
     """Stale token (fewer items than take) never triggers the pagination prompt."""
     patch_keyring(monkeypatch)


### PR DESCRIPTION
## Summary
- Prevent captured or non-TTY CLI list commands from blocking on interactive pagination prompts.
- Harden Windows E2E subprocess encoding, non-interactive behavior, multi-platform overrides, and config discovery.

## Testing
- poetry run black --check slcli tests
- poetry run ni-python-styleguide lint
- poetry run mypy slcli tests
- poetry run pytest: 1,448 passed, 1 skipped
- MCP E2E: 2 passed
- Non-MCP E2E diagnostic run: 116 passed, 9 skipped; 2 routine creates were blocked by the configured SLE TAG plugin validation timeout.

## Release Notes
- patch: Added newsfragments/windows-e2e-noninteractive.patch.md.

## Notes
- The remaining routine E2E failures are remote SLE service health issues, not local Windows configuration failures.