### PR TITLE
Align bundled skill guidance with current CLI

### DIFF
--- a/newsfragments/focused-webapp-skill.patch.md
+++ b/newsfragments/focused-webapp-skill.patch.md
@@ -1,0 +1,1 @@
+Refresh bundled CLI guidance to match current command behavior, recommend focused webapp scaffolds, and hide the legacy webapp init command from help.

--- a/slcli/skills/slcli/SKILL.md
+++ b/slcli/skills/slcli/SKILL.md
@@ -76,7 +76,7 @@ Load only what the current task needs.
 | `feed` | Package feeds | `list`, `create`, `package upload` |
 | `customfield` | Dynamic form fields | `list`, `create`, `export`, `edit` |
 | `template` | Test plan templates | `list`, `import`, `export` |
-| `webapp` | Web applications | `init`, `pack`, `publish`, `list` |
+| `webapp` | Web applications | `new`, `pack`, `publish`, `list` |
 | `config` | Connection profiles | `list`, `use`, `add`, `delete` |
 | `user` | User management | `list`, `get`, `create`, `update` |
 | `auth` | Authorization policies | `policy list/create`, `template list` |

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -893,6 +893,7 @@ For new applications, use `slcli webapp new <app-name>`. Treat the older
 is intentionally omitted from the recommended command sequence.
 
 ```bash
+slcli webapp new <APP_NAME> [OPTIONS]                # Generate a hosted Angular webapp
 slcli webapp manifest init <DIRECTORY> [OPTIONS]  # Create nipkg.config.json for packaging
 slcli webapp pack [FOLDER] [--config FILE] [--output OUTPUT_FILE]  # Package a webapp into a .nipkg
 slcli webapp list [-w WORKSPACE] [--filter TEXT] [--take INT] [--format json]

--- a/slcli/skills/slcli/references/commands.md
+++ b/slcli/skills/slcli/references/commands.md
@@ -427,11 +427,11 @@ slcli dataframe delete <TABLE_ID>... [--yes]
 
 ```bash
 slcli tag list [OPTIONS]                            # List tags (filter by path glob, workspace)
-slcli tag get <TAG_PATH> [-f json]                  # Get tag metadata
+slcli tag get <TAG_PATH>                            # Get tag metadata
 slcli tag get-value <TAG_PATH>                      # Read current tag value
 slcli tag history <TAG_PATH> [-w WORKSPACE] [-t TAKE] [-f json] [--graph]  # Read or graph history
 slcli tag set-value <TAG_PATH> <VALUE>              # Write a tag value
-slcli tag create --path <PATH> --data-type <TYPE>   # Create a new tag
+slcli tag create <TAG_PATH> --type <TYPE> [OPTIONS]  # Create a new tag
 slcli tag update <TAG_PATH> [OPTIONS]               # Update tag metadata
 slcli tag delete <TAG_PATH>                         # Delete a tag
 ```
@@ -666,7 +666,8 @@ slcli comment delete <ID1> <ID2> <ID3>
 
 ```bash
 slcli workspace list [-f json]
-slcli workspace get <WORKSPACE_ID> [-f json]
+slcli workspace get --workspace WORKSPACE_ID [-f json]
+slcli workspace disable --id WORKSPACE_ID [--yes]
 ```
 
 ## config — Profile and credential management
@@ -683,7 +684,7 @@ slcli completion [--shell SHELL] [--install]    # Generate or install shell tab 
 slcli config list [-f json]                     # List all profiles
 slcli config current                            # Show the active profile name
 slcli config use <PROFILE>                      # Switch the active profile
-slcli config view [--profile NAME] [-f json]    # Show full profile details
+slcli config view [-f json] [--show-secrets]    # Show stored profile details
 slcli config add [--profile NAME] [OPTIONS]     # Add or update a profile
 slcli config delete <PROFILE> [--force]         # Delete a profile
 slcli config migrate                            # Migrate legacy keyring credentials
@@ -693,10 +694,10 @@ slcli config migrate                            # Migrate legacy keyring credent
 
 ```bash
 slcli user list [--workspace NAME] [-t INT] [-f json]
