### PR TITLE
chore: remove Snyk configuration

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-exclude: {}
-version: v1.25.1
-ignore: {}
-patch: {}


### PR DESCRIPTION
Removes the `.snyk` configuration file as part of the Snyk -> Wiz migration.

Snyk scanning has been replaced by Wiz, so the repo-level `.snyk` policy /
ignore file is no longer used.

Work item: AB#3893372