-slcli user get <USER_ID> [-f json]
+slcli user get [--id USER_ID | --email EMAIL] [-f json]
 slcli user create [OPTIONS]         # Create a new user
-slcli user update <USER_ID> [OPTIONS]
-slcli user delete <USER_ID>
+slcli user update --id USER_ID [OPTIONS]
+slcli user delete --id USER_ID [--yes]
 ```
 
 ## auth — Authorization policies and templates
@@ -705,10 +706,10 @@ slcli user delete <USER_ID>
 # Policies
 slcli auth policy list [--type CHOICE] [--builtin] [-t INT] [-f json]
 slcli auth policy get <POLICY_ID> [-f json]
-slcli auth policy create --name TEXT [OPTIONS]
+slcli auth policy create TEMPLATE_ID --name TEXT --workspace WORKSPACE [OPTIONS]
 slcli auth policy update <POLICY_ID> [OPTIONS]
 slcli auth policy delete <POLICY_ID>
-slcli auth policy diff <POLICY_ID>              # Show diff of a pending policy change
+slcli auth policy diff <POLICY_ID_1> <POLICY_ID_2>  # Compare two policies
 
 # Policy templates
 slcli auth template list [-t INT] [-f json]
@@ -723,28 +724,29 @@ Supports Windows (.nipkg) and NI Linux RT (.ipk/.deb).
 
 ```bash
 slcli feed list [-w WORKSPACE] [-t INT] [-f json]
-slcli feed get <FEED_ID> [-f json]
+slcli feed get --id FEED_ID [-f json]
 slcli feed create --name TEXT [--workspace NAME] [OPTIONS]
-slcli feed delete <FEED_ID>
-slcli feed replicate --source-id FEED_ID --target-workspace WORKSPACE [OPTIONS]
+slcli feed delete --id FEED_ID [--yes] [--wait] [--timeout INT]
+slcli feed replicate --name NAME --platform [windows|ni-linux-rt] --url URL [OPTIONS]
 
 # Packages within a feed
-slcli feed package list --feed-id FEED_ID [-f json]
+slcli feed package list --feed-id FEED_ID [--take INT] [--format json]
 slcli feed package upload --feed-id FEED_ID --file PATH
-slcli feed package delete --feed-id FEED_ID --package-name NAME
+slcli feed package delete --id PACKAGE_ID [--yes] [--wait] [--timeout INT]
 ```
 
 ## file — File Service management
 
 ```bash
-slcli file list [--workspace NAME] [--name TEXT] [-t INT] [-f json]
+slcli file list [--workspace NAME] [--filter TEXT] [--id-filter IDS] [-t INT] [-f json]
 slcli file get <FILE_ID> [-f json]
-slcli file upload --file PATH [--workspace NAME] [OPTIONS]
-slcli file download <FILE_ID> -o OUTPUT_PATH
-slcli file delete <FILE_ID>
+slcli file upload FILE_PATH [--workspace NAME] [--name NAME] [--properties JSON]
+slcli file download <FILE_ID> [-o OUTPUT_PATH] [--force]
+slcli file delete --id FILE_ID [--force]
 slcli file query [--filter TEXT] [-t INT] [-f json]      # Advanced filter query
 slcli file update-metadata <FILE_ID> [OPTIONS]
-slcli file watch [--workspace NAME] [--filter TEXT]      # Stream new file events
+slcli file watch WATCH_DIR [--workspace NAME] [--move-to DIRECTORY | --delete-after-upload]
+                         [--pattern GLOB] [--debounce SECONDS] [--recursive]
 ```
 
 ## notebook — Jupyter Notebook management and execution
@@ -754,21 +756,26 @@ slcli file watch [--workspace NAME] [--filter TEXT]      # Stream new file event
 slcli notebook init [--name NAME] [--directory DIR]      # Create a local .ipynb template
 
 # Remote notebook management
-slcli notebook manage list [-w WORKSPACE] [-t INT] [-f json]
-slcli notebook manage get <NOTEBOOK_ID> [-f json]
-slcli notebook manage create --file PATH [--workspace NAME]
-slcli notebook manage update <NOTEBOOK_ID> --file PATH
-slcli notebook manage set-interface <NOTEBOOK_ID> [OPTIONS]  # Define parameter interface
-slcli notebook manage download <NOTEBOOK_ID> -o PATH
-slcli notebook manage delete <NOTEBOOK_ID>
+slcli notebook manage list [-w WORKSPACE] [--filter TEXT] [-t INT] [-f json]
+slcli notebook manage get --id NOTEBOOK_ID [-f json]
+slcli notebook manage create [--file PATH] [--workspace NAME] --name NAME [--interface CHOICE]
+slcli notebook manage update --id NOTEBOOK_ID [--metadata FILE] [--content FILE] [--interface CHOICE]
+slcli notebook manage set-interface --id NOTEBOOK_ID --interface CHOICE
+slcli notebook manage download [--id NOTEBOOK_ID | --name NAME] [--workspace NAME]
+                                     [--output PATH] [--type CHOICE]
+slcli notebook manage delete --id NOTEBOOK_ID [--yes]
 
 # Notebook executions
-slcli notebook execute list [-w WORKSPACE] [-t INT] [-f json]
-slcli notebook execute get <EXECUTION_ID> [-f json]
-slcli notebook execute start <NOTEBOOK_ID> [--params JSON] [--workspace NAME]
-slcli notebook execute sync <EXECUTION_ID>               # Wait for completion
-slcli notebook execute cancel <EXECUTION_ID>
-slcli notebook execute retry <EXECUTION_ID>
+slcli notebook execute list [-w WORKSPACE] [--status STATUS] [--notebook-id NOTEBOOK_ID]
+                                  [-t INT] [-f json]
+slcli notebook execute get --id EXECUTION_ID [-f json]
+slcli notebook execute start --notebook-id NOTEBOOK_ID [--workspace NAME] [--parameters JSON]
+                                      [--timeout INT] [--no-cache] [--format table|json]
+slcli notebook execute sync --notebook-id NOTEBOOK_ID [--workspace NAME] [--parameters JSON]
+                                      [--timeout INT] [--poll-interval FLOAT] [--max-wait INT]
+                                      [--format table|json] [--no-cache]
+slcli notebook execute cancel --id EXECUTION_ID
+slcli notebook execute retry --id EXECUTION_ID
 ```
 
 ## customfield — Custom field (DFF) configuration
@@ -776,14 +783,15 @@ slcli notebook execute retry <EXECUTION_ID>
 Manage Dynamic Form Field definitions used to attach custom metadata to resources.
 
 ```bash
-slcli customfield list [-w WORKSPACE] [-t INT] [-f json]
-slcli customfield get <FIELD_ID> [-f json]
-slcli customfield create --name TEXT --entity-type TYPE [OPTIONS]
-slcli customfield update <FIELD_ID> [OPTIONS]
-slcli customfield delete <FIELD_ID>
-slcli customfield export [-o FILE]                       # Export all custom fields to JSON
-slcli customfield init [--directory DIR]                 # Scaffold a local config template
-slcli customfield edit [--directory DIR]                 # Interactively edit + push config
+slcli customfield list [-w WORKSPACE] [--take INT] [-f json]
+slcli customfield get --id FIELD_ID [-f json]
+slcli customfield create --file FILE
+slcli customfield update --file FILE
+slcli customfield delete --id CONFIG_ID [--group-id GROUP_ID] [--field-id FIELD_ID]
+                              [--no-recursive] [--yes]
+slcli customfield export --id CONFIG_ID [-o FILE]         # Export a configuration to JSON
+slcli customfield init [--name NAME] [--workspace NAME] [--resource-type TYPE] [-o FILE]
+slcli customfield edit [--file FILE] [--id CONFIG_ID] [--port INT] [--no-browser]
 ```
 
 ## template — Test plan template management
@@ -795,12 +803,12 @@ slcli customfield edit [--directory DIR]                 # Interactively edit + 
 > when provisioning new test plan instances.
 
 ```bash
-slcli template init [--name TEXT] [--directory DIR]      # Scaffold a local template file
+slcli template init [--name TEXT] [--template-group TEXT] [-o FILE]  # Scaffold a local template file
 slcli template list [-w WORKSPACE] [-t INT] [-f json]
-slcli template get <TEMPLATE_ID> [-f json]
-slcli template export [-o FILE] [-w WORKSPACE]           # Export all templates to JSON
-slcli template import --file PATH [--workspace NAME]     # Import templates from JSON
-slcli template delete <TEMPLATE_ID>
+slcli template get [--id TEMPLATE_ID | --name NAME] [-f json]
+slcli template export [--id TEMPLATE_ID | --name NAME] [-o FILE]  # Export templates to JSON
+slcli template import --file PATH                         # Import templates from JSON
+slcli template delete --id TEMPLATE_ID [--yes]
 ```
 
 ## workitem — Work item, template, and workflow management
@@ -846,13 +854,13 @@ slcli workitem template delete <TEMPLATE_ID>... [--yes]
 # Workflow subgroup
 slcli workitem workflow list [-w WORKSPACE] [-t INT] [-f json]
 slcli workitem workflow get [--id WORKFLOW_ID] [--name NAME] [-f json]
-slcli workitem workflow init [--name TEXT] [--directory DIR]   # Scaffold a local workflow file
-slcli workitem workflow create --file PATH [-w WORKSPACE]      # Create from JSON file
+slcli workitem workflow init [--name TEXT] [--description TEXT] [--workspace NAME] [-o FILE]
 slcli workitem workflow import --file PATH [-w WORKSPACE]      # Import workflow from JSON
 slcli workitem workflow export [--id WORKFLOW_ID] [--name NAME] [-o FILE]  # Export to JSON
 slcli workitem workflow update --id WORKFLOW_ID --file PATH    # Update from JSON file
 slcli workitem workflow delete --id WORKFLOW_ID [--yes]
-slcli workitem workflow preview [--file PATH] [--id WORKFLOW_ID] [--html] [--no-open] [-o FILE]
+slcli workitem workflow preview [--file PATH | --id WORKFLOW_ID] [--format html|mmd]
+                                [--no-emoji] [--no-legend] [--no-open] [-o FILE]
 ```
 
 **Create work item options:**
@@ -878,23 +886,25 @@ slcli workitem create \
 
 ## webapp — Web application management
 
-Scaffold, package, and publish custom web applications to SystemLink.
+Create, package, and publish custom web applications to SystemLink.
+
+For new applications, use `slcli webapp new <app-name>`. Treat the older
+`slcli webapp init` command as a compatibility-only manual bootstrap path; it
+is intentionally omitted from the recommended command sequence.
 
 ```bash
-slcli webapp init <DIRECTORY>                      # Scaffold the Angular starter
 slcli webapp manifest init <DIRECTORY> [OPTIONS]  # Create nipkg.config.json for packaging
-slcli webapp pack [FOLDER] [--config FILE] [-o OUTPUT_FILE]  # Package a webapp into a .nipkg
-slcli webapp list [-w WORKSPACE] [-t INT] [-f json]
-slcli webapp get <WEBAPP_ID> [-f json]
+slcli webapp pack [FOLDER] [--config FILE] [--output OUTPUT_FILE]  # Package a webapp into a .nipkg
+slcli webapp list [-w WORKSPACE] [--filter TEXT] [--take INT] [--format json]
+slcli webapp get --id WEBAPP_ID [--format json]
 slcli webapp publish PATH [--workspace NAME]             # Upload and publish a webapp
-slcli webapp delete <WEBAPP_ID>
-slcli webapp open <WEBAPP_ID>                            # Open webapp URL in browser
+slcli webapp delete --id WEBAPP_ID [--yes]
+slcli webapp open --id WEBAPP_ID                          # Open webapp URL in browser
 ```
 
-`webapp init` creates the SystemLink Angular starter, not a generic HTML app. The starter installs
-project-scoped skills into `.agents/skills/` and creates `PROMPTS.md` plus `START_HERE.md` so an
-AI assistant can bootstrap the Angular workspace in place with the same Nimble/SystemLink
-conventions described by the webapp overview inside the `slcli` skill.
+For an existing Angular project, work in that project directly and load the
+webapp references as needed. Do not introduce the legacy `webapp init` step
+into a new project workflow.
 
 `webapp manifest init` writes `nipkg.config.json` using the Plugin Manager field names
 (`section`, `maintainer`, `homepage`, `xbPlugin`, `slPluginManagerTags`,
@@ -921,7 +931,6 @@ Notes:
 
 - `agents` is the default client in interactive mode.
 - The bundled `slcli` skill now covers the previous standalone workflow skills.
-- `webapp init` installs project-scoped skills into `.agents/skills/` by default.
 
 ## example — Built-in example resource provisioning
 
@@ -930,10 +939,10 @@ for training, testing, or evaluation.
 
 ```bash
 slcli example list [-f json]                             # List available examples
-slcli example info <EXAMPLE_ID>                          # Show example details
-slcli example install <EXAMPLE_ID> [--workspace NAME]    # Provision example resources
-slcli example install --file PATH [--workspace NAME]     # Install a local fixture
-slcli example delete <EXAMPLE_ID> [--workspace NAME]     # Remove provisioned resources
+slcli example info <EXAMPLE_NAME>                        # Show example details
+slcli example install [EXAMPLE_NAME] --workspace NAME    # Provision example resources
+slcli example install --file PATH --workspace NAME      # Install a local fixture
+slcli example delete <EXAMPLE_NAME> --workspace NAME     # Remove provisioned resources
 ```
 
 For a local fixture, `PATH` points to its `config.yaml`; referenced files are

--- a/slcli/skills/slcli/references/filtering.md
+++ b/slcli/skills/slcli/references/filtering.md
@@ -198,7 +198,9 @@ Available `--group-by` values: `status`, `programName`, `serialNumber`,
 ## Pagination
 
 - **Table output**: Paginated interactively (default 25 rows, Y/n prompt for next page).
-- **JSON output**: Returns all results up to `--take` limit in a single array.
+- **JSON output**: Most commands return matching results up to the `--take` limit in a single array.
+- **Notebook exception**: `notebook manage list` currently queries up to 1000 notebooks for JSON output;
+  its `--take` value controls table paging but is not a JSON result cap.
 - **`--take, -t`**: Controls maximum items. Default 25 for most commands, 100 for systems.
 
 ```bash

--- a/slcli/skills/slcli/references/python-test/overview.md
+++ b/slcli/skills/slcli/references/python-test/overview.md
@@ -15,7 +15,7 @@ control metadata, or deployment layout.
 
 ## Prerequisites
 
-- Python 3.10+
+- Python >=3.11.1,<3.15 (Python 3.11.1 through 3.14)
 - `nisystemlink-clients` as the primary communication layer
 - SystemLink server with Test Monitor, Asset Management, Work Order, and File services
 - Valid API key with appropriate permissions for dev-mode runs

--- a/slcli/skills/slcli/references/webapp/overview.md
+++ b/slcli/skills/slcli/references/webapp/overview.md
@@ -40,7 +40,7 @@ Before generating code, clarify only the details that change the implementation:
 
 1. Goal: what the app should show or let the user do.
 2. Services: which SystemLink resources it must read or mutate.
-3. Starting point: new app via `slcli webapp new`, manual `slcli webapp init` starter, or existing Angular codebase.
+3. Starting point: new app via `slcli webapp new`, or an existing Angular codebase.
 4. Auth context: same-origin hosted app versus remote/dev API-key flow.
 5. Deployment target: ordinary hosted webapp only, or Plugin Manager package as well.
 
@@ -58,20 +58,25 @@ For a new SystemLink app, default to the hosted scaffold path:
 slcli webapp new <app-name>
 ```
 
-Use `slcli webapp init` only when the user explicitly wants the low-level manual bootstrap path or needs a non-standard framework setup. In that case, generate Angular in the starter directory so the SystemLink scaffolding stays at the project root:
-
-```bash
-slcli webapp init <app-dir>
-npx -y @angular/cli@20 new <app-name> --directory . --routing --style=scss --skip-git --no-standalone --defaults --force
-npm install @ni/nimble-angular @ni/nimble-components @ni/unit-format @ni/spright-angular @ni/ok-angular @ni/systemlink-clients-ts @angular/localize
-npm install --save-dev @angular/build
-```
-
-Be explicit with users: if they ask to scaffold a new hosted Angular app for SystemLink and do not ask for a manual setup, recommend `slcli webapp new` first, not `slcli webapp init`. Treat `init` as the exception path.
+Use `slcli webapp new` for new hosted Angular applications. For an existing
+Angular codebase, work in place and skip both scaffold commands. The older
+`slcli webapp init` command is a compatibility-only manual bootstrap path and
+is not a supported starting point for new skill-guided work.
 
 Prefer a hybrid Angular shape for this workflow: standalone root bootstrap with NgModule-managed feature declarations. That keeps the generated app off `@angular/platform-browser-dynamic` while still letting Nimble Angular wrappers live in a centralized `AppModule` for most feature imports.
 
 Immediately after scaffold, inspect `package.json` and `angular.json` before building features. The generator or migrations may leave the workspace on the wrong Angular major or on a builder configuration that does not bundle `@ni/nimble-angular` cleanly.
+
+Treat the generated template as a parts bin, not as the application's final information architecture. Before adding real API calls or polishing the UI, define the one primary user job and aggressively prune everything that does not support it. A focused application is usually better than a showcase of every starter pattern.
+
+For the first pass, remove:
+
+- routes, navigation tabs, and feature folders that are outside the primary workflow
+- sample cards, metrics, tables, forms, buttons, and placeholder copy that do not support a real user decision
+- demo data, mock handlers, and state branches that the application will not use
+- component styles, assets, and package dependencies left unused after the deletion
+
+Keep only the smallest coherent flow, including the states that make that flow usable: loading, empty, error, and successful completion where applicable. Do not keep a generated screen merely because it demonstrates a Nimble pattern, and do not fill every route before the primary workflow is deliberate and working. After pruning, remove the corresponding route entries, imports, and navigation items, then run the production build so dead template assumptions are caught early.
 
 For the currently supported path, standardize on:
 
@@ -96,9 +101,9 @@ Also add `@angular-devkit/build-angular` back to `devDependencies` before switch
 
 This fallback is not optional when the Nimble packages fail under the application builder. Fix the builder mismatch before implementing more UI.
 
-Recommend installing `@ni/spright-angular` and `@ni/ok-angular` early when using the manual `init` path, even if the first slice only uses Nimble. That avoids dependency churn later when the UI needs chat surfaces, product-specific icons, or OK wrappers.
-
-If the user has not scaffolded anything yet and explicitly wants a SystemLink-hosted webapp, recommend `slcli webapp new` first. Only fall back to `slcli webapp init` when they ask for manual bootstrapping or need to control the Angular workspace creation themselves.
+Install `@ni/spright-angular` and `@ni/ok-angular` early when the first slice
+needs chat surfaces, product-specific icons, or OK wrappers. This avoids
+dependency churn later without requiring a legacy bootstrap path.
 
 ### 2. Lock in the non-negotiables early
 
@@ -189,6 +194,8 @@ Always verify:
 Before you consider a SystemLink webapp slice correct, confirm all of the following:
 
 - Angular 20 workspace created in the intended starter directory.
+- Generated template was pruned to the primary user job rather than retained as a multi-route showcase.
+- Every retained route, component, dependency, asset, and style supports a real user workflow or required application state.
 - Angular and NI package versions verified after scaffold, not assumed.
 - `@ni/nimble-components`, `@ni/unit-format`, `@angular/localize`, and `@angular/build` installed when using `@ni/nimble-angular`.
 - `angular.json` uses builders that are known to bundle Nimble successfully.

--- a/slcli/skills/slcli/references/webapp/overview.md
+++ b/slcli/skills/slcli/references/webapp/overview.md
@@ -67,16 +67,30 @@ Prefer a hybrid Angular shape for this workflow: standalone root bootstrap with 
 
 Immediately after scaffold, inspect `package.json` and `angular.json` before building features. The generator or migrations may leave the workspace on the wrong Angular major or on a builder configuration that does not bundle `@ni/nimble-angular` cleanly.
 
-Treat the generated template as a parts bin, not as the application's final information architecture. Before adding real API calls or polishing the UI, define the one primary user job and aggressively prune everything that does not support it. A focused application is usually better than a showcase of every starter pattern.
+#### Establish the operator workflow before extending the template
 
-For the first pass, remove:
+Treat the generated starter screens as a parts bin, not as the application's final information architecture. Before adding API calls, new routes, or visual polish:
 
-- routes, navigation tabs, and feature folders that are outside the primary workflow
-- sample cards, metrics, tables, forms, buttons, and placeholder copy that do not support a real user decision
-- demo data, mock handlers, and state branches that the application will not use
-- component styles, assets, and package dependencies left unused after the deletion
+1. Write the primary user job in one sentence.
+2. Define the decision the user must make and the evidence needed to make it.
+3. Keep one primary workflow and one dominant results surface in the first viewport.
+4. Put filters and the primary action next to that results surface.
+5. Remove starter routes, tabs, dashboards, cards, status panels, and placeholder content that do not support the job.
+6. Keep loading, error, and empty states inside the same workflow rather than creating separate decorative panels for them.
+7. Use summary metrics only when they answer a decision the user cannot answer from the main result.
 
-Keep only the smallest coherent flow, including the states that make that flow usable: loading, empty, error, and successful completion where applicable. Do not keep a generated screen merely because it demonstrates a Nimble pattern, and do not fill every route before the primary workflow is deliberate and working. After pruning, remove the corresponding route entries, imports, and navigation items, then run the production build so dead template assumptions are caught early.
+Prefer this compact hierarchy:
+
+- context and purpose
+- filters and primary action
+- evidence
+- supporting detail
+
+Avoid repeating the product identity in both the application shell and page header. Avoid stacking multiple headings, status blocks, KPI cards, and toolbars before the user reaches the main evidence.
+
+After defining the workflow, aggressively prune the starter template. Remove routes, navigation tabs, feature folders, sample UI, demo data, mock handlers, unused state branches, styles, assets, and package dependencies that do not support the job. Keep only the smallest coherent flow and its necessary loading, empty, error, and successful-completion states. Do not keep a generated screen merely because it demonstrates a Nimble pattern, and do not fill every route before the primary workflow is deliberate and working. Remove corresponding route entries, imports, and navigation items, then run the production build so dead template assumptions are caught early.
+
+Validate the composition with populated and empty/error states at desktop and mobile widths. The design is ready when a user can identify the page's purpose, find the main control, and reach the evidence without passing through unrelated starter UI.
 
 For the currently supported path, standardize on:
 
@@ -195,6 +209,8 @@ Before you consider a SystemLink webapp slice correct, confirm all of the follow
 
 - Angular 20 workspace created in the intended starter directory.
 - Generated template was pruned to the primary user job rather than retained as a multi-route showcase.
+- Primary user job, decision evidence, dominant results surface, and compact page hierarchy are explicit.
+- Populated, empty, and error states have been checked at desktop and mobile widths.
 - Every retained route, component, dependency, asset, and style supports a real user workflow or required application state.
 - Angular and NI package versions verified after scaffold, not assumed.
 - `@ni/nimble-components`, `@ni/unit-format`, `@angular/localize`, and `@angular/build` installed when using `@ni/nimble-angular`.

--- a/slcli/webapp_click.py
+++ b/slcli/webapp_click.py
@@ -1018,7 +1018,7 @@ def register_webapp_commands(cli: Any) -> None:
 
     register_webapp_bootstrap_commands(webapp)
 
-    @webapp.command(name="init")
+    @webapp.command(name="init", hidden=True)
     @click.argument(
         "directory",
         type=click.Path(file_okay=False, dir_okay=True, path_type=Path),

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -1,6 +1,7 @@
 """Unit tests for slcli webapp commands."""
 
 import io
+import re
 import shutil
 import subprocess
 import tarfile
@@ -105,10 +106,13 @@ def test_webapp_help_omits_legacy_init_command() -> None:
     runner = CliRunner()
 
     result = runner.invoke(cli, ["webapp", "--help"])
+    visible_commands = re.findall(
+        r"^\s*[^a-zA-Z\s]?\s*([a-z][a-z-]*)\s{2,}", result.output, re.MULTILINE
+    )
 
     assert result.exit_code == 0
-    assert "init" not in result.output
-    assert "new" in result.output
+    assert "init" not in visible_commands
+    assert "new" in visible_commands
 
 
 def test_webapp_init_creates_starter_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -101,6 +101,16 @@ def _no_profile_workspace() -> Any:
         yield
 
 
+def test_webapp_help_omits_legacy_init_command() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["webapp", "--help"])
+
+    assert result.exit_code == 0
+    assert "init" not in result.output
+    assert "new" in result.output
+
+
 def test_webapp_init_creates_starter_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     runner = CliRunner()
     patch_keyring(monkeypatch)

--- a/tests/unit/test_webapp_click.py
+++ b/tests/unit/test_webapp_click.py
@@ -1,7 +1,6 @@
 """Unit tests for slcli webapp commands."""
 
 import io
-import re
 import shutil
 import subprocess
 import tarfile
@@ -106,9 +105,10 @@ def test_webapp_help_omits_legacy_init_command() -> None:
     runner = CliRunner()
 
     result = runner.invoke(cli, ["webapp", "--help"])
-    visible_commands = re.findall(
-        r"^\s*[^a-zA-Z\s]?\s*([a-z][a-z-]*)\s{2,}", result.output, re.MULTILINE
-    )
+    webapp_group: Any = cli.commands["webapp"]
+    visible_commands = [
+        name for name, command in webapp_group.commands.items() if not command.hidden
+    ]
 
     assert result.exit_code == 0
     assert "init" not in visible_commands


### PR DESCRIPTION
## Summary

- Align bundled `slcli` skill references with current command behavior and supported prerequisites.
- Encourage agents to aggressively prune generated webapp templates around one primary user workflow.
- Hide legacy `webapp init` from `slcli webapp --help` while preserving direct invocation compatibility.

## Testing

- `poetry run black .`
- `poetry run ni-python-styleguide lint`
- `poetry run mypy slcli tests`
- `poetry run pytest` (1,451 passed)
- `poetry run python scripts/smoke_test_webapp.py`
- `poetry run towncrier check --compare-with origin/main`
- `git diff --check`

## Release Notes

- Added `newsfragments/focused-webapp-skill.patch.md` for the bundled guidance and legacy help behavior updates